### PR TITLE
Latency int bug

### DIFF
--- a/Jenkinsfile-nightly
+++ b/Jenkinsfile-nightly
@@ -4,7 +4,7 @@ pipeline {
     environment{
         //Do not change. 
         //Performance Storage Service(Django) authentication information. The credentials can only be changed on Jenkins webpage
-        PSS_CREATOR= credentials('pss-creator')
+        PSS_CREATOR= credentials('pss-creator-testing')
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '30'))
@@ -23,9 +23,9 @@ pipeline {
                 sh 'echo y | sudo ./script/installation/packages.sh all'
                 sh 'mkdir build'
                 sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF -DTERRIER_USE_JEMALLOC=ON -DTERRIER_BUILD_TESTS=OFF .. && make -j$(nproc) terrier'
-                sh "cd build && timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}"
-                sh "cd build && timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly_ramdisk.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}"
-                sh "cd build && timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly_wal_disabled.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}"
+                sh "cd build && timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly.json --build-type=release --publish-results=test --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}"
+                sh "cd build && timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly_ramdisk.json --build-type=release --publish-results=test --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}"
+                sh "cd build && timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly_wal_disabled.json --build-type=release --publish-results=test --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}"
 
                 archiveArtifacts(artifacts: 'build/oltp_result/**/*.*', excludes: 'build/oltp_result/**/*.csv', fingerprint: true)
             }

--- a/Jenkinsfile-nightly
+++ b/Jenkinsfile-nightly
@@ -4,7 +4,7 @@ pipeline {
     environment{
         //Do not change. 
         //Performance Storage Service(Django) authentication information. The credentials can only be changed on Jenkins webpage
-        PSS_CREATOR= credentials('pss-creator-testing')
+        PSS_CREATOR= credentials('pss-creator')
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '30'))

--- a/Jenkinsfile-nightly
+++ b/Jenkinsfile-nightly
@@ -23,9 +23,9 @@ pipeline {
                 sh 'echo y | sudo ./script/installation/packages.sh all'
                 sh 'mkdir build'
                 sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF -DTERRIER_USE_JEMALLOC=ON -DTERRIER_BUILD_TESTS=OFF .. && make -j$(nproc) terrier'
-                sh "cd build && timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly.json --build-type=release --publish-results=test --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}"
-                sh "cd build && timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly_ramdisk.json --build-type=release --publish-results=test --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}"
-                sh "cd build && timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly_wal_disabled.json --build-type=release --publish-results=test --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}"
+                sh "cd build && timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}"
+                sh "cd build && timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly_ramdisk.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}"
+                sh "cd build && timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly_wal_disabled.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}"
 
                 archiveArtifacts(artifacts: 'build/oltp_result/**/*.*', excludes: 'build/oltp_result/**/*.csv', fingerprint: true)
             }

--- a/script/testing/oltpbench/reporting/constants.py
+++ b/script/testing/oltpbench/reporting/constants.py
@@ -3,4 +3,4 @@
 UNKNOWN_RESULT = 'unknown'
 LATENCY_ATTRIBUTE_MAPPING = [
     ('l_25','25'),('l_75','75'),('l_90','90'), ('l_95','95'), ('l_99','99'),
-    ('avg','average'),('median','median'),('min','minimum'), ('max','maximum')]
+    ('avg','av'),('median','median'),('min','min'), ('max','max')]

--- a/script/testing/oltpbench/reporting/parsers/res_parser.py
+++ b/script/testing/oltpbench/reporting/parsers/res_parser.py
@@ -14,8 +14,6 @@ def parse_res_file(path):
         incremental_metrics (list, json array): The throughput at different time.
 
     """
-    # time, throughput, min_lat, lat_25th, median_lat, avg_lat, lat_75th, lat_90th, lat_95th, lat_99th, max_lat = [
-    # ], [], [], [], [], [], [], [], [], [], []
     with open(path) as csvfile:
         reader = csv.DictReader(csvfile, delimiter=',')
         incremental_metrics = []
@@ -24,23 +22,10 @@ def parse_res_file(path):
                 "time": float(get_value_by_pattern(row,'time',None)),
                 "throughput": float(get_value_by_pattern(row, 'throughput', None))
             }
-            # time.append(float(row['time(sec)']))
-            # throughput.append(float(row[' throughput(req/sec)']))
             latency = {}
             for key, pattern in LATENCY_ATTRIBUTE_MAPPING:
                 value = get_value_by_pattern(row, pattern, None)
-                latency[key] = float(value) if value else value
+                latency[key] = float("{:.4}".format(value)) if value else value
             metrics_instance['latency'] = latency
             incremental_metrics.append(metrics_instance)
-            # min_lat.append(float(row[' min_lat(ms)']))
-            # lat_25th.append(float(row[' 25th_lat(ms)']))
-            # median_lat.append(float(row[' median_lat(ms)']))
-            # avg_lat.append(float(row[' avg_lat(ms)']))
-            # lat_75th.append(float(row[' 75th_lat(ms)']))
-            # lat_90th.append(float(row[' 90th_lat(ms)']))
-            # lat_95th.append(float(row[' 95th_lat(ms)']))
-            # lat_99th.append(float(row[' 99th_lat(ms)']))
-            # max_lat.append(float(row[' max_lat(ms)']))
-        # incremental_metrics = [{"time": t, "throughput": tp, "latency":latency}
-        #                        for t, tp, ml, l25, mel, al, l75, l90, l95, l99, mal in zip(time, throughput, min_lat, lat_25th, median_lat, avg_lat, lat_75th, lat_90th, lat_95th, lat_99th, max_lat)]
         return incremental_metrics

--- a/script/testing/oltpbench/reporting/parsers/res_parser.py
+++ b/script/testing/oltpbench/reporting/parsers/res_parser.py
@@ -1,6 +1,8 @@
 import csv
 import json
 
+from oltpbench.reporting.utils import get_value_by_pattern
+from oltpbench.reporting.constants import LATENCY_ATTRIBUTE_MAPPING
 
 def parse_res_file(path):
     """Read data from file ends with ".res".
@@ -12,22 +14,33 @@ def parse_res_file(path):
         incremental_metrics (list, json array): The throughput at different time.
 
     """
-    time, throughput, min_lat, lat_25th, median_lat, avg_lat, lat_75th, lat_90th, lat_95th, lat_99th, max_lat = [
-    ], [], [], [], [], [], [], [], [], [], []
+    # time, throughput, min_lat, lat_25th, median_lat, avg_lat, lat_75th, lat_90th, lat_95th, lat_99th, max_lat = [
+    # ], [], [], [], [], [], [], [], [], [], []
     with open(path) as csvfile:
         reader = csv.DictReader(csvfile, delimiter=',')
+        incremental_metrics = []
         for row in reader:
-            time.append(float(row['time(sec)']))
-            throughput.append(float(row[' throughput(req/sec)']))
-            min_lat.append(float(row[' min_lat(ms)']))
-            lat_25th.append(float(row[' 25th_lat(ms)']))
-            median_lat.append(float(row[' median_lat(ms)']))
-            avg_lat.append(float(row[' avg_lat(ms)']))
-            lat_75th.append(float(row[' 75th_lat(ms)']))
-            lat_90th.append(float(row[' 90th_lat(ms)']))
-            lat_95th.append(float(row[' 95th_lat(ms)']))
-            lat_99th.append(float(row[' 99th_lat(ms)']))
-            max_lat.append(float(row[' max_lat(ms)']))
-        incremental_metrics = [{"time": t, "throughput": tp, "latency":{"min": ml, "l_25": l25, "median": mel, "avg": al, "l_75": l75, "l_90": l90, "l_95": l95, "l_99": l99, "max": mal}}
-                               for t, tp, ml, l25, mel, al, l75, l90, l95, l99, mal in zip(time, throughput, min_lat, lat_25th, median_lat, avg_lat, lat_75th, lat_90th, lat_95th, lat_99th, max_lat)]
+            metrics_instance = {
+                "time": float(get_value_by_pattern(row,'time',None)),
+                "throughput": float(get_value_by_pattern(row, 'throughput', None))
+            }
+            # time.append(float(row['time(sec)']))
+            # throughput.append(float(row[' throughput(req/sec)']))
+            latency = {}
+            for key, pattern in LATENCY_ATTRIBUTE_MAPPING:
+                value = get_value_by_pattern(row, pattern, None)
+                latency[key] = float(value) if value else value
+            metrics_instance['latency'] = latency
+            incremental_metrics.append(metrics_instance)
+            # min_lat.append(float(row[' min_lat(ms)']))
+            # lat_25th.append(float(row[' 25th_lat(ms)']))
+            # median_lat.append(float(row[' median_lat(ms)']))
+            # avg_lat.append(float(row[' avg_lat(ms)']))
+            # lat_75th.append(float(row[' 75th_lat(ms)']))
+            # lat_90th.append(float(row[' 90th_lat(ms)']))
+            # lat_95th.append(float(row[' 95th_lat(ms)']))
+            # lat_99th.append(float(row[' 99th_lat(ms)']))
+            # max_lat.append(float(row[' max_lat(ms)']))
+        # incremental_metrics = [{"time": t, "throughput": tp, "latency":latency}
+        #                        for t, tp, ml, l25, mel, al, l75, l90, l95, l99, mal in zip(time, throughput, min_lat, lat_25th, median_lat, avg_lat, lat_75th, lat_90th, lat_95th, lat_99th, max_lat)]
         return incremental_metrics

--- a/script/testing/oltpbench/reporting/parsers/summary_parser.py
+++ b/script/testing/oltpbench/reporting/parsers/summary_parser.py
@@ -70,5 +70,5 @@ def parse_latency_data(latency_dict):
     latency = {}
     for key, pattern in LATENCY_ATTRIBUTE_MAPPING:
         value = get_value_by_pattern(latency_dict, pattern, None)
-        latency[key] = int(value) if value else value
+        latency[key] = float(value) if value else value
     return latency

--- a/script/testing/oltpbench/reporting/parsers/summary_parser.py
+++ b/script/testing/oltpbench/reporting/parsers/summary_parser.py
@@ -70,5 +70,5 @@ def parse_latency_data(latency_dict):
     latency = {}
     for key, pattern in LATENCY_ATTRIBUTE_MAPPING:
         value = get_value_by_pattern(latency_dict, pattern, None)
-        latency[key] = float(value) if value else value
+        latency[key] = float("{:.4}".format(value)) if value else value
     return latency

--- a/script/testing/oltpbench/test_case_oltp.py
+++ b/script/testing/oltpbench/test_case_oltp.py
@@ -119,8 +119,8 @@ class TestCaseOLTPBench(TestCase):
 
         # publish results
         if self.publish_results:
-            report(self.publish_results, self.server_data,os.path.join(
-                os.getcwd(), "oltp_result",self.filename_suffix),self.publish_username,self.publish_password,self.query_mode)
+            report(self.publish_results, self.server_data, os.path.join(
+                os.getcwd(), "oltp_result",self.filename_suffix), self.publish_username, self.publish_password, self.query_mode)
 
     def create_result_dir(self):
         if not os.path.exists(self.test_result_dir):


### PR DESCRIPTION
There is currently a bug in the oltpbench scripts where the latency numbers are converted into ints before being sent to the performance storage service. This causes problems with the Grafana visualizations because a number of the latency metrics end up being <1. This causes /0 errors as you can see here https://stats.noise.page/grafana/d/latency_trends/latency-trends?orgId=1

This PR fixes this issue and refactors the code by implementing reuse to give a single place to control the parsing of latency metric labels. This will be especially helpful if https://github.com/oltpbenchmark/oltpbench/pull/338 gets merged (though it also works without that other PR).

I tested this code on both pipelines:
Terrier: http://jenkins.db.cs.cmu.edu:8080/blue/organizations/jenkins/testing-team%2Fterrier/detail/latency-int-bug/3/pipeline/375
Nightly: http://jenkins.db.cs.cmu.edu:8080/blue/organizations/jenkins/testing-team%2Fterrier-nightly/detail/latency-int-bug/5/pipeline/
 