### PR TITLE
Fail fast on Jenkins without "ready" GitHub labels.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh 'python3 ./build-support/check_github_labels.py'
                         sh 'echo y | ./script/installation/packages.sh build'
                         sh 'cd apidoc && doxygen -u Doxyfile.in && doxygen Doxyfile.in 2>warnings.txt && if [ -s warnings.txt ]; then cat warnings.txt; false; fi'
                         sh 'mkdir build'
@@ -40,6 +41,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh 'python3 ./build-support/check_github_labels.py'
                         sh 'echo y | sudo ./script/installation/packages.sh build'
                         sh 'cd apidoc && doxygen -u Doxyfile.in && doxygen Doxyfile.in 2>warnings.txt && if [ -s warnings.txt ]; then cat warnings.txt; false; fi'
                         sh 'mkdir build'
@@ -67,6 +69,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh 'python3 ./build-support/check_github_labels.py'
                         sh 'echo y | sudo ./script/installation/packages.sh build'
                         sh 'cd apidoc && doxygen -u Doxyfile.in && doxygen Doxyfile.in 2>warnings.txt && if [ -s warnings.txt ]; then cat warnings.txt; false; fi'
                         sh 'mkdir build'
@@ -96,6 +99,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh 'python3 ./build-support/check_github_labels.py'
                         sh 'echo y | ./script/installation/packages.sh all'
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON -DTERRIER_BUILD_BENCHMARKS=OFF .. && make -j4'
@@ -126,6 +130,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh 'python3 ./build-support/check_github_labels.py'
                         sh 'echo y | sudo ./script/installation/packages.sh all'
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON -DTERRIER_BUILD_BENCHMARKS=OFF .. && make -j$(nproc)'
@@ -159,6 +164,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh 'python3 ./build-support/check_github_labels.py'
                         sh 'echo y | sudo ./script/installation/packages.sh all'
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=OFF -DTERRIER_BUILD_BENCHMARKS=OFF -DTERRIER_GENERATE_COVERAGE=ON .. && make -j$(nproc)'
@@ -204,6 +210,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh 'python3 ./build-support/check_github_labels.py'
                         sh 'echo y | sudo ./script/installation/packages.sh all'
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON -DTERRIER_BUILD_BENCHMARKS=OFF .. && make -j$(nproc)'
@@ -235,6 +242,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh 'python3 ./build-support/check_github_labels.py'
                         sh 'echo y | ./script/installation/packages.sh all'
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF -DTERRIER_BUILD_BENCHMARKS=OFF .. && make -j4'
@@ -264,6 +272,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh 'python3 ./build-support/check_github_labels.py'
                         sh 'echo y | sudo ./script/installation/packages.sh all'
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF -DTERRIER_BUILD_BENCHMARKS=OFF .. && make -j$(nproc)'
@@ -297,6 +306,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh 'python3 ./build-support/check_github_labels.py'
                         sh 'echo y | sudo ./script/installation/packages.sh all'
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF -DTERRIER_BUILD_BENCHMARKS=OFF .. && make -j$(nproc)'
@@ -331,6 +341,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh 'python3 ./build-support/check_github_labels.py'
                         sh 'echo y | ./script/installation/packages.sh all'
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=debug -DTERRIER_USE_ASAN=ON -DTERRIER_USE_JEMALLOC=OFF .. && make -j$(nproc) terrier'
@@ -359,6 +370,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh 'python3 ./build-support/check_github_labels.py'
                         sh 'echo y | sudo ./script/installation/packages.sh all'
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=debug -DTERRIER_USE_ASAN=ON -DTERRIER_USE_JEMALLOC=OFF .. && make -j$(nproc) terrier'
@@ -384,6 +396,7 @@ pipeline {
             agent { label 'benchmark' }
             steps {
                 sh 'echo $NODE_NAME'
+                sh 'python3 ./build-support/check_github_labels.py'
                 sh 'echo y | sudo ./script/installation/packages.sh all'
                 sh 'mkdir build'
                 sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF -DTERRIER_USE_JEMALLOC=ON .. && make -j$(nproc) terrier'
@@ -404,6 +417,7 @@ pipeline {
             agent { label 'benchmark' }            
             steps {
                 sh 'echo $NODE_NAME'
+                sh 'python3 ./build-support/check_github_labels.py'
                 sh 'echo y | sudo ./script/installation/packages.sh all'
                 sh 'mkdir build'
                 sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF -DTERRIER_USE_JEMALLOC=ON -DTERRIER_BUILD_TESTS=OFF .. && make -j$(nproc) all'

--- a/build-support/check_github_labels.py
+++ b/build-support/check_github_labels.py
@@ -5,11 +5,11 @@ If a PR number cannot be detected from the current working directory,
 or if the tags are present, then the script exits with error code 0.
 Otherwise the script exits with error code 1.
 '''
-import re
+import json
 import os
+import re
 import sys
-
-import requests
+import urllib.request
 
 
 def get_pr_num():
@@ -26,7 +26,7 @@ if __name__ == '__main__':
         sys.exit(0)
     # Otherwise, get the labels for the PR.
     api_url = r'https://api.github.com/repos/cmu-db/noisepage/issues/{}/labels'
-    req = requests.get(api_url.format(pr_num))
+    req = json.loads(urllib.request.urlopen(api_url.format(pr_num)).read().decode('utf-8'))
     labels = [label['name'] for label in req.json()]
 
     if 'ready-for-review' in labels or 'ready-to-merge' in labels:

--- a/build-support/check_github_labels.py
+++ b/build-support/check_github_labels.py
@@ -26,8 +26,8 @@ if __name__ == '__main__':
         sys.exit(0)
     # Otherwise, get the labels for the PR.
     api_url = r'https://api.github.com/repos/cmu-db/noisepage/issues/{}/labels'
-    req = json.loads(urllib.request.urlopen(api_url.format(pr_num)).read().decode('utf-8'))
-    labels = [label['name'] for label in req.json()]
+    data = json.loads(urllib.request.urlopen(api_url.format(pr_num)).read().decode('utf-8'))
+    labels = [label['name'] for label in data]
 
     if 'ready-for-review' in labels or 'ready-to-merge' in labels:
         sys.exit(0)

--- a/build-support/check_github_labels.py
+++ b/build-support/check_github_labels.py
@@ -1,0 +1,35 @@
+'''
+Check to see if we've tagged the build as ready on GitHub.
+Valid tags: ready-for-review, ready-to-merge
+If a PR number cannot be detected from the current working directory,
+or if the tags are present, then the script exits with error code 0.
+Otherwise the script exits with error code 1.
+'''
+import re
+import os
+import sys
+
+import requests
+
+
+def get_pr_num():
+    match = re.match(r'.*terrier_PR-([^@/]*).*', os.getcwd())
+    if len(match.groups()) == 1:
+        return int(match.groups()[0])
+    return None
+
+
+if __name__ == '__main__':
+    pr_num = get_pr_num()
+    # If we can't find a PR number, allow the build to go on.
+    if pr_num is None:
+        sys.exit(0)
+    # Otherwise, get the labels for the PR.
+    api_url = r'https://api.github.com/repos/cmu-db/noisepage/issues/{}/labels'
+    req = requests.get(api_url.format(pr_num))
+    labels = [label['name'] for label in req.json()]
+
+    if 'ready-for-review' in labels or 'ready-to-merge' in labels:
+        sys.exit(0)
+    else:
+        sys.exit(1)


### PR DESCRIPTION
# Fail fast on Jenkins without "ready" GitHub labels.

## Description

Fail fast when building on Jenkins unless ready-for-review or ready-to-merge labels are present.