### PR TITLE
Fix Compiled Parallel Aggregations

### DIFF
--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -3505,14 +3505,23 @@ void BytecodeGenerator::VisitMemberExpr(ast::MemberExpr *node) {
   // object is zero, we needn't do anything - we can just reinterpret the object
   // pointer. If the field offset is greater than zero, we generate a LEA.
 
-  LocalVar field_ptr;
-  if (offset == 0) {
-    field_ptr = obj_ptr;
-  } else {
-    field_ptr = GetCurrentFunction()->NewLocal(node->GetType()->PointerTo());
-    GetEmitter()->EmitLea(field_ptr, obj_ptr, offset);
-    field_ptr = field_ptr.ValueOf();
-  }
+  // TODO(Kyle): the optimization described above is ultimately what leads
+  // us to attempt a non-type-system-compliant store when compiling the
+  // resulting bytecode to LLVM IR; eliding the optimization entirely solves
+  // the issue here at the bytecode level, but always incurs the cost of an
+  // additional Lea bytecode as well as an additional store in the IR
+
+//  LocalVar field_ptr;
+//  if (offset == 0) {
+//    field_ptr = obj_ptr;
+//  } else {
+//    field_ptr = GetCurrentFunction()->NewLocal(node->GetType()->PointerTo());
+//    GetEmitter()->EmitLea(field_ptr, obj_ptr, offset);
+//    field_ptr = field_ptr.ValueOf();
+//  }
+  LocalVar field_ptr = GetCurrentFunction()->NewLocal(node->GetType()->PointerTo());
+  GetEmitter()->EmitLea(field_ptr, obj_ptr, offset);
+  field_ptr = field_ptr.ValueOf();
 
   if (GetExecutionResult()->IsLValue()) {
     TERRIER_ASSERT(!GetExecutionResult()->HasDestination(), "L-Values produce their destination");

--- a/src/execution/vm/llvm_engine.cpp
+++ b/src/execution/vm/llvm_engine.cpp
@@ -731,7 +731,8 @@ void LLVMEngine::CompiledModuleBuilder::DefineFunction(const FunctionInfo &func_
         case OperandType::LocalCount: {
           std::vector<LocalVar> locals;
           iter.GetLocalCountOperand(i, &locals);
-          for (const auto local : locals) {
+          // TODO(Kyle): need to make & in order to compile?
+          for (const auto& local : locals) {
             args.push_back(locals_map.GetArgumentById(local));
           }
           break;

--- a/src/include/main/db_main.h
+++ b/src/include/main/db_main.h
@@ -709,9 +709,11 @@ class DBMain {
       optimizer_timeout_ = static_cast<uint64_t>(settings_manager->GetInt(settings::Param::task_execution_timeout));
       use_query_cache_ = settings_manager->GetBool(settings::Param::use_query_cache);
 
-      execution_mode_ = settings_manager->GetBool(settings::Param::compiled_query_execution)
-                            ? execution::vm::ExecutionMode::Compiled
-                            : execution::vm::ExecutionMode::Interpret;
+      // TODO(Kyle): manually setting exec mode to compiled for testing purposes
+      execution_mode_ = execution::vm::ExecutionMode::Compiled;
+//      execution_mode_ = settings_manager->GetBool(settings::Param::compiled_query_execution)
+//                            ? execution::vm::ExecutionMode::Compiled
+//                            : execution::vm::ExecutionMode::Interpret;
 
       metrics_query_trace_ = settings_manager->GetBool(settings::Param::metrics_query_trace);
       metrics_pipeline_ = settings_manager->GetBool(settings::Param::metrics_pipeline);


### PR DESCRIPTION
Fix for issue [#1099](https://github.com/cmu-db/noisepage/issues/1099).

Parallel static aggregations fail in compiled mode. A simple procedure to reproduce follows:

```
CREATE TABLE test (a INT, b INT);
INSERT INTO test (a , b) VALUES (1, 2);
SELECT SUM(a), SUM(b) FROM test;
```

Executing the final query produces the following error messages:

```
[2020-09-17 18:31:34.843] [execution_logger] [error] ERROR IN MODULE:
Stored value type does not match pointer operand type!
  store %1* %16, %"class.terrier::execution::sql::IntegerSumAggregate"** %5
 %"class.terrier::execution::sql::IntegerSumAggregate"*Stored value type does not match pointer operand type!
  store %1* %22, %"class.terrier::execution::sql::IntegerSumAggregate"** %8
 %"class.terrier::execution::sql::IntegerSumAggregate"*Stored value type does not match pointer operand type!
  store %1* %5, %"class.terrier::execution::sql::IntegerSumAggregate"** %2
 %"class.terrier::execution::sql::IntegerSumAggregate"*Stored value type does not match pointer operand type!
  store %1* %7, %"class.terrier::execution::sql::IntegerSumAggregate"** %3
 %"class.terrier::execution::sql::IntegerSumAggregate"*Stored value type does not match pointer operand type!
  store %1* %31, %"class.terrier::execution::sql::IntegerSumAggregate"** %10
 %"class.terrier::execution::sql::IntegerSumAggregate"*Stored value type does not match pointer operand type!
  store %1* %35, %"class.terrier::execution::sql::IntegerSumAggregate"** %12
 %"class.terrier::execution::sql::IntegerSumAggregate"*
```

The majority of this error message is produced by the `Verifier::visitStoreInst()` function in `Verifier.cpp` within LLVM. As the message suggests, we generate IR with a type mismatch between the stored value and the location (address) at which it is stored. The (simplified) syntax for an LLVM IR `store` looks like: `store <ty> <value> <ty>* <pointer>` and the LLVM type system (enforced in part by `Verifier.cpp`) requires that "the type of the <pointer> operand must be a pointer to the first class type of the <value> operand". 

The issue arises in the `MergeAggregates` function. We produce the following bytecode for `MergeAggregates`:

```
Function 0 <MergeAggregates>:
  Frame size 48 bytes (2 parameters, 6 locals)
    param     queryState:  offset=0       size=8       align=8       type=*struct{*ExecutionContext,struct{IntegerSumAggregate,IntegerSumAggregate}}
    param  pipelineState:  offset=8       size=8       align=8       type=*struct{struct{IntegerSumAggregate,IntegerSumAggregate}}
    local           tmp1:  offset=16      size=8       align=8       type=*struct{IntegerSumAggregate,IntegerSumAggregate}
    local           tmp2:  offset=24      size=8       align=8       type=*struct{IntegerSumAggregate,IntegerSumAggregate}
    local           tmp3:  offset=32      size=8       align=8       type=*IntegerSumAggregate
    local           tmp4:  offset=40      size=8       align=8       type=*IntegerSumAggregate

  0x00000000    Lea                                             local=&tmp1  local=queryState  i32=8
  0x00000010    IntegerSumAggregateMerge                        local=tmp1  local=pipelineState
  0x0000001c    Lea                                             local=&tmp2  local=queryState  i32=8
  0x0000002c    Lea                                             local=&tmp3  local=tmp2  i32=16
  0x0000003c    Lea                                             local=&tmp4  local=pipelineState  i32=16
  0x0000004c    IntegerSumAggregateMerge                        local=tmp3  local=tmp4
  0x00000058    Return  
```

The error occurs at the final `Lea` bytecode: `Lea &tmp4, pipelineState, 16`. Within the LLVM engine, the `Lea` TPL instruction is implemented in terms of a `store` in LLVM IR.

We have that the `pipelineState` type looks like:

```
struct {
    struct {
        IntegerSumAggregate,
        IntegerSumAggregate
    }
}
```

While the type of local `tmp4` is simply `*IntegerSumAggregate`.

To construct the `store` instruction from the bytecode, we perform the following procedure:

- Get the offset from the 2nd (0-indexed) operand to the `Lea` instruction (16)
- Compute the element within `pipelineState` that contains this offset; `pipelineState` is a structure with only a single member (itself a structure) so the result of this computation is the sole member of `pipelineState` with type: `struct {IntegerSumAggregate, IntegerSumAggregate}`
- Compute the index of this element within the top level structure (`pipelineState`); this calculation results in 0 as the index
- Compute a pointer to the element at the index computed above; this results in a pointer with type `*struct {IntegerSumAggregate, IntegerSumAggregate}`
- Create a `store` instruction that stores this computed pointer to `&tmp4`

The resulting `store` IR therefore looks like (in pseudo-IR):

```
store *struct{IntegerSumAggregate, IntegerSumAggregate} val, **IntegerSumAggregate ptr
```

`Verifier::visitStoreInst()` contains an assertion that verifies (essentially) the following type constraint:

```
typeof(*ptr) == typeof(val)
```

We fail this assertion because we attempt to store a pointer to the structure `struct {IntegerSumAggregate, IntegerSumAggregate}` to a location that expects a pointer to a lone `IntegerSumAggregate`.