### PR TITLE
Use regions to allocate plan generator expressions

### DIFF
--- a/src/binder/binder_context.cpp
+++ b/src/binder/binder_context.cpp
@@ -211,6 +211,7 @@ void BinderContext::GenerateAllColumnExpressions(
     auto col_cnt = schema.GetColumns().size();
     for (uint32_t i = 0; i < col_cnt; i++) {
       const auto &col_obj = schema.GetColumn(i);
+      // TODO(jordig) Should this be allocated in a region?
       auto tv_expr = new parser::ColumnValueExpression(std::string(entry.first), std::string(col_obj.Name()));
       tv_expr->SetReturnValueType(col_obj.Type());
       tv_expr->DeriveExpressionName();

--- a/src/include/optimizer/abstract_optimizer.h
+++ b/src/include/optimizer/abstract_optimizer.h
@@ -106,7 +106,8 @@ class AbstractOptimizer {
   virtual std::unique_ptr<planner::AbstractPlanNode> BuildPlanTree(transaction::TransactionContext *txn,
                                                                    catalog::CatalogAccessor *accessor,
                                                                    StatsStorage *storage, QueryInfo query_info,
-                                                                   std::unique_ptr<AbstractOptimizerNode> op_tree) = 0;
+                                                                   std::unique_ptr<AbstractOptimizerNode> op_tree,
+                                                                   execution::util::Region *region) = 0;
 
   /**
    * Reset the optimizer's internal state

--- a/src/include/optimizer/optimizer.h
+++ b/src/include/optimizer/optimizer.h
@@ -35,7 +35,8 @@ class Optimizer : public AbstractOptimizer {
   /**
    * Disallow copy and move
    */
-  DISALLOW_COPY_AND_MOVE(Optimizer);
+  // TODO(Jordi) figure this stuff out.
+  // DISALLOW_COPY_AND_MOVE(Optimizer);
 
   /**
    * Constructor for Optimizer with a cost_model
@@ -59,7 +60,8 @@ class Optimizer : public AbstractOptimizer {
   std::unique_ptr<planner::AbstractPlanNode> BuildPlanTree(transaction::TransactionContext *txn,
                                                            catalog::CatalogAccessor *accessor, StatsStorage *storage,
                                                            QueryInfo query_info,
-                                                           std::unique_ptr<AbstractOptimizerNode> op_tree) override;
+                                                           std::unique_ptr<AbstractOptimizerNode> op_tree,
+                                                           execution::util::Region *region) override;
 
   /**
    * Reset the optimizer state
@@ -88,7 +90,8 @@ class Optimizer : public AbstractOptimizer {
   std::unique_ptr<planner::AbstractPlanNode> ChooseBestPlan(
       transaction::TransactionContext *txn, catalog::CatalogAccessor *accessor, group_id_t id,
       PropertySet *required_props,
-      const std::vector<common::ManagedPointer<parser::AbstractExpression>> &required_cols);
+      const std::vector<common::ManagedPointer<parser::AbstractExpression>> &required_cols,
+      execution::util::Region *region);
 
   /**
    * Execute elements of given optimization task stack and ensure that we

--- a/src/include/optimizer/plan_generator.h
+++ b/src/include/optimizer/plan_generator.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "catalog/schema.h"
+#include "network/connection_context.h"
 #include "optimizer/abstract_optimizer_node.h"
 #include "optimizer/operator_visitor.h"
 #include "transaction/transaction_context.h"
@@ -62,6 +63,7 @@ class PlanGenerator : public OperatorVisitor {
       transaction::TransactionContext *txn, catalog::CatalogAccessor *accessor, AbstractOptimizerNode *op,
       PropertySet *required_props, const std::vector<common::ManagedPointer<parser::AbstractExpression>> &required_cols,
       const std::vector<common::ManagedPointer<parser::AbstractExpression>> &output_cols,
+      execution::util::Region *region,
       std::vector<std::unique_ptr<planner::AbstractPlanNode>> &&children_plans,
       std::vector<ExprMap> &&children_expr_map);
 
@@ -399,6 +401,11 @@ class PlanGenerator : public OperatorVisitor {
    * Transaction Context executing under
    */
   transaction::TransactionContext *txn_;
+
+  /**
+   * Region used for allocation
+   */
+   execution::util::Region *region_;
 };
 
 }  // namespace optimizer

--- a/src/include/traffic_cop/traffic_cop_util.h
+++ b/src/include/traffic_cop/traffic_cop_util.h
@@ -5,6 +5,7 @@
 
 #include "catalog/catalog_defs.h"
 #include "common/managed_pointer.h"
+#include "execution/util/region.h"
 #include "network/network_defs.h"
 
 namespace terrier::catalog {
@@ -52,7 +53,8 @@ class TrafficCopUtil {
       common::ManagedPointer<transaction::TransactionContext> txn,
       common::ManagedPointer<catalog::CatalogAccessor> accessor, common::ManagedPointer<parser::ParseResult> query,
       catalog::db_oid_t db_oid, common::ManagedPointer<optimizer::StatsStorage> stats_storage,
-      std::unique_ptr<optimizer::AbstractCostModel> cost_model, uint64_t optimizer_timeout);
+      std::unique_ptr<optimizer::AbstractCostModel> cost_model, uint64_t optimizer_timeout,
+      execution::util::Region *region);
 
   /**
    * Converts parser statement types (which rely on multiple enums) to a single QueryType enum from the network layer

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -15,6 +15,7 @@
 #include "execution/exec/output.h"
 #include "execution/executable_query.h"
 #include "execution/sql/ddl_executors.h"
+#include "execution/util/region.h"
 #include "execution/vm/module.h"
 #include "network/connection_context.h"
 #include "network/postgres/portal.h"
@@ -131,7 +132,8 @@ std::unique_ptr<planner::AbstractPlanNode> TrafficCop::OptimizeBoundQuery(
 
   return TrafficCopUtil::Optimize(connection_ctx->Transaction(), connection_ctx->Accessor(), query,
                                   connection_ctx->GetDatabaseOid(), stats_storage_,
-                                  std::make_unique<optimizer::TrivialCostModel>(), optimizer_timeout_);
+                                  std::make_unique<optimizer::TrivialCostModel>(), optimizer_timeout_,
+                                  connection_ctx->Region());
 }
 
 TrafficCopResult TrafficCop::ExecuteCreateStatement(

--- a/src/traffic_cop/traffic_cop_util.cpp
+++ b/src/traffic_cop/traffic_cop_util.cpp
@@ -19,7 +19,8 @@ std::unique_ptr<planner::AbstractPlanNode> TrafficCopUtil::Optimize(
     const common::ManagedPointer<catalog::CatalogAccessor> accessor,
     const common::ManagedPointer<parser::ParseResult> query, const catalog::db_oid_t db_oid,
     common::ManagedPointer<optimizer::StatsStorage> stats_storage,
-    std::unique_ptr<optimizer::AbstractCostModel> cost_model, const uint64_t optimizer_timeout) {
+    std::unique_ptr<optimizer::AbstractCostModel> cost_model, const uint64_t optimizer_timeout,
+    execution::util::Region *region) {
   // Optimizer transforms annotated ParseResult to logical expressions (ephemeral Optimizer structure)
   optimizer::QueryToOperatorTransformer transformer(accessor, db_oid);
   auto logical_exprs = transformer.ConvertToOpExpression(query->GetStatement(0), query);
@@ -62,7 +63,7 @@ std::unique_ptr<planner::AbstractPlanNode> TrafficCopUtil::Optimize(
   // TODO(Matt): QueryInfo holding a raw pointer to PropertySet obfuscates the required life cycle of PropertySet
 
   // Optimize, consuming the logical expressions in the process
-  return optimizer.BuildPlanTree(txn.Get(), accessor.Get(), stats_storage.Get(), query_info, std::move(logical_exprs));
+  return optimizer.BuildPlanTree(txn.Get(), accessor.Get(), stats_storage.Get(), query_info, std::move(logical_exprs), region);
   // TODO(Matt): I see a lot of copying going on in the Optimizer that maybe shouldn't be happening. BuildPlanTree's
   // signature is copying QueryInfo object (contains a vector of output columns), which then immediately makes a local
   // copy of that vector anyway. Presumably those are immutable expressions, in which case they should be const & to the


### PR DESCRIPTION
Title: Use regions to allocate plan generator expressions

# Proposal: Allocate plan expressions in regions


## Motivation & Design

Currently, a large number of allocations are performed as part of physical plan generation.
This presents a number of issues:
1. A large number of small allocations in a hottish path adds unnecessary overhead.
2. Managing the newly allocated memory adds unnecessary code complexity and further overhead.
3. Presenting a large number of expensive allocations encourages/normalizes the use of allocations where they might otherwise be unnecessary.

We can address these issues with a per-connection-context region allocator.

- This addresses issue 1. by using an allocator that has extremely little overhead.
- This addresses issue 2. by deferring frees to the closure of a connection context.
- This addresses issue 3. by using placement new's allocation semantics, which I consider to be more discouraging than encouraging.

It may be possible to avoid allocations entirely in certain cases going into the future.


## The PR's future


### The path toward merge

1. Get a dev machine to the point where it can compile and run tests. Then, use it to compile and run tests (which I can't get to compile and run with Arch's gcc-10). This has only been built with `make terrier -j4`

2. Discuss this PR with others who know more about what they're doing. (Is this architecture even desirable? Are there any blatant oversights? There are a number of comments I made concerning questions--can we discuss those?)

3. Remove comments/rewrite code based on #3. This is more of an exploratory PR as it stands right now. The rewrite would involve, among other things, finding a way to break things into multiple commits. (Unfortunately pretty hard, since the changes are generally interdependent.)

4. Figure out how to track memory leaks. Then, check for memory leaks.

5. The use of `unique_ptr`s is pretty concerning. I'm not sure the expressions ever leak, and since we're trying to avoid having to free objects at a per-object level, this seems unnecessary and probably dangerous.



### Going forward


Not all allocations have been made into region allocations. Copies, specifically, remain an issue. Making it so that copies are allocated in a region would require pretty substantial code changes and refactoring, whereas eliminating the allocations entirely could be trivial. I would like to see if we can avoid deep copies and rely on references.

I'm intrigued by the large number of `unique_ptr`s associated with expressions in `expression_util.h` and `plan_generator.cpp`. I would like to see if we should/could remove them.


It seems like it will be important to document failure cases and write tests. I'm specifically curious about if region allocation stays safe as more allocations happen. 


Investigate whether or not long-lasting connections with many transactions are an issue. If it's thread safe, I *believe* that we should reset the region on transaction commit/abort. This should be doable as part of the transaction cleanup/GC process. The question is if that's safe and worthwhile.