### PR TITLE
WAL: Remove redundant call between serializer and disk consumer

### DIFF
--- a/src/include/storage/write_ahead_log/disk_log_consumer_task.h
+++ b/src/include/storage/write_ahead_log/disk_log_consumer_task.h
@@ -69,7 +69,7 @@ class DiskLogConsumerTask : public common::DedicatedThreadTask {
   common::ConcurrentQueue<SerializedLogs> *filled_buffer_queue_;
 
   // Flag used by the serializer thread to signal the disk log consumer task thread to persist the data on disk
-  volatile bool do_persist_;
+  volatile bool force_flush_;
 
   // Synchronisation primitives to synchronise persisting buffers to disk
   std::mutex persist_lock_;

--- a/src/storage/write_ahead_log/log_manager.cpp
+++ b/src/storage/write_ahead_log/log_manager.cpp
@@ -35,11 +35,11 @@ void LogManager::ForceFlush() {
   log_serializer_task_->Process();
   // Signal the disk log consumer task thread to persist the buffers to disk
   std::unique_lock<std::mutex> lock(disk_log_writer_task_->persist_lock_);
-  disk_log_writer_task_->do_persist_ = true;
+  disk_log_writer_task_->force_flush_ = true;
   disk_log_writer_task_->disk_log_writer_thread_cv_.notify_one();
 
   // Wait for the disk log consumer task thread to persist the logs
-  disk_log_writer_task_->persist_cv_.wait(lock, [&] { return !disk_log_writer_task_->do_persist_; });
+  disk_log_writer_task_->persist_cv_.wait(lock, [&] { return !disk_log_writer_task_->force_flush_; });
 }
 
 void LogManager::PersistAndStop() {

--- a/src/storage/write_ahead_log/log_serializer_task.cpp
+++ b/src/storage/write_ahead_log/log_serializer_task.cpp
@@ -110,9 +110,6 @@ std::tuple<uint64_t, uint64_t, uint64_t> LogSerializerTask::Process() {
     // Mark the last buffer that was written to as full
     if (buffers_processed) HandFilledBufferToWriter();
 
-    // Mark the last buffer that was written to as full
-    if (filled_buffer_ != nullptr) HandFilledBufferToWriter();
-
     // Bulk remove all the transactions we serialized. This prevents having to take the TimestampManager's latch once
     // for each timestamp we remove.
     for (const auto &txns : serialized_txns_) {


### PR DESCRIPTION
Probably a merge error somewhere in the 10,000 line diff of #774.

Also renamed a variable to make its purpose more clear. This is part of a more exhaustive review of WAL performance.