### PR TITLE
Fix GC-Compactor race in storage layer

### DIFF
--- a/src/storage/garbage_collector.cpp
+++ b/src/storage/garbage_collector.cpp
@@ -125,8 +125,8 @@ std::tuple<uint32_t, uint32_t, uint32_t> GarbageCollector::ProcessUnlinkQueue(tr
         // Regardless of the version chain we will need to reclaim deleted slots and any dangling pointers to varlens,
         // unless the transaction is aborted, and the record holds a version that is still visible.
         if (!txn->Aborted()) {
-          ReclaimSlotIfDeleted(&undo_record);
           ReclaimBufferIfVarlen(txn, &undo_record);
+          ReclaimSlotIfDeleted(&undo_record);
         }
         if (observer_ != nullptr) observer_->ObserveWrite(undo_record.Slot().GetBlock());
         buffer_processed++;


### PR DESCRIPTION
## Summary

There is a very unlikely race between the garbage collector's logic and the compactor's logic that could cause both memory leaks and use-after-free errors.  Note:  This race cannot occur in the current codebase because the compactor is not used.

## Race

The GC will do the following:
1. Truncate the version chain
2. Reclaim the tuple slot (i.e. mark it as unallocated)
3. Reclaim varlens (i.e. collect the underlying pointers for a call to free)

Meanwhile the compactor's logic:
1. Iterate over the block recording all slots marked unallocated
2. Select the last slot in the region being compacted and perform a deep copy of all varlens
3. Inserts the materialized tuple into the first available unallocated spot.

If the compactor's logic executes from start to finish in between steps 2 and 3 of the GC's logic, then we will leak the varlen associated with the logically deleted tuple (no references exist anymore) and we will free the backing memory for varlen we moved into place (creating the conditions for a use-after-free).

## Fix

Swap steps 2 and 3 in the GC logic.  This ensures all "dereferencing" of the tuple slot is complete prior to marking it as available reuse.

## Other

@mush-zhang, this race also exists in your DAF PR (#1157) and will not get automatically fixed by git's merge logic.  You'll need to manually fix it in [`transaction_context.cpp`](https://github.com/cmu-db/noisepage/pull/1157/files#diff-c2974ff8f0338fe220a8450bc4e9b71a).