### PR TITLE
Fix the PR label check

### DIFF
--- a/build-support/check_github_labels.py
+++ b/build-support/check_github_labels.py
@@ -14,7 +14,7 @@ import urllib.request
 
 def get_pr_num():
     match = re.match(r'.*terrier_PR-([^@/]*).*', os.getcwd())
-    if len(match.groups()) == 1:
+    if match and len(match.groups()) == 1:
         return int(match.groups()[0])
     return None
 


### PR DESCRIPTION
# Fix the PR label check 

## Description
Currently, the check_github_labels.py errors out if there is no regex match. This is a hotfix so that builds can complete. when `match` is `None` it will just continue with the build.

Here is proof that it works if there are no matches http://jenkins.db.cs.cmu.edu:8080/blue/organizations/jenkins/testing-team%2Fterrier/detail/pr-check-fix/1/pipeline/9