### PR TITLE
fix typo in SetIndexedUpdate in Update Plannode

### DIFF
--- a/src/include/planner/plannodes/update_plan_node.h
+++ b/src/include/planner/plannodes/update_plan_node.h
@@ -70,7 +70,7 @@ class UpdatePlanNode : public AbstractPlanNode {
      * @return builder object
      */
     Builder &SetIndexedUpdate(bool indexed_update) {
-      indexed_update_ = true;
+      indexed_update_ = indexed_update;
       return *this;
     }
 


### PR DESCRIPTION
# Fix Typo in SetIndexedUpdate in Update Plannode

## Description:
  
The indexed_update_ variable is not set according to the passed in parameter, but always to true. Fixed it by letting indexed_update_ adopt the boolean value passed into this function.
