### PR TITLE
Prefer fdatasync over fsync of WAL on supported platforms

### DIFF
--- a/src/include/storage/write_ahead_log/log_io.h
+++ b/src/include/storage/write_ahead_log/log_io.h
@@ -5,6 +5,7 @@
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <unistd.h>
+
 #include <cerrno>
 #include <cstring>
 #include <string>
@@ -124,6 +125,8 @@ class BufferedLogWriter {
    */
   void Persist() {
 #if __APPLE__
+    // macOS provides fcntl(out_, F_FULLFSYNC) to guarantee that on-disk buffers are flushed. AFAIK there is no portable
+    // way to do this on Linux so we'll just keep fsync for now.
     if (fsync(out_) == -1) throw std::runtime_error("fsync failed with errno " + std::to_string(errno));
 #else
     if (fdatasync(out_) == -1) throw std::runtime_error("fdatasync failed with errno " + std::to_string(errno));

--- a/src/include/storage/write_ahead_log/log_io.h
+++ b/src/include/storage/write_ahead_log/log_io.h
@@ -120,7 +120,7 @@ class BufferedLogWriter {
 
   /**
    * Call fsync to make sure that all writes are consistent. fdatasync is used as an optimization on Linux since we
-   * don't care able all of the file's metadata being persisted, just the contents.
+   * don't care about all of the file's metadata being persisted, just the contents.
    */
   void Persist() {
 #if __APPLE__

--- a/src/include/storage/write_ahead_log/log_io.h
+++ b/src/include/storage/write_ahead_log/log_io.h
@@ -5,7 +5,6 @@
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <unistd.h>
-
 #include <cerrno>
 #include <cstring>
 #include <string>
@@ -120,10 +119,15 @@ class BufferedLogWriter {
   }
 
   /**
-   * Call fsync to make sure that all writes are consistent.
+   * Call fsync to make sure that all writes are consistent. fdatasync is used as an optimization on Linux since we
+   * don't care able all of the file's metadata being persisted, just the contents.
    */
   void Persist() {
+#if __APPLE__
     if (fsync(out_) == -1) throw std::runtime_error("fsync failed with errno " + std::to_string(errno));
+#else
+    if (fdatasync(out_) == -1) throw std::runtime_error("fdatasync failed with errno " + std::to_string(errno));
+#endif
   }
 
   /**


### PR DESCRIPTION
[fdatasync](https://linux.die.net/man/2/fdatasync) is used as an optimization on Linux since we don't care about all of the file's metadata being persisted, just the contents. macOS does not provide this syscall.