### PR TITLE
Add explicit dependencies to CMake and -GNinja to nightly.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -625,6 +625,13 @@ target_link_libraries(noisepage_objlib PUBLIC       # PUBLIC: all consumers of t
         ${TBB_LIBRARIES_RELEASE}
         )
 
+# Dependencies are built in release because the debug versions have unacceptable performance for coverage builds.
+# make appears to struggle to figure these dependencies out on its own.
+# spdlog is not added as a true dependency because the library name changes between debug mode and release mode,
+# namely libspdlogd.a versus libspdlog.a. Due to the different names, the build system gets confused.
+# Therefore the dependency is manually added. This pattern is repeated below for gtest and gmock.
+add_dependencies(noisepage_objlib spdlog)
+
 # Create the noisepage_static and noisepage_shared libraries using the objects from noisepage_objlib.
 add_library(noisepage_static STATIC $<TARGET_OBJECTS:noisepage_objlib>)     # Bundle up these objects into static lib.
 target_link_libraries(noisepage_static PUBLIC noisepage_objlib)             # Consumers will inherit this link.
@@ -795,6 +802,7 @@ file(GLOB_RECURSE
 function(add_test_util_lib TYPE)
     string(TOLOWER ${TYPE} TYPE_LOWER)
     add_library(noisepage_test_util_${TYPE_LOWER} ${TYPE} ${NOISEPAGE_TEST_UTIL_SRCS})
+    add_dependencies(noisepage_test_util_${TYPE_LOWER} gtest gtest_main gmock gmock_main)
     target_compile_options(noisepage_test_util_${TYPE_LOWER} PRIVATE "-Werror" "-Wall")
     target_include_directories(noisepage_test_util_${TYPE_LOWER} PUBLIC ${PROJECT_SOURCE_DIR}/test/include/)
     target_include_directories(noisepage_test_util_${TYPE_LOWER} SYSTEM PUBLIC
@@ -982,6 +990,7 @@ file(GLOB_RECURSE
         )
 
 add_library(noisepage_benchmark_util STATIC ${NOISEPAGE_BENCHMARK_UTIL_SRCS})
+add_dependencies(noisepage_benchmark_util gtest gtest_main gmock gmock_main)
 target_compile_options(noisepage_benchmark_util PRIVATE "-Werror" "-Wall")
 target_include_directories(noisepage_benchmark_util PUBLIC ${PROJECT_SOURCE_DIR}/benchmark/include)
 target_link_libraries(noisepage_benchmark_util PUBLIC ${CMAKE_BINARY_DIR}/lib/libgmock_main.a noisepage_test_util_static benchmark)

--- a/Jenkinsfile-nightly
+++ b/Jenkinsfile-nightly
@@ -22,7 +22,7 @@ pipeline {
                 sh 'echo $NODE_NAME'
                 sh 'echo y | sudo ./script/installation/packages.sh all'
                 sh 'mkdir build'
-                sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DNOISEPAGE_USE_ASAN=OFF -DNOISEPAGE_USE_JEMALLOC=ON -DNOISEPAGE_BUILD_TESTS=OFF .. && ninja noisepage'
+                sh 'cd build && cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DNOISEPAGE_USE_ASAN=OFF -DNOISEPAGE_USE_JEMALLOC=ON -DNOISEPAGE_BUILD_TESTS=OFF .. && ninja noisepage'
                 sh "cd build && timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}"
                 sh "cd build && timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly_ramdisk.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}"
                 sh "cd build && timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly_wal_disabled.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}"
@@ -42,7 +42,7 @@ pipeline {
                 sh 'echo $NODE_NAME'
                 sh 'echo y | sudo ./script/installation/packages.sh all'
                 sh 'mkdir build'
-                sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DNOISEPAGE_USE_ASAN=OFF -DNOISEPAGE_USE_JEMALLOC=ON -DNOISEPAGE_BUILD_TESTS=OFF .. && ninja noisepage'
+                sh 'cd build && cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DNOISEPAGE_USE_ASAN=OFF -DNOISEPAGE_USE_JEMALLOC=ON -DNOISEPAGE_BUILD_TESTS=OFF .. && ninja noisepage'
                 // The micro_bench configuration has to be consistent because we currently check against previous runs with the same config
                 //  # of Threads: 4
                 //  WAL Path: Ramdisk


### PR DESCRIPTION
# Heading

Add explicit dependencies to CMake and -GNinja to nightly Jenkinsfile.

## Description

Dependencies added:
- noisepage_objlib (spdlog)
- test_util libs (gtest gtest_main gmock gmock_main)
- benchmark_util libs (gtest gtest_main gmock gmock_main)

Dependencies are built in release because the debug versions have unacceptable performance for coverage builds. Especially spdlog. `make` appears to struggle to figure these dependencies out on its own.

spdlog is not added as a true dependency because the library name changes between debug mode and release mode, namely libspdlogd.a versus libspdlog.a. Due to the different names, the build system gets confused.

Therefore the dependency is manually added.

The nightly Jenkinsfile is an omission I made.