### PR TITLE
Remove varlen_entry_benchmark from CI

### DIFF
--- a/benchmark/storage/varlen_entry_benchmark.cpp
+++ b/benchmark/storage/varlen_entry_benchmark.cpp
@@ -6,6 +6,14 @@
 
 namespace terrier {
 
+/**
+ * Currently exercises 2 key areas of VarlenEntry performance: hashing and equality comparisons. The former is mostly
+ * exercising the hash functions used for various content lengths. If hashing algorithms are changed/updated, we should
+ * run this benchmark. The other part of this benchmark evaluates comparisons of VarlenEntrys, exercising if it just
+ * looks at the length, prefix, content, or all of the above. If the logic is changed, we should rerun the benchmark.
+ *
+ * The benchmark is not currently part of CI because it proved too noisy in Jenkins runs.
+ */
 class VarlenEntryBenchmark : public benchmark::Fixture {
  public:
   void SetUp(const benchmark::State &state) final {}

--- a/script/micro_bench/run_micro_bench.py
+++ b/script/micro_bench/run_micro_bench.py
@@ -84,7 +84,6 @@ BENCHMARKS_TO_RUN = {
     "cuckoomap_benchmark":                  DEFAULT_FAILURE_THRESHOLD,
     "parser_benchmark":                     20,
     "slot_iterator_benchmark":              DEFAULT_FAILURE_THRESHOLD,
-    "varlen_entry_benchmark":               30,
 }
 
 # The number of threads to use for multi-threaded benchmarks.

--- a/src/include/common/hash_util.h
+++ b/src/include/common/hash_util.h
@@ -23,6 +23,9 @@ using hash_t = uint64_t;
  * Generic hashing utility class. The main entry point are the HashUtil::Hash() functions. There are
  * overloaded specialized versions for arithmetic values (integers and floats), and generic versions
  * for longer buffers (strings, c-strings, and opaque buffers).
+ *
+ * @warning If you change any of this functionality, compare stable performance numbers of varlen_entry_benchmark before
+ * and after. It is not currently part of CI because it can be noisy.
  */
 class EXPORT HashUtil {
  public:

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -400,6 +400,9 @@ class VarlenEntry {
    * Compute the hash value of this variable-length string instance.
    * @param seed The value to seed the hash with.
    * @return The hash value for this string instance.
+   *
+   * @warning If you change any of this functionality, compare stable performance numbers of varlen_entry_benchmark
+   * before and after. It is not currently part of CI because it can be noisy.
    */
   hash_t Hash(hash_t seed) const {
     // "small" strings use CRC hashing, "long" strings use XXH3.
@@ -415,6 +418,9 @@ class VarlenEntry {
    * @param left The first string.
    * @param right The second string.
    * @return 0 if equal according to EqualCheck; any non-zero value otherwise.
+   *
+   * @warning If you change any of this functionality, compare stable performance numbers of varlen_entry_benchmark
+   * before and after. It is not currently part of CI because it can be noisy.
    */
   template <bool EqualityCheck>
   static bool CompareEqualOrNot(const VarlenEntry &left, const VarlenEntry &right) {

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -230,6 +230,9 @@ enum class LogRecordType : uint8_t { REDO = 1, DELETE, COMMIT, ABORT };
 /**
  * A varlen entry is always a 32-bit size field and the varlen content,
  * with exactly size many bytes (no extra nul in the end).
+ *
+ * @warning If you change any of this functionality, compare stable performance numbers of varlen_entry_benchmark before
+ * and after. It is not currently part of CI because it can be noisy.
  */
 class VarlenEntry {
  public:


### PR DESCRIPTION
It's just too noisy to be reliable. Added documentation that performance should be looked at critically using the benchmark locally if exercised code is changed.