### PR TITLE
Graceful Failures in Nightly Build

### DIFF
--- a/Jenkinsfile-nightly
+++ b/Jenkinsfile-nightly
@@ -28,25 +28,25 @@ pipeline {
                 cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DNOISEPAGE_USE_ASAN=OFF -DNOISEPAGE_USE_JEMALLOC=ON -DNOISEPAGE_BUILD_TESTS=OFF ..
                 ninja noisepage''', label: 'Compiling'
 
-                catchError{
+                catchError(stageResult: 'Failure'){
                     sh script:'''
                     cd build
                     timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
                     ''', label: 'OLTPBench (HDD WAL)'
                 }
-                catchError{
+                catchError(stageResult: 'Failure'){
                     sh script:'''
                     cd build
                     timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly_ramdisk.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
                     ''', label: 'OLTPBench (RamDisk WAL)'
                 }
-                catchError{
+                catchError(stageResult: 'Failure'){
                     sh script:'''
                     cd build
                     timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly_wal_disabled.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
                     ''', label: 'OLTPBench (No WAL)'
                 }
-                
+
                 archiveArtifacts(artifacts: 'build/oltp_result/**/*.*', excludes: 'build/oltp_result/**/*.csv', fingerprint: true)
             }
             post {

--- a/Jenkinsfile-nightly
+++ b/Jenkinsfile-nightly
@@ -28,21 +28,25 @@ pipeline {
                 cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DNOISEPAGE_USE_ASAN=OFF -DNOISEPAGE_USE_JEMALLOC=ON -DNOISEPAGE_BUILD_TESTS=OFF ..
                 ninja noisepage''', label: 'Compiling'
 
-                sh script:'''
-                cd build
-                timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
-                ''', label: 'OLTPBench (HDD WAL)'
-
-                sh script:'''
-                cd build
-                timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly_ramdisk.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
-                ''', label: 'OLTPBench (RamDisk WAL)'
-
-                sh script:'''
-                cd build
-                timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly_wal_disabled.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
-                ''', label: 'OLTPBench (No WAL)'
-
+                catchError{
+                    sh script:'''
+                    cd build
+                    timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
+                    ''', label: 'OLTPBench (HDD WAL)'
+                }
+                catchError{
+                    sh script:'''
+                    cd build
+                    timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly_ramdisk.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
+                    ''', label: 'OLTPBench (RamDisk WAL)'
+                }
+                catchError{
+                    sh script:'''
+                    cd build
+                    timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly_wal_disabled.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
+                    ''', label: 'OLTPBench (No WAL)'
+                }
+                
                 archiveArtifacts(artifacts: 'build/oltp_result/**/*.*', excludes: 'build/oltp_result/**/*.csv', fingerprint: true)
             }
             post {


### PR DESCRIPTION

# Graceful Failures in Nightly Build

## Description
This adds catchError statements in the nightly build so that as many steps as possible can execute. This makes sure that we are getting and storing as much data as possible. It also means that if a stage fails the other stages can still execute. Also it will still look like it failed when you look at Jenkins this will make sure that we aren't just ignoring failures when they happen. Here is an example: http://jenkins.db.cs.cmu.edu:8080/blue/organizations/jenkins/testing-team%2Fterrier-nightly/detail/flip-night-stages/2/pipeline/39/

