### PR TITLE
Fix Memory Tracking Issue (#1250)

### DIFF
--- a/src/include/execution/sql/memory_tracker.h
+++ b/src/include/execution/sql/memory_tracker.h
@@ -4,9 +4,6 @@
 
 namespace noisepage::execution::sql {
 
-/**
- * TODO: track memory usage
- */
 class EXPORT MemoryTracker {
  public:
   // TODO(pmenon): Fill me in
@@ -14,30 +11,34 @@ class EXPORT MemoryTracker {
   /**
    * Reset tracker
    */
-  void Reset() { allocated_bytes_ = 0; }
+  void Reset() { stats_.local().allocated_bytes_ = 0; }
 
   /**
    * @returns number of allocated bytes
    */
-  size_t GetAllocatedSize() { return allocated_bytes_; }
+  size_t GetAllocatedSize() { return stats_.local().allocated_bytes_; }
 
   /**
    * Increments number of allocated bytes
    * @param size number to increment by
    */
-  void Increment(size_t size) { allocated_bytes_ += size; }
+  void Increment(size_t size) { stats_.local().allocated_bytes_ += size; }
 
   /**
    * Decrements number of allocated bytes
    * @param size number to decrement by
    */
-  void Decrement(size_t size) { allocated_bytes_ -= size; }
+  void Decrement(size_t size) { stats_.local().allocated_bytes_ -= size; }
 
  private:
-  struct Stats {};
+  /**
+   * Struct to store per-thread tracking data.
+   */
+  struct Stats {
+    // Number of bytes allocated
+    size_t allocated_bytes_ = 0;
+  };
   tbb::enumerable_thread_specific<Stats> stats_;
-  // number of bytes allocated
-  size_t allocated_bytes_;
 };
 
 }  // namespace noisepage::execution::sql

--- a/src/include/execution/sql/memory_tracker.h
+++ b/src/include/execution/sql/memory_tracker.h
@@ -4,10 +4,12 @@
 
 namespace noisepage::execution::sql {
 
+/**
+ * Class for tracking memory on a per-thread granularity.
+ * Currently tracks allocation size in bytes during thread's execution.
+ */
 class EXPORT MemoryTracker {
  public:
-  // TODO(pmenon): Fill me in
-
   /**
    * Reset tracker
    */


### PR DESCRIPTION
# Fix Parallel Memory Tracking Issue (#1250)

## Description
Fixes memory tracking in parallel by moving `allocated_bytes_` in the MemoryTracker into `tbb::enumerable_thread_specific`.