### PR TITLE
Ubuntu 20.04 fixes for packages.sh and Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
                 stage('ubuntu-18.04/gcc-7.3.0 (Debug/format/lint/censored)') {
                     agent {
                         docker {
-                            image 'ubuntu:bionic'
+                            image 'terrier:focal'
                         }
                     }
                     steps {
@@ -58,7 +58,7 @@ pipeline {
                 stage('ubuntu-18.04/clang-8.0.0 (Debug/format/lint/censored)') {
                     agent {
                         docker {
-                            image 'ubuntu:bionic'
+                            image 'terrier:focal'
                         }
                     }
                     environment {
@@ -119,7 +119,7 @@ pipeline {
                 stage('ubuntu-18.04/gcc-7.3.0 (Debug/ASAN/unittest)') {
                     agent {
                         docker {
-                            image 'ubuntu:bionic'
+                            image 'terrier:focal'
                             args '--cap-add sys_ptrace -v /jenkins/ccache:/home/jenkins/.ccache'
                         }
                     }
@@ -148,7 +148,7 @@ pipeline {
                 stage('ubuntu-18.04/gcc-7.3.0 (Debug/Coverage/unittest)') {
                     agent {
                         docker {
-                            image 'ubuntu:bionic'
+                            image 'terrier:focal'
                             args '-v /jenkins/ccache:/home/jenkins/.ccache'
                         }
                     }
@@ -191,7 +191,7 @@ pipeline {
                 stage('ubuntu-18.04/clang-8.0.0 (Debug/ASAN/unittest)') {
                     agent {
                         docker {
-                            image 'ubuntu:bionic'
+                            image 'terrier:focal'
                             args '--cap-add sys_ptrace -v /jenkins/ccache:/home/jenkins/.ccache'
                         }
                     }
@@ -253,7 +253,7 @@ pipeline {
                 stage('ubuntu-18.04/gcc-7.3.0 (Release/unittest)') {
                     agent {
                         docker {
-                            image 'ubuntu:bionic'
+                            image 'terrier:focal'
                             args '-v /jenkins/ccache:/home/jenkins/.ccache'
                         }
                     }
@@ -281,7 +281,7 @@ pipeline {
                 stage('ubuntu-18.04/clang-8.0.0 (Release/unittest)') {
                     agent {
                         docker {
-                            image 'ubuntu:bionic'
+                            image 'terrier:focal'
                             args '-v /jenkins/ccache:/home/jenkins/.ccache'
                         }
                     }
@@ -346,7 +346,7 @@ pipeline {
                 stage('ubuntu-18.04/gcc-7.3.0 (Debug/e2etest/oltpbench)') {
                     agent {
                         docker {
-                            image 'ubuntu:bionic'
+                            image 'terrier:focal'
                             args '--cap-add sys_ptrace -v /jenkins/ccache:/home/jenkins/.ccache'
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
 
         stage('Check') {
             parallel {
-                stage('macos-10.14/clang-8 (Debug/format/lint/censored)') {
+                stage('macos-10.14/clang-8.0 (Debug/format/lint/censored)') {
                     agent { label 'macos' }
                     environment {
                         LLVM_DIR=sh(script: "brew --prefix llvm@8", label: "Fetching LLVM path", returnStdout: true).trim()
@@ -32,7 +32,7 @@ pipeline {
                     }
                 }
 
-                stage('ubuntu-18.04/gcc-7.3.0 (Debug/format/lint/censored)') {
+                stage('ubuntu-20.04/gcc-9.3 (Debug/format/lint/censored)') {
                     agent {
                         docker {
                             image 'terrier:focal'
@@ -55,7 +55,7 @@ pipeline {
                     }
                 }
 
-                stage('ubuntu-18.04/clang-8.0.0 (Debug/format/lint/censored)') {
+                stage('ubuntu-20.04/clang-8.0 (Debug/format/lint/censored)') {
                     agent {
                         docker {
                             image 'terrier:focal'
@@ -86,7 +86,7 @@ pipeline {
 
         stage('Test') {
             parallel {
-                stage('macos-10.14/clang-8 (Debug/ASAN/unittest)') {
+                stage('macos-10.14/clang-8.0 (Debug/ASAN/unittest)') {
                     agent { label 'macos' }
                     environment {
                         ASAN_OPTIONS="detect_container_overflow=0"
@@ -116,7 +116,7 @@ pipeline {
                     }
                 }
 
-                stage('ubuntu-18.04/gcc-7.3.0 (Debug/ASAN/unittest)') {
+                stage('ubuntu-20.04/gcc-9.3 (Debug/ASAN/unittest)') {
                     agent {
                         docker {
                             image 'terrier:focal'
@@ -145,7 +145,7 @@ pipeline {
                     }
                 }
 
-                stage('ubuntu-18.04/gcc-7.3.0 (Debug/Coverage/unittest)') {
+                stage('ubuntu-20.04/gcc-9.3 (Debug/Coverage/unittest)') {
                     agent {
                         docker {
                             image 'terrier:focal'
@@ -188,7 +188,7 @@ pipeline {
                     }
                 }
 
-                stage('ubuntu-18.04/clang-8.0.0 (Debug/ASAN/unittest)') {
+                stage('ubuntu-20.04/clang-8.0 (Debug/ASAN/unittest)') {
                     agent {
                         docker {
                             image 'terrier:focal'
@@ -221,7 +221,7 @@ pipeline {
                     }
                 }
 
-                stage('macos-10.14/clang-8 (Release/unittest)') {
+                stage('macos-10.14/clang-8.0 (Release/unittest)') {
                     agent { label 'macos' }
                     environment {
                         ASAN_OPTIONS="detect_container_overflow=0"
@@ -250,7 +250,7 @@ pipeline {
                     }
                 }
 
-                stage('ubuntu-18.04/gcc-7.3.0 (Release/unittest)') {
+                stage('ubuntu-20.04/gcc-9.3 (Release/unittest)') {
                     agent {
                         docker {
                             image 'terrier:focal'
@@ -278,7 +278,7 @@ pipeline {
                     }
                 }
 
-                stage('ubuntu-18.04/clang-8.0.0 (Release/unittest)') {
+                stage('ubuntu-20.04/clang-8.0 (Release/unittest)') {
                     agent {
                         docker {
                             image 'terrier:focal'
@@ -314,7 +314,7 @@ pipeline {
 
         stage('End-to-End Debug') {
             parallel{
-                stage('macos-10.14/clang-8 (Debug/e2etest/oltpbench)') {
+                stage('macos-10.14/clang-8.0 (Debug/e2etest/oltpbench)') {
                     agent { label 'macos' }
                     environment {
                         ASAN_OPTIONS="detect_container_overflow=0"
@@ -343,7 +343,7 @@ pipeline {
                         }
                     }
                 }
-                stage('ubuntu-18.04/gcc-7.3.0 (Debug/e2etest/oltpbench)') {
+                stage('ubuntu-20.04/gcc-9.3 (Debug/e2etest/oltpbench)') {
                     agent {
                         docker {
                             image 'terrier:focal'

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -31,8 +31,6 @@ OSX_TEST_PACKAGES=(\
   "lsof" \
 )
 
-# IMPORTANT: If you change anything listed below, you must 
-# also change it in the Dockerfile in the root directory of the repository!
 LINUX_BUILD_PACKAGES=(\
   "build-essential" \
   "clang-8" \

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -41,10 +41,10 @@ LINUX_BUILD_PACKAGES=(\
   "cmake" \
   "doxygen" \
   "git" \
-  "g++-7" \
   "libevent-dev" \
   "libjemalloc-dev" \
   "libpq-dev" \
+  "libpqxx-dev" \
   "libssl-dev" \
   "libtbb-dev" \
   "zlib1g-dev" \
@@ -142,7 +142,7 @@ install() {
       
       # Check Ubuntu version
       case $VERSION in
-        18.04) install_linux ;;
+        20.04) install_linux ;;
         *) give_up $DISTRO $VERSION;;
       esac
       ;;
@@ -204,24 +204,6 @@ install_linux() {
   # python3 -m pip --version || install_pip
   for pkg in "${PYTHON_PACKAGES[@]}"; do
     python3 -m pip show $pkg || python3 -m pip install $pkg
-  done
-         
-  # IMPORTANT: Ubuntu 18.04 does not have libpqxx-6.2 available. So we have to download the package
-  # manually and install it ourselves. We are *not* able to upgrade to libpqxx-6.4 because 18.04
-  # does not have the right version of libstdc++6 that it needs.
-  # Again, if you change the version make sure you update Dockerfile.
-  LIBPQXX_VERSION="6.2.5-1"
-  LIBPQXX_URL="http://mirrors.kernel.org/ubuntu/pool/universe/libp/libpqxx"
-  LIBPQXX_FILES=(\
-    "libpqxx-6.2_${LIBPQXX_VERSION}_amd64.deb" \
-    "libpqxx-dev_${LIBPQXX_VERSION}_amd64.deb" \
-  )
-  for file in "${LIBPQXX_FILES[@]}"; do
-    if [ ! -f "$file" ]; then
-      wget ${LIBPQXX_URL}/$file
-    fi
-    dpkg -i $file
-    rm $file
   done
 }
 

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -7,7 +7,7 @@
 ## build and run the DBMS.
 ##
 ## Supported environments:
-##  * Ubuntu 18.04
+##  * Ubuntu 20.04
 ##  * macOS
 ## =================================================================
 


### PR DESCRIPTION
- Packages.sh is now checking against 20.04.
- Add `libpqxx-dev` to the Linux package list rather than `wget`ing it.
- Jenkins will use the `terrier:focal` image now.