### PR TITLE
Forward declare more stuff in expressions, plan nodes, error data.

### DIFF
--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -12,6 +12,7 @@
 #include "binder/binder_util.h"
 #include "catalog/catalog_accessor.h"
 #include "catalog/catalog_defs.h"
+#include "common/error/error_code.h"
 #include "common/error/exception.h"
 #include "common/managed_pointer.h"
 #include "execution/functions/function_context.h"

--- a/src/binder/binder_context.cpp
+++ b/src/binder/binder_context.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "catalog/catalog_accessor.h"
+#include "common/error/error_code.h"
 #include "common/error/exception.h"
 #include "parser/expression/column_value_expression.h"
 #include "parser/expression/table_star_expression.h"

--- a/src/binder/binder_sherpa.cpp
+++ b/src/binder/binder_sherpa.cpp
@@ -3,8 +3,10 @@
 #include <unordered_map>
 
 #include "binder/binder_util.h"
+#include "common/error/error_code.h"
 #include "parser/expression/abstract_expression.h"
 #include "spdlog/fmt/fmt.h"
+
 namespace noisepage::binder {
 
 void BinderSherpa::SetDesiredTypePair(const common::ManagedPointer<parser::AbstractExpression> left,

--- a/src/binder/binder_util.cpp
+++ b/src/binder/binder_util.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <limits>
 
+#include "common/error/error_code.h"
 #include "network/postgres/postgres_defs.h"
 #include "parser/expression/constant_value_expression.h"
 #include "spdlog/fmt/fmt.h"

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -17,6 +17,7 @@
 #include "catalog/postgres/pg_proc.h"
 #include "catalog/postgres/pg_type.h"
 #include "catalog/schema.h"
+#include "common/error/error_code.h"
 #include "execution/functions/function_context.h"
 #include "nlohmann/json.hpp"
 #include "storage/index/index.h"

--- a/src/execution/compiler/operator/csv_scan_translator.cpp
+++ b/src/execution/compiler/operator/csv_scan_translator.cpp
@@ -1,5 +1,6 @@
 #include "execution/compiler/operator/csv_scan_translator.h"
 
+#include "common/error/error_code.h"
 #include "common/error/exception.h"
 #include "execution/compiler/codegen.h"
 #include "execution/compiler/compilation_context.h"
@@ -8,6 +9,7 @@
 #include "execution/compiler/pipeline.h"
 #include "execution/compiler/work_context.h"
 #include "planner/plannodes/csv_scan_plan_node.h"
+#include "planner/plannodes/output_schema.h"
 #include "spdlog/fmt/fmt.h"
 
 namespace noisepage::execution::compiler {

--- a/src/execution/compiler/operator/hash_join_translator.cpp
+++ b/src/execution/compiler/operator/hash_join_translator.cpp
@@ -8,6 +8,7 @@
 #include "execution/compiler/work_context.h"
 #include "execution/sql/join_hash_table.h"
 #include "planner/plannodes/hash_join_plan_node.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::execution::compiler {
 

--- a/src/execution/compiler/operator/operator_translator.cpp
+++ b/src/execution/compiler/operator/operator_translator.cpp
@@ -1,11 +1,13 @@
 #include "execution/compiler/operator/operator_translator.h"
 
 #include "brain/operating_unit_util.h"
+#include "common/error/error_code.h"
 #include "common/error/exception.h"
 #include "common/json.h"
 #include "execution/compiler/compilation_context.h"
 #include "execution/compiler/work_context.h"
 #include "planner/plannodes/abstract_plan_node.h"
+#include "planner/plannodes/output_schema.h"
 #include "spdlog/fmt/fmt.h"
 
 namespace noisepage::execution::compiler {

--- a/src/execution/compiler/operator/output_translator.cpp
+++ b/src/execution/compiler/operator/output_translator.cpp
@@ -6,6 +6,7 @@
 #include "execution/compiler/if.h"
 #include "execution/compiler/loop.h"
 #include "planner/plannodes/aggregate_plan_node.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::execution::compiler {
 

--- a/src/execution/compiler/operator/seq_scan_translator.cpp
+++ b/src/execution/compiler/operator/seq_scan_translator.cpp
@@ -1,6 +1,7 @@
 #include "execution/compiler/operator/seq_scan_translator.h"
 
 #include "catalog/catalog_accessor.h"
+#include "common/error/error_code.h"
 #include "common/error/exception.h"
 #include "execution/compiler/codegen.h"
 #include "execution/compiler/compilation_context.h"

--- a/src/execution/compiler/operator/sort_translator.cpp
+++ b/src/execution/compiler/operator/sort_translator.cpp
@@ -9,6 +9,7 @@
 #include "execution/compiler/work_context.h"
 #include "execution/sql/sorter.h"
 #include "planner/plannodes/order_by_plan_node.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::execution::compiler {
 

--- a/src/execution/sql/sql.cpp
+++ b/src/execution/sql/sql.cpp
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include "common/error/error_code.h"
 #include "common/error/exception.h"
 #include "spdlog/fmt/fmt.h"
 #include "type/type_id.h"

--- a/src/execution/sql/vector_operations/arithmetic.cpp
+++ b/src/execution/sql/vector_operations/arithmetic.cpp
@@ -1,3 +1,4 @@
+#include "common/error/error_code.h"
 #include "common/error/exception.h"
 #include "execution/exec/execution_settings.h"
 #include "execution/sql/operators/numeric_binary_operators.h"

--- a/src/execution/sql/vector_operations/fill.cpp
+++ b/src/execution/sql/vector_operations/fill.cpp
@@ -1,3 +1,4 @@
+#include "common/error/error_code.h"
 #include "common/error/exception.h"
 #include "execution/sql/generic_value.h"
 #include "execution/sql/vector_operations/vector_operations.h"

--- a/src/execution/sql/vector_operations/gather.cpp
+++ b/src/execution/sql/vector_operations/gather.cpp
@@ -1,3 +1,4 @@
+#include "common/error/error_code.h"
 #include "common/error/exception.h"
 #include "execution/sql/vector_operations/vector_operations.h"
 #include "spdlog/fmt/fmt.h"

--- a/src/execution/sql/vector_operations/gather_select.cpp
+++ b/src/execution/sql/vector_operations/gather_select.cpp
@@ -1,3 +1,4 @@
+#include "common/error/error_code.h"
 #include "common/error/exception.h"
 #include "execution/sql/operators/comparison_operators.h"
 #include "execution/sql/vector_operations/vector_operations.h"

--- a/src/execution/sql/vector_operations/generate.cpp
+++ b/src/execution/sql/vector_operations/generate.cpp
@@ -1,3 +1,4 @@
+#include "common/error/error_code.h"
 #include "common/error/exception.h"
 #include "execution/sql/vector_operations/vector_operations.h"
 #include "spdlog/fmt/fmt.h"

--- a/src/execution/sql/vector_operations/hash.cpp
+++ b/src/execution/sql/vector_operations/hash.cpp
@@ -1,3 +1,4 @@
+#include "common/error/error_code.h"
 #include "common/error/exception.h"
 #include "execution/sql/operators/hash_operators.h"
 #include "execution/sql/vector_operations/vector_operations.h"

--- a/src/execution/sql/vector_operations/like.cpp
+++ b/src/execution/sql/vector_operations/like.cpp
@@ -1,3 +1,4 @@
+#include "common/error/error_code.h"
 #include "common/error/exception.h"
 #include "common/macros.h"
 #include "execution/sql/operators/like_operators.h"

--- a/src/execution/sql/vector_operations/select.cpp
+++ b/src/execution/sql/vector_operations/select.cpp
@@ -1,3 +1,4 @@
+#include "common/error/error_code.h"
 #include "common/error/exception.h"
 #include "execution/exec/execution_settings.h"
 #include "execution/sql/operators/comparison_operators.h"

--- a/src/include/binder/bind_node_visitor.h
+++ b/src/include/binder/bind_node_visitor.h
@@ -34,7 +34,7 @@ class BinderSherpa;
 /**
  * Interface to be notified of the composition of a bind node.
  */
-class BindNodeVisitor : public SqlNodeVisitor {
+class BindNodeVisitor final : public SqlNodeVisitor {
  public:
   /**
    * Initialize the bind node visitor object with a pointer to a catalog accessor, and a default database name
@@ -44,7 +44,7 @@ class BindNodeVisitor : public SqlNodeVisitor {
   BindNodeVisitor(common::ManagedPointer<catalog::CatalogAccessor> catalog_accessor, catalog::db_oid_t db_oid);
 
   /** Destructor. Must be defined due to forward declaration. */
-  ~BindNodeVisitor();
+  ~BindNodeVisitor() final;
 
   /**
    * Perform binding on the passed in tree. Bind the relation names to oids
@@ -103,7 +103,7 @@ class BindNodeVisitor : public SqlNodeVisitor {
   const common::ManagedPointer<catalog::CatalogAccessor> catalog_accessor_;
   const catalog::db_oid_t db_oid_;
 
-  static void InitTableRef(const common::ManagedPointer<parser::TableRef> node);
+  static void InitTableRef(common::ManagedPointer<parser::TableRef> node);
 
   /**
    * Change the type of exprs_ of order_by_description from ConstantValueExpression to ColumnValueExpression.

--- a/src/include/binder/bind_node_visitor.h
+++ b/src/include/binder/bind_node_visitor.h
@@ -2,21 +2,16 @@
 
 #include <memory>
 #include <string>
-#include <utility>
 #include <vector>
 
-#include "binder/binder_sherpa.h"
 #include "binder/sql_node_visitor.h"
-#include "catalog/catalog_accessor.h"
 #include "catalog/catalog_defs.h"
-#include "parser/expression/column_value_expression.h"
-#include "parser/postgresparser.h"
-#include "parser/select_statement.h"
 #include "type/type_id.h"
 
 namespace noisepage {
 
 namespace parser {
+class AbstractExpression;
 class AggregateExpression;
 class CaseExpression;
 class ConstantValueExpression;
@@ -34,6 +29,7 @@ class CatalogAccessor;
 
 namespace binder {
 class BinderContext;
+class BinderSherpa;
 
 /**
  * Interface to be notified of the composition of a bind node.
@@ -46,6 +42,9 @@ class BindNodeVisitor : public SqlNodeVisitor {
    * @param db_oid oid of the connected database
    */
   BindNodeVisitor(common::ManagedPointer<catalog::CatalogAccessor> catalog_accessor, catalog::db_oid_t db_oid);
+
+  /** Destructor. Must be defined due to forward declaration. */
+  ~BindNodeVisitor();
 
   /**
    * Perform binding on the passed in tree. Bind the relation names to oids
@@ -96,7 +95,7 @@ class BindNodeVisitor : public SqlNodeVisitor {
 
  private:
   /** BinderSherpa which stores metadata (e.g. type information) across Visit calls. **/
-  std::unique_ptr<BinderSherpa> sherpa_ = nullptr;
+  std::unique_ptr<BinderSherpa> sherpa_;
   /** Current context of the query or subquery */
   common::ManagedPointer<BinderContext> context_ = nullptr;
 
@@ -104,9 +103,7 @@ class BindNodeVisitor : public SqlNodeVisitor {
   const common::ManagedPointer<catalog::CatalogAccessor> catalog_accessor_;
   const catalog::db_oid_t db_oid_;
 
-  static void InitTableRef(const common::ManagedPointer<parser::TableRef> node) {
-    if (node->table_info_ == nullptr) node->table_info_ = std::make_unique<parser::TableInfo>();
-  }
+  static void InitTableRef(const common::ManagedPointer<parser::TableRef> node);
 
   /**
    * Change the type of exprs_ of order_by_description from ConstantValueExpression to ColumnValueExpression.
@@ -116,17 +113,7 @@ class BindNodeVisitor : public SqlNodeVisitor {
   void UnifyOrderByExpression(common::ManagedPointer<parser::OrderByDescription> order_by_description,
                               const std::vector<common::ManagedPointer<parser::AbstractExpression>> &select_items);
 
-  void ValidateDatabaseName(const std::string &db_name) {
-    if (!(db_name.empty())) {
-      const auto db_oid = catalog_accessor_->GetDatabaseOid(db_name);
-      if (db_oid == catalog::INVALID_DATABASE_OID)
-        throw BINDER_EXCEPTION(fmt::format("Database \"{}\" does not exist", db_name),
-                               common::ErrorCode::ERRCODE_UNDEFINED_DATABASE);
-      if (db_oid != db_oid_)
-        throw BINDER_EXCEPTION("cross-database references are not implemented: ",
-                               common::ErrorCode::ERRCODE_FEATURE_NOT_SUPPORTED);
-    }
-  }
+  void ValidateDatabaseName(const std::string &db_name);
 };
 
 }  // namespace binder

--- a/src/include/binder/binder_context.h
+++ b/src/include/binder/binder_context.h
@@ -14,6 +14,7 @@ namespace noisepage {
 
 namespace parser {
 struct ColumnDefinition;
+class ColumnValueExpression;
 class CreateStatement;
 class TableRef;
 class TableStarExpression;

--- a/src/include/common/error/exception.h
+++ b/src/include/common/error/exception.h
@@ -6,7 +6,9 @@
 #include <memory>
 #include <string>
 
-#include "common/error/error_code.h"
+namespace noisepage::common {
+enum class ErrorCode : uint16_t;
+}  // namespace noisepage::common
 
 namespace noisepage {
 

--- a/src/include/common/hash_defs.h
+++ b/src/include/common/hash_defs.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <cstdint>
+
+namespace noisepage::common {
+/**
+ * This is our typedef that we use throughout the entire code to represent a hash value.
+ */
+using hash_t = uint64_t;
+}  // namespace noisepage

--- a/src/include/common/hash_defs.h
+++ b/src/include/common/hash_defs.h
@@ -7,4 +7,4 @@ namespace noisepage::common {
  * This is our typedef that we use throughout the entire code to represent a hash value.
  */
 using hash_t = uint64_t;
-}  // namespace noisepage
+}  // namespace noisepage::common

--- a/src/include/common/hash_util.h
+++ b/src/include/common/hash_util.h
@@ -7,17 +7,13 @@
 #include <string>
 #include <type_traits>
 
+#include "common/hash_defs.h"
 #include "common/macros.h"
 #include "common/strong_typedef.h"
 #include "execution/util/execution_common.h"
 #include "xxHash/xxh3.h"
 
 namespace noisepage::common {
-
-/**
- * This is our typedef that we use throughout the entire code to represent a hash value.
- */
-using hash_t = uint64_t;
 
 /**
  * Generic hashing utility class. The main entry point are the HashUtil::Hash() functions. There are

--- a/src/include/execution/exec/execution_context.h
+++ b/src/include/execution/exec/execution_context.h
@@ -29,6 +29,10 @@ namespace noisepage::metrics {
 class MetricsManager;
 }  // namespace noisepage::metrics
 
+namespace noisepage::parser {
+class ConstantValueExpression;
+}  // namespace noisepage::parser
+
 namespace noisepage::execution::exec {
 class ExecutionSettings;
 /**

--- a/src/include/execution/sql/operators/cast_operators.h
+++ b/src/include/execution/sql/operators/cast_operators.h
@@ -5,6 +5,7 @@
 #include <limits>
 #include <string>
 
+#include "common/error/error_code.h"
 #include "common/error/exception.h"
 #include "execution/sql/runtime_types.h"
 #include "execution/sql/sql.h"

--- a/src/include/execution/sql/vector_operations/inplace_operation_executor.h
+++ b/src/include/execution/sql/vector_operations/inplace_operation_executor.h
@@ -2,6 +2,7 @@
 
 #include <type_traits>
 
+#include "common/error/error_code.h"
 #include "common/error/exception.h"
 #include "execution/sql/vector.h"
 #include "execution/sql/vector_operations/traits.h"

--- a/src/include/parser/expression/abstract_expression.h
+++ b/src/include/parser/expression/abstract_expression.h
@@ -5,8 +5,7 @@
 #include <utility>
 #include <vector>
 
-#include "binder/sql_node_visitor.h"
-#include "common/hash_util.h"
+#include "common/hash_defs.h"
 #include "common/json_header.h"
 #include "common/managed_pointer.h"
 #include "parser/expression_defs.h"
@@ -21,6 +20,7 @@ class ExpressionNodeContents;
 namespace noisepage::binder {
 class BindNodeVisitor;
 class BinderUtil;
+class SqlNodeVisitor;
 }  // namespace noisepage::binder
 
 namespace noisepage::parser {

--- a/src/include/parser/expression/aggregate_expression.h
+++ b/src/include/parser/expression/aggregate_expression.h
@@ -43,11 +43,7 @@ class AggregateExpression : public AbstractExpression {
   std::unique_ptr<AbstractExpression> CopyWithChildren(
       std::vector<std::unique_ptr<AbstractExpression>> &&children) const override;
 
-  common::hash_t Hash() const override {
-    common::hash_t hash = AbstractExpression::Hash();
-    hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(distinct_));
-    return hash;
-  }
+  common::hash_t Hash() const override;
 
   bool operator==(const AbstractExpression &rhs) const override {
     if (!AbstractExpression::operator==(rhs)) return false;
@@ -63,7 +59,7 @@ class AggregateExpression : public AbstractExpression {
    */
   void DeriveReturnValueType() override;
 
-  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override { v->Visit(common::ManagedPointer(this)); }
+  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override;
 
   /** @return expression serialized to json */
   nlohmann::json ToJson() const override;

--- a/src/include/parser/expression/case_expression.h
+++ b/src/include/parser/expression/case_expression.h
@@ -38,12 +38,7 @@ class CaseExpression : public AbstractExpression {
      * Hash the current WhenClause.
      * @return hash of WhenClause
      */
-    common::hash_t Hash() const {
-      common::hash_t hash = condition_->Hash();
-      hash = common::HashUtil::CombineHashes(hash, condition_->Hash());
-      hash = common::HashUtil::CombineHashes(hash, then_->Hash());
-      return hash;
-    }
+    common::hash_t Hash() const;
 
     /**
      * Derived expressions should call this base method
@@ -130,7 +125,7 @@ class CaseExpression : public AbstractExpression {
   /** @return default clause, if it exists */
   common::ManagedPointer<AbstractExpression> GetDefaultClause() const { return common::ManagedPointer(default_expr_); }
 
-  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override { v->Visit(common::ManagedPointer(this)); }
+  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override;
 
   /** @return expression serialized to json */
   nlohmann::json ToJson() const override;

--- a/src/include/parser/expression/column_value_expression.h
+++ b/src/include/parser/expression/column_value_expression.h
@@ -152,7 +152,7 @@ class ColumnValueExpression : public AbstractExpression {
    */
   void DeriveExpressionName() override;
 
-  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override { v->Visit(common::ManagedPointer(this)); }
+  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override;
 
   /**
    * @return expression serialized to json

--- a/src/include/parser/expression/comparison_expression.h
+++ b/src/include/parser/expression/comparison_expression.h
@@ -40,7 +40,7 @@ class ComparisonExpression : public AbstractExpression {
   std::unique_ptr<AbstractExpression> CopyWithChildren(
       std::vector<std::unique_ptr<AbstractExpression>> &&children) const override;
 
-  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override { v->Visit(common::ManagedPointer(this)); }
+  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override;
 };
 
 DEFINE_JSON_HEADER_DECLARATIONS(ComparisonExpression);

--- a/src/include/parser/expression/conjunction_expression.h
+++ b/src/include/parser/expression/conjunction_expression.h
@@ -39,7 +39,7 @@ class ConjunctionExpression : public AbstractExpression {
   std::unique_ptr<AbstractExpression> CopyWithChildren(
       std::vector<std::unique_ptr<AbstractExpression>> &&children) const override;
 
-  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override { v->Visit(common::ManagedPointer(this)); }
+  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override;
 };
 
 DEFINE_JSON_HEADER_DECLARATIONS(ConjunctionExpression);

--- a/src/include/parser/expression/constant_value_expression.h
+++ b/src/include/parser/expression/constant_value_expression.h
@@ -227,7 +227,7 @@ class ConstantValueExpression : public AbstractExpression {
   template <typename T>
   T Peek() const;
 
-  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override { v->Visit(common::ManagedPointer(this)); }
+  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override;
 
   /** @return A string representation of this ConstantValueExpression. */
   std::string ToString() const;

--- a/src/include/parser/expression/default_value_expression.h
+++ b/src/include/parser/expression/default_value_expression.h
@@ -33,7 +33,7 @@ class DefaultValueExpression : public AbstractExpression {
     return Copy();
   }
 
-  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override { v->Visit(common::ManagedPointer(this)); }
+  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override;
 };
 
 DEFINE_JSON_HEADER_DECLARATIONS(DefaultValueExpression);

--- a/src/include/parser/expression/derived_value_expression.h
+++ b/src/include/parser/expression/derived_value_expression.h
@@ -56,7 +56,7 @@ class DerivedValueExpression : public AbstractExpression {
 
   bool operator==(const AbstractExpression &rhs) const override;
 
-  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override { v->Visit(common::ManagedPointer(this)); }
+  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override;
 
   /** @return expression serialized to json */
   nlohmann::json ToJson() const override;

--- a/src/include/parser/expression/function_expression.h
+++ b/src/include/parser/expression/function_expression.h
@@ -56,11 +56,7 @@ class FunctionExpression : public AbstractExpression {
   std::unique_ptr<AbstractExpression> CopyWithChildren(
       std::vector<std::unique_ptr<AbstractExpression>> &&children) const override;
 
-  common::hash_t Hash() const override {
-    common::hash_t hash = AbstractExpression::Hash();
-    hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(func_name_));
-    return hash;
-  }
+  common::hash_t Hash() const override;
 
   bool operator==(const AbstractExpression &rhs) const override {
     if (!AbstractExpression::operator==(rhs)) return false;
@@ -73,7 +69,7 @@ class FunctionExpression : public AbstractExpression {
 
   void DeriveExpressionName() override { SetExpressionName(GetFuncName()); }
 
-  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override { v->Visit(common::ManagedPointer(this)); }
+  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override;
 
   /** @return expression serialized to json */
   nlohmann::json ToJson() const override;

--- a/src/include/parser/expression/operator_expression.h
+++ b/src/include/parser/expression/operator_expression.h
@@ -42,7 +42,7 @@ class OperatorExpression : public AbstractExpression {
 
   void DeriveReturnValueType() override;
 
-  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override { v->Visit(common::ManagedPointer(this)); }
+  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override;
 };
 
 DEFINE_JSON_HEADER_DECLARATIONS(OperatorExpression);

--- a/src/include/parser/expression/parameter_value_expression.h
+++ b/src/include/parser/expression/parameter_value_expression.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <memory>
 #include <vector>
 
@@ -53,11 +54,7 @@ class ParameterValueExpression : public AbstractExpression {
   /** @return offset in the expression */
   uint32_t GetValueIdx() const { return value_idx_; }
 
-  common::hash_t Hash() const override {
-    common::hash_t hash = AbstractExpression::Hash();
-    hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(value_idx_));
-    return hash;
-  }
+  common::hash_t Hash() const override;
 
   bool operator==(const AbstractExpression &rhs) const override {
     if (!AbstractExpression::operator==(rhs)) return false;
@@ -65,7 +62,7 @@ class ParameterValueExpression : public AbstractExpression {
     return GetValueIdx() == other.GetValueIdx();
   }
 
-  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override { v->Visit(common::ManagedPointer(this)); }
+  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override;
 
   /** @return expression serialized to json */
   nlohmann::json ToJson() const override;

--- a/src/include/parser/expression/star_expression.h
+++ b/src/include/parser/expression/star_expression.h
@@ -36,7 +36,7 @@ class StarExpression : public AbstractExpression {
     return Copy();
   }
 
-  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override { v->Visit(common::ManagedPointer(this)); }
+  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override;
 };
 
 DEFINE_JSON_HEADER_DECLARATIONS(StarExpression);

--- a/src/include/parser/expression/table_star_expression.h
+++ b/src/include/parser/expression/table_star_expression.h
@@ -51,7 +51,7 @@ class TableStarExpression : public AbstractExpression {
   /** @return target table specified by TableStarExpression */
   const std::string &GetTargetTable() { return target_table_; }
 
-  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override { v->Visit(common::ManagedPointer(this)); }
+  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override;
 
  private:
   bool target_table_specified_ = false;

--- a/src/include/parser/expression/type_cast_expression.h
+++ b/src/include/parser/expression/type_cast_expression.h
@@ -35,7 +35,7 @@ class TypeCastExpression : public AbstractExpression {
   std::unique_ptr<AbstractExpression> CopyWithChildren(
       std::vector<std::unique_ptr<AbstractExpression>> &&children) const override;
 
-  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override { v->Visit(common::ManagedPointer(this)); }
+  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override;
 };
 
 DEFINE_JSON_HEADER_DECLARATIONS(TypeCastExpression);

--- a/src/include/parser/parse_result.h
+++ b/src/include/parser/parse_result.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "common/managed_pointer.h"
+
+namespace noisepage::parser {
+
+class AbstractExpression;
+class SQLStatement;
+
+/**
+ * ParseResult is the parser's output to the binder. It allows you to obtain non-owning managed pointers to the
+ * statements and expressions that were generated during the parse. If you need to take ownership, you can do that
+ * too, but then the parse result's copy is invalidated.
+ */
+class ParseResult {
+ public:
+  /**
+   * @return true if no statements exist
+   */
+  bool Empty() const { return statements_.empty(); }
+
+  /**
+   * Adds a statement to this parse result.
+   */
+  void AddStatement(std::unique_ptr<SQLStatement> statement) { statements_.emplace_back(std::move(statement)); }
+
+  /**
+   * Adds an expression to this parse result.
+   */
+  void AddExpression(std::unique_ptr<AbstractExpression> expression) {
+    expressions_.emplace_back(std::move(expression));
+  }
+
+  /**
+   * @return non-owning list of all the statements contained in this parse result
+   */
+  std::vector<common::ManagedPointer<SQLStatement>> GetStatements() {
+    std::vector<common::ManagedPointer<SQLStatement>> statements;
+    statements.reserve(statements_.size());
+    for (const auto &statement : statements_) {
+      statements.emplace_back(common::ManagedPointer(statement));
+    }
+    return statements;
+  }
+
+  /**
+   * @return size of internal statements_ vector
+   */
+  uint32_t NumStatements() const { return statements_.size(); }
+
+  /**
+   * @return the statement at a particular index
+   */
+  common::ManagedPointer<SQLStatement> GetStatement(size_t idx) { return common::ManagedPointer(statements_[idx]); }
+
+  /**
+   * @return non-owning list of all the expressions contained in this parse result
+   */
+  std::vector<common::ManagedPointer<AbstractExpression>> GetExpressions() {
+    std::vector<common::ManagedPointer<AbstractExpression>> expressions;
+    expressions.reserve(expressions_.size());
+    for (const auto &statement : expressions_) {
+      expressions.emplace_back(common::ManagedPointer(statement));
+    }
+    return expressions;
+  }
+
+  /**
+   * @return the expression at a particular index
+   */
+  common::ManagedPointer<AbstractExpression> GetExpression(size_t idx) {
+    return common::ManagedPointer(expressions_[idx]);
+  }
+
+  /**
+   * Returns ownership of the statements in this parse result.
+   * @return moved statements
+   */
+  std::vector<std::unique_ptr<SQLStatement>> &&TakeStatementsOwnership() { return std::move(statements_); }
+
+  /**
+   * Returns ownership of the expressions in this parse result.
+   * @return moved expressions
+   */
+  std::vector<std::unique_ptr<AbstractExpression>> &&TakeExpressionsOwnership() { return std::move(expressions_); }
+
+ private:
+  std::vector<std::unique_ptr<SQLStatement>> statements_;
+  std::vector<std::unique_ptr<AbstractExpression>> expressions_;
+};
+
+}  // namespace noisepage::parser

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -7,6 +7,7 @@
 
 #include "libpg_query/pg_query.h"
 #include "parser/create_statement.h"
+#include "parser/parse_result.h"
 #include "parser/parsenodes.h"
 
 namespace noisepage::parser {
@@ -18,88 +19,6 @@ class UpdateStatement;
 }  // namespace noisepage::parser
 
 namespace noisepage::parser {
-
-/**
- * ParseResult is the parser's output to the binder. It allows you to obtain non-owning managed pointers to the
- * statements and expressions that were generated during the parse. If you need to take ownership, you can do that
- * too, but then the parse result's copy is invalidated.
- */
-class ParseResult {
- public:
-  /**
-   * @return true if no statements exist
-   */
-  bool Empty() const { return statements_.empty(); }
-
-  /**
-   * Adds a statement to this parse result.
-   */
-  void AddStatement(std::unique_ptr<SQLStatement> statement) { statements_.emplace_back(std::move(statement)); }
-
-  /**
-   * Adds an expression to this parse result.
-   */
-  void AddExpression(std::unique_ptr<AbstractExpression> expression) {
-    expressions_.emplace_back(std::move(expression));
-  }
-
-  /**
-   * @return non-owning list of all the statements contained in this parse result
-   */
-  std::vector<common::ManagedPointer<SQLStatement>> GetStatements() {
-    std::vector<common::ManagedPointer<SQLStatement>> statements;
-    statements.reserve(statements_.size());
-    for (const auto &statement : statements_) {
-      statements.emplace_back(common::ManagedPointer(statement));
-    }
-    return statements;
-  }
-
-  /**
-   * @return size of internal statements_ vector
-   */
-  uint32_t NumStatements() const { return statements_.size(); }
-
-  /**
-   * @return the statement at a particular index
-   */
-  common::ManagedPointer<SQLStatement> GetStatement(size_t idx) { return common::ManagedPointer(statements_[idx]); }
-
-  /**
-   * @return non-owning list of all the expressions contained in this parse result
-   */
-  std::vector<common::ManagedPointer<AbstractExpression>> GetExpressions() {
-    std::vector<common::ManagedPointer<AbstractExpression>> expressions;
-    expressions.reserve(expressions_.size());
-    for (const auto &statement : expressions_) {
-      expressions.emplace_back(common::ManagedPointer(statement));
-    }
-    return expressions;
-  }
-
-  /**
-   * @return the expression at a particular index
-   */
-  common::ManagedPointer<AbstractExpression> GetExpression(size_t idx) {
-    return common::ManagedPointer(expressions_[idx]);
-  }
-
-  /**
-   * Returns ownership of the statements in this parse result.
-   * @return moved statements
-   */
-  std::vector<std::unique_ptr<SQLStatement>> &&TakeStatementsOwnership() { return std::move(statements_); }
-
-  /**
-   * Returns ownership of the expressions in this parse result.
-   * @return moved expressions
-   */
-  std::vector<std::unique_ptr<AbstractExpression>> &&TakeExpressionsOwnership() { return std::move(expressions_); }
-
- private:
-  std::vector<std::unique_ptr<SQLStatement>> statements_;
-  std::vector<std::unique_ptr<AbstractExpression>> expressions_;
-};
 
 /**
  * PostgresParser obtains and transforms the Postgres parse tree into our Terrier parse tree.

--- a/src/include/planner/plannodes/abstract_join_plan_node.h
+++ b/src/include/planner/plannodes/abstract_join_plan_node.h
@@ -59,10 +59,7 @@ class AbstractJoinPlanNode : public AbstractPlanNode {
    */
   AbstractJoinPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
                        std::unique_ptr<OutputSchema> output_schema, LogicalJoinType join_type,
-                       common::ManagedPointer<parser::AbstractExpression> predicate)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)),
-        join_type_(join_type),
-        join_predicate_(predicate) {}
+                       common::ManagedPointer<parser::AbstractExpression> predicate);
 
  public:
   /**

--- a/src/include/planner/plannodes/abstract_scan_plan_node.h
+++ b/src/include/planner/plannodes/abstract_scan_plan_node.h
@@ -120,15 +120,7 @@ class AbstractScanPlanNode : public AbstractPlanNode {
                        std::unique_ptr<OutputSchema> output_schema,
                        common::ManagedPointer<parser::AbstractExpression> predicate, bool is_for_update,
                        catalog::db_oid_t database_oid, uint32_t scan_limit, bool scan_has_limit, uint32_t scan_offset,
-                       bool scan_has_offset)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)),
-        scan_predicate_(predicate),
-        is_for_update_(is_for_update),
-        database_oid_(database_oid),
-        scan_limit_(scan_limit),
-        scan_has_limit_(scan_has_limit),
-        scan_offset_(scan_offset),
-        scan_has_offset_(scan_has_offset) {}
+                       bool scan_has_offset);
 
  public:
   /**

--- a/src/include/planner/plannodes/aggregate_plan_node.h
+++ b/src/include/planner/plannodes/aggregate_plan_node.h
@@ -79,11 +79,7 @@ class AggregatePlanNode : public AbstractPlanNode {
      * Build the aggregate plan node
      * @return plan node
      */
-    std::unique_ptr<AggregatePlanNode> Build() {
-      return std::unique_ptr<AggregatePlanNode>(
-          new AggregatePlanNode(std::move(children_), std::move(output_schema_), std::move(groupby_terms_),
-                                having_clause_predicate_, std::move(aggregate_terms_), aggregate_strategy_));
-    }
+    std::unique_ptr<AggregatePlanNode> Build();
 
    protected:
     /**
@@ -116,12 +112,7 @@ class AggregatePlanNode : public AbstractPlanNode {
   AggregatePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
                     std::unique_ptr<OutputSchema> output_schema, std::vector<GroupByTerm> groupby_terms,
                     common::ManagedPointer<parser::AbstractExpression> having_clause_predicate,
-                    std::vector<AggregateTerm> aggregate_terms, AggregateStrategyType aggregate_strategy)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)),
-        groupby_terms_(std::move(groupby_terms)),
-        having_clause_predicate_(having_clause_predicate),
-        aggregate_terms_(std::move(aggregate_terms)),
-        aggregate_strategy_(aggregate_strategy) {}
+                    std::vector<AggregateTerm> aggregate_terms, AggregateStrategyType aggregate_strategy);
 
  public:
   /**

--- a/src/include/planner/plannodes/analyze_plan_node.h
+++ b/src/include/planner/plannodes/analyze_plan_node.h
@@ -59,10 +59,7 @@ class AnalyzePlanNode : public AbstractPlanNode {
      * Build the analyze plan node
      * @return plan node
      */
-    std::unique_ptr<AnalyzePlanNode> Build() {
-      return std::unique_ptr<AnalyzePlanNode>(new AnalyzePlanNode(std::move(children_), std::move(output_schema_),
-                                                                  database_oid_, table_oid_, std::move(column_oids_)));
-    }
+    std::unique_ptr<AnalyzePlanNode> Build();
 
    protected:
     /**
@@ -91,11 +88,7 @@ class AnalyzePlanNode : public AbstractPlanNode {
    */
   AnalyzePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
                   std::unique_ptr<OutputSchema> output_schema, catalog::db_oid_t database_oid,
-                  catalog::table_oid_t table_oid, std::vector<catalog::col_oid_t> &&column_oids)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)),
-        database_oid_(database_oid),
-        table_oid_(table_oid),
-        column_oids_(std::move(column_oids)) {}
+                  catalog::table_oid_t table_oid, std::vector<catalog::col_oid_t> &&column_oids);
 
  public:
   /**

--- a/src/include/planner/plannodes/create_database_plan_node.h
+++ b/src/include/planner/plannodes/create_database_plan_node.h
@@ -45,10 +45,7 @@ class CreateDatabasePlanNode : public AbstractPlanNode {
      * Build the create database plan node
      * @return plan node
      */
-    std::unique_ptr<CreateDatabasePlanNode> Build() {
-      return std::unique_ptr<CreateDatabasePlanNode>(
-          new CreateDatabasePlanNode(std::move(children_), std::move(output_schema_), std::move(database_name_)));
-    }
+    std::unique_ptr<CreateDatabasePlanNode> Build();
 
    protected:
     /**
@@ -64,8 +61,7 @@ class CreateDatabasePlanNode : public AbstractPlanNode {
    * @param database_name the name of the database
    */
   CreateDatabasePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
-                         std::unique_ptr<OutputSchema> output_schema, std::string database_name)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)), database_name_(std::move(database_name)) {}
+                         std::unique_ptr<OutputSchema> output_schema, std::string database_name);
 
  public:
   /**

--- a/src/include/planner/plannodes/create_function_plan_node.h
+++ b/src/include/planner/plannodes/create_function_plan_node.h
@@ -123,12 +123,7 @@ class CreateFunctionPlanNode : public AbstractPlanNode {
      * Build the create function plan node
      * @return plan node
      */
-    std::unique_ptr<CreateFunctionPlanNode> Build() {
-      return std::unique_ptr<CreateFunctionPlanNode>(new CreateFunctionPlanNode(
-          std::move(children_), std::move(output_schema_), database_oid_, namespace_oid_, language_,
-          std::move(function_param_names_), std::move(function_param_types_), std::move(function_body_), is_replace_,
-          std::move(function_name_), return_type_, param_count_));
-    }
+    std::unique_ptr<CreateFunctionPlanNode> Build();
 
    protected:
     /**
@@ -203,18 +198,7 @@ class CreateFunctionPlanNode : public AbstractPlanNode {
                          std::vector<std::string> &&function_param_names,
                          std::vector<parser::BaseFunctionParameter::DataType> &&function_param_types,
                          std::vector<std::string> &&function_body, bool is_replace, std::string function_name,
-                         parser::BaseFunctionParameter::DataType return_type, int param_count)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)),
-        database_oid_(database_oid),
-        namespace_oid_(namespace_oid),
-        language_(language),
-        function_param_names_(std::move(function_param_names)),
-        function_param_types_(std::move(function_param_types)),
-        function_body_(std::move(function_body)),
-        is_replace_(is_replace),
-        function_name_(std::move(function_name)),
-        return_type_(return_type),
-        param_count_(param_count) {}
+                         parser::BaseFunctionParameter::DataType return_type, int param_count);
 
  public:
   /**

--- a/src/include/planner/plannodes/create_index_plan_node.h
+++ b/src/include/planner/plannodes/create_index_plan_node.h
@@ -70,11 +70,7 @@ class CreateIndexPlanNode : public AbstractPlanNode {
      * Build the create index plan node
      * @return plan node
      */
-    std::unique_ptr<CreateIndexPlanNode> Build() {
-      return std::unique_ptr<CreateIndexPlanNode>(
-          new CreateIndexPlanNode(std::move(children_), std::move(output_schema_), namespace_oid_, table_oid_,
-                                  std::move(index_name_), std::move(schema_)));
-    }
+    std::unique_ptr<CreateIndexPlanNode> Build();
 
    protected:
     /**
@@ -113,12 +109,7 @@ class CreateIndexPlanNode : public AbstractPlanNode {
   CreateIndexPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
                       std::unique_ptr<OutputSchema> output_schema, catalog::namespace_oid_t namespace_oid,
                       catalog::table_oid_t table_oid, std::string index_name,
-                      std::unique_ptr<catalog::IndexSchema> schema)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)),
-        namespace_oid_(namespace_oid),
-        table_oid_(table_oid),
-        index_name_(std::move(index_name)),
-        schema_(std::move(schema)) {}
+                      std::unique_ptr<catalog::IndexSchema> schema);
 
  public:
   /**

--- a/src/include/planner/plannodes/create_namespace_plan_node.h
+++ b/src/include/planner/plannodes/create_namespace_plan_node.h
@@ -42,10 +42,7 @@ class CreateNamespacePlanNode : public AbstractPlanNode {
      * Build the create namespace plan node
      * @return plan node
      */
-    std::unique_ptr<CreateNamespacePlanNode> Build() {
-      return std::unique_ptr<CreateNamespacePlanNode>(
-          new CreateNamespacePlanNode(std::move(children_), std::move(output_schema_), std::move(namespace_name_)));
-    }
+    std::unique_ptr<CreateNamespacePlanNode> Build();
 
    protected:
     /**
@@ -62,8 +59,7 @@ class CreateNamespacePlanNode : public AbstractPlanNode {
    * @param namespace_name name of the namespace
    */
   CreateNamespacePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
-                          std::unique_ptr<OutputSchema> output_schema, std::string namespace_name)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)), namespace_name_(std::move(namespace_name)) {}
+                          std::unique_ptr<OutputSchema> output_schema, std::string namespace_name);
 
  public:
   /**

--- a/src/include/planner/plannodes/create_table_plan_node.h
+++ b/src/include/planner/plannodes/create_table_plan_node.h
@@ -511,12 +511,7 @@ class CreateTablePlanNode : public AbstractPlanNode {
      * Build the create table plan node
      * @return plan node
      */
-    std::unique_ptr<CreateTablePlanNode> Build() {
-      return std::unique_ptr<CreateTablePlanNode>(new CreateTablePlanNode(
-          std::move(children_), std::move(output_schema_), namespace_oid_, std::move(table_name_),
-          std::move(table_schema_), block_store_, has_primary_key_, std::move(primary_key_), std::move(foreign_keys_),
-          std::move(con_uniques_), std::move(con_checks_)));
-    }
+    std::unique_ptr<CreateTablePlanNode> Build();
 
    protected:
     /**
@@ -585,17 +580,7 @@ class CreateTablePlanNode : public AbstractPlanNode {
                       std::string table_name, std::unique_ptr<catalog::Schema> table_schema,
                       common::ManagedPointer<storage::BlockStore> block_store, bool has_primary_key,
                       PrimaryKeyInfo primary_key, std::vector<ForeignKeyInfo> &&foreign_keys,
-                      std::vector<UniqueInfo> &&con_uniques, std::vector<CheckInfo> &&con_checks)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)),
-        namespace_oid_(namespace_oid),
-        table_name_(std::move(table_name)),
-        table_schema_(std::move(table_schema)),
-        block_store_(block_store),
-        has_primary_key_(has_primary_key),
-        primary_key_(std::move(primary_key)),
-        foreign_keys_(std::move(foreign_keys)),
-        con_uniques_(std::move(con_uniques)),
-        con_checks_(std::move(con_checks)) {}
+                      std::vector<UniqueInfo> &&con_uniques, std::vector<CheckInfo> &&con_checks);
 
  public:
   /**

--- a/src/include/planner/plannodes/create_trigger_plan_node.h
+++ b/src/include/planner/plannodes/create_trigger_plan_node.h
@@ -115,12 +115,7 @@ class CreateTriggerPlanNode : public AbstractPlanNode {
      * Build the create trigger plan node
      * @return plan node
      */
-    std::unique_ptr<CreateTriggerPlanNode> Build() {
-      return std::unique_ptr<CreateTriggerPlanNode>(new CreateTriggerPlanNode(
-          std::move(children_), std::move(output_schema_), database_oid_, namespace_oid_, table_oid_,
-          std::move(trigger_name_), std::move(trigger_funcnames_), std::move(trigger_args_),
-          std::move(trigger_columns_), trigger_when_, trigger_type_));
-    }
+    std::unique_ptr<CreateTriggerPlanNode> Build();
 
    protected:
     /**
@@ -188,17 +183,7 @@ class CreateTriggerPlanNode : public AbstractPlanNode {
                         catalog::namespace_oid_t namespace_oid, catalog::table_oid_t table_oid,
                         std::string trigger_name, std::vector<std::string> &&trigger_funcnames,
                         std::vector<std::string> &&trigger_args, std::vector<catalog::col_oid_t> &&trigger_columns,
-                        common::ManagedPointer<parser::AbstractExpression> trigger_when, int16_t trigger_type)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)),
-        database_oid_(database_oid),
-        namespace_oid_(namespace_oid),
-        table_oid_(table_oid),
-        trigger_name_(std::move(trigger_name)),
-        trigger_funcnames_(std::move(trigger_funcnames)),
-        trigger_args_(std::move(trigger_args)),
-        trigger_columns_(std::move(trigger_columns)),
-        trigger_when_(trigger_when),
-        trigger_type_(trigger_type) {}
+                        common::ManagedPointer<parser::AbstractExpression> trigger_when, int16_t trigger_type);
 
  public:
   /**

--- a/src/include/planner/plannodes/create_view_plan_node.h
+++ b/src/include/planner/plannodes/create_view_plan_node.h
@@ -69,11 +69,7 @@ class CreateViewPlanNode : public AbstractPlanNode {
      * Build the create view plan node
      * @return plan node
      */
-    std::unique_ptr<CreateViewPlanNode> Build() {
-      return std::unique_ptr<CreateViewPlanNode>(new CreateViewPlanNode(std::move(children_), std::move(output_schema_),
-                                                                        database_oid_, namespace_oid_,
-                                                                        std::move(view_name_), std::move(view_query_)));
-    }
+    std::unique_ptr<CreateViewPlanNode> Build();
 
    protected:
     /** OID of the database */
@@ -101,12 +97,7 @@ class CreateViewPlanNode : public AbstractPlanNode {
   CreateViewPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
                      std::unique_ptr<OutputSchema> output_schema, catalog::db_oid_t database_oid,
                      catalog::namespace_oid_t namespace_oid, std::string view_name,
-                     std::unique_ptr<parser::SelectStatement> view_query)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)),
-        database_oid_(database_oid),
-        namespace_oid_(namespace_oid),
-        view_name_(std::move(view_name)),
-        view_query_(std::move(view_query)) {}
+                     std::unique_ptr<parser::SelectStatement> view_query);
 
  public:
   /** Default constructor for deserialization. */

--- a/src/include/planner/plannodes/csv_scan_plan_node.h
+++ b/src/include/planner/plannodes/csv_scan_plan_node.h
@@ -75,12 +75,7 @@ class CSVScanPlanNode : public AbstractScanPlanNode {
      * Build the csv scan plan node
      * @return plan node
      */
-    std::unique_ptr<CSVScanPlanNode> Build() {
-      return std::unique_ptr<CSVScanPlanNode>(
-          new CSVScanPlanNode(std::move(children_), std::move(output_schema_), nullptr /* predicate */, is_for_update_,
-                              database_oid_, file_name_, delimiter_, quote_, escape_, value_types_, scan_limit_,
-                              scan_has_limit_, scan_offset_, scan_has_offset_));
-    }
+    std::unique_ptr<CSVScanPlanNode> Build();
 
    protected:
     /**
@@ -124,14 +119,7 @@ class CSVScanPlanNode : public AbstractScanPlanNode {
                   common::ManagedPointer<parser::AbstractExpression> predicate, bool is_for_update,
                   catalog::db_oid_t database_oid, std::string file_name, char delimiter, char quote, char escape,
                   std::vector<type::TypeId> value_types, uint32_t scan_limit, bool scan_has_limit, uint32_t scan_offset,
-                  bool scan_has_offset)
-      : AbstractScanPlanNode(std::move(children), std::move(output_schema), predicate, is_for_update, database_oid,
-                             scan_limit, scan_has_limit, scan_offset, scan_has_offset),
-        file_name_(std::move(file_name)),
-        delimiter_(delimiter),
-        quote_(quote),
-        escape_(escape),
-        value_types_(std::move(value_types)) {}
+                  bool scan_has_offset);
 
  public:
   /**

--- a/src/include/planner/plannodes/delete_plan_node.h
+++ b/src/include/planner/plannodes/delete_plan_node.h
@@ -55,10 +55,7 @@ class DeletePlanNode : public AbstractPlanNode {
      * Build the delete plan node
      * @return plan node
      */
-    std::unique_ptr<DeletePlanNode> Build() {
-      return std::unique_ptr<DeletePlanNode>(
-          new DeletePlanNode(std::move(children_), std::make_unique<OutputSchema>(), database_oid_, table_oid_));
-    }
+    std::unique_ptr<DeletePlanNode> Build();
 
    protected:
     /**
@@ -81,10 +78,7 @@ class DeletePlanNode : public AbstractPlanNode {
    * @param table_oid the OID of the target SQL table
    */
   DeletePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children, std::unique_ptr<OutputSchema> output_schema,
-                 catalog::db_oid_t database_oid, catalog::table_oid_t table_oid)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)),
-        database_oid_(database_oid),
-        table_oid_(table_oid) {}
+                 catalog::db_oid_t database_oid, catalog::table_oid_t table_oid);
 
  public:
   /**

--- a/src/include/planner/plannodes/drop_database_plan_node.h
+++ b/src/include/planner/plannodes/drop_database_plan_node.h
@@ -41,10 +41,7 @@ class DropDatabasePlanNode : public AbstractPlanNode {
      * Build the drop database plan node
      * @return plan node
      */
-    std::unique_ptr<DropDatabasePlanNode> Build() {
-      return std::unique_ptr<DropDatabasePlanNode>(
-          new DropDatabasePlanNode(std::move(children_), std::move(output_schema_), database_oid_));
-    }
+    std::unique_ptr<DropDatabasePlanNode> Build();
 
    protected:
     /**
@@ -60,8 +57,7 @@ class DropDatabasePlanNode : public AbstractPlanNode {
    * @param database_oid OID of the database to drop
    */
   DropDatabasePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
-                       std::unique_ptr<OutputSchema> output_schema, catalog::db_oid_t database_oid)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)), database_oid_(database_oid) {}
+                       std::unique_ptr<OutputSchema> output_schema, catalog::db_oid_t database_oid);
 
  public:
   /**

--- a/src/include/planner/plannodes/drop_index_plan_node.h
+++ b/src/include/planner/plannodes/drop_index_plan_node.h
@@ -41,10 +41,7 @@ class DropIndexPlanNode : public AbstractPlanNode {
      * Build the drop index plan node
      * @return plan node
      */
-    std::unique_ptr<DropIndexPlanNode> Build() {
-      return std::unique_ptr<DropIndexPlanNode>(
-          new DropIndexPlanNode(std::move(children_), std::move(output_schema_), index_oid_));
-    }
+    std::unique_ptr<DropIndexPlanNode> Build();
 
    protected:
     /**
@@ -62,8 +59,7 @@ class DropIndexPlanNode : public AbstractPlanNode {
    * @param index_oid OID of the index to drop
    */
   DropIndexPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
-                    std::unique_ptr<OutputSchema> output_schema, catalog::index_oid_t index_oid)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)), index_oid_(index_oid) {}
+                    std::unique_ptr<OutputSchema> output_schema, catalog::index_oid_t index_oid);
 
  public:
   /**

--- a/src/include/planner/plannodes/drop_namespace_plan_node.h
+++ b/src/include/planner/plannodes/drop_namespace_plan_node.h
@@ -41,10 +41,7 @@ class DropNamespacePlanNode : public AbstractPlanNode {
      * Build the drop namespace plan node
      * @return plan node
      */
-    std::unique_ptr<DropNamespacePlanNode> Build() {
-      return std::unique_ptr<DropNamespacePlanNode>(
-          new DropNamespacePlanNode(std::move(children_), std::move(output_schema_), namespace_oid_));
-    }
+    std::unique_ptr<DropNamespacePlanNode> Build();
 
    protected:
     /**
@@ -61,8 +58,7 @@ class DropNamespacePlanNode : public AbstractPlanNode {
    * @param namespace_oid OID of the namespace to drop
    */
   DropNamespacePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
-                        std::unique_ptr<OutputSchema> output_schema, catalog::namespace_oid_t namespace_oid)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)), namespace_oid_(namespace_oid) {}
+                        std::unique_ptr<OutputSchema> output_schema, catalog::namespace_oid_t namespace_oid);
 
  public:
   /**

--- a/src/include/planner/plannodes/drop_table_plan_node.h
+++ b/src/include/planner/plannodes/drop_table_plan_node.h
@@ -41,10 +41,7 @@ class DropTablePlanNode : public AbstractPlanNode {
      * Build the drop table plan node
      * @return plan node
      */
-    std::unique_ptr<DropTablePlanNode> Build() {
-      return std::unique_ptr<DropTablePlanNode>(
-          new DropTablePlanNode(std::move(children_), std::move(output_schema_), table_oid_));
-    }
+    std::unique_ptr<DropTablePlanNode> Build();
 
    protected:
     /**
@@ -62,8 +59,7 @@ class DropTablePlanNode : public AbstractPlanNode {
    * @param table_oid OID of the table to drop
    */
   DropTablePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
-                    std::unique_ptr<OutputSchema> output_schema, catalog::table_oid_t table_oid)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)), table_oid_(table_oid) {}
+                    std::unique_ptr<OutputSchema> output_schema, catalog::table_oid_t table_oid);
 
  public:
   /**

--- a/src/include/planner/plannodes/drop_trigger_plan_node.h
+++ b/src/include/planner/plannodes/drop_trigger_plan_node.h
@@ -68,10 +68,7 @@ class DropTriggerPlanNode : public AbstractPlanNode {
      * Build the drop trigger plan node
      * @return plan node
      */
-    std::unique_ptr<DropTriggerPlanNode> Build() {
-      return std::unique_ptr<DropTriggerPlanNode>(new DropTriggerPlanNode(
-          std::move(children_), std::move(output_schema_), database_oid_, namespace_oid_, trigger_oid_, if_exists_));
-    }
+    std::unique_ptr<DropTriggerPlanNode> Build();
 
    protected:
     /**
@@ -105,12 +102,7 @@ class DropTriggerPlanNode : public AbstractPlanNode {
    */
   DropTriggerPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
                       std::unique_ptr<OutputSchema> output_schema, catalog::db_oid_t database_oid,
-                      catalog::namespace_oid_t namespace_oid, catalog::trigger_oid_t trigger_oid, bool if_exists)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)),
-        database_oid_(database_oid),
-        namespace_oid_(namespace_oid),
-        trigger_oid_(trigger_oid),
-        if_exists_(if_exists) {}
+                      catalog::namespace_oid_t namespace_oid, catalog::trigger_oid_t trigger_oid, bool if_exists);
 
  public:
   /**

--- a/src/include/planner/plannodes/drop_view_plan_node.h
+++ b/src/include/planner/plannodes/drop_view_plan_node.h
@@ -59,10 +59,7 @@ class DropViewPlanNode : public AbstractPlanNode {
      * Build the drop view plan node
      * @return plan node
      */
-    std::unique_ptr<DropViewPlanNode> Build() {
-      return std::unique_ptr<DropViewPlanNode>(
-          new DropViewPlanNode(std::move(children_), std::move(output_schema_), database_oid_, view_oid_, if_exists_));
-    }
+    std::unique_ptr<DropViewPlanNode> Build();
 
    protected:
     /**
@@ -91,11 +88,7 @@ class DropViewPlanNode : public AbstractPlanNode {
    */
   DropViewPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
                    std::unique_ptr<OutputSchema> output_schema, catalog::db_oid_t database_oid,
-                   catalog::view_oid_t view_oid, bool if_exists)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)),
-        database_oid_(database_oid),
-        view_oid_(view_oid),
-        if_exists_(if_exists) {}
+                   catalog::view_oid_t view_oid, bool if_exists);
 
  public:
   /**

--- a/src/include/planner/plannodes/export_external_file_plan_node.h
+++ b/src/include/planner/plannodes/export_external_file_plan_node.h
@@ -83,10 +83,7 @@ class ExportExternalFilePlanNode : public AbstractPlanNode {
      * Build the export external file scan plan node
      * @return plan node
      */
-    std::unique_ptr<ExportExternalFilePlanNode> Build() {
-      return std::unique_ptr<ExportExternalFilePlanNode>(
-          new ExportExternalFilePlanNode(std::move(children_), format_, file_name_, delimiter_, quote_, escape_));
-    }
+    std::unique_ptr<ExportExternalFilePlanNode> Build();
 
    protected:
     /**
@@ -122,13 +119,7 @@ class ExportExternalFilePlanNode : public AbstractPlanNode {
    */
   explicit ExportExternalFilePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
                                       parser::ExternalFileFormat format, std::string file_name, char delimiter,
-                                      char quote, char escape)
-      : AbstractPlanNode(std::move(children), nullptr),
-        format_(format),
-        file_name_(std::move(file_name)),
-        delimiter_(delimiter),
-        quote_(quote),
-        escape_(escape) {}
+                                      char quote, char escape);
 
  public:
   /**

--- a/src/include/planner/plannodes/hash_join_plan_node.h
+++ b/src/include/planner/plannodes/hash_join_plan_node.h
@@ -78,10 +78,7 @@ class HashJoinPlanNode : public AbstractJoinPlanNode {
                    std::unique_ptr<OutputSchema> output_schema, LogicalJoinType join_type,
                    common::ManagedPointer<parser::AbstractExpression> predicate,
                    std::vector<common::ManagedPointer<parser::AbstractExpression>> &&left_hash_keys,
-                   std::vector<common::ManagedPointer<parser::AbstractExpression>> &&right_hash_keys)
-      : AbstractJoinPlanNode(std::move(children), std::move(output_schema), join_type, predicate),
-        left_hash_keys_(std::move(left_hash_keys)),
-        right_hash_keys_(std::move(right_hash_keys)) {}
+                   std::vector<common::ManagedPointer<parser::AbstractExpression>> &&right_hash_keys);
 
  public:
   /**

--- a/src/include/planner/plannodes/hash_join_plan_node.h
+++ b/src/include/planner/plannodes/hash_join_plan_node.h
@@ -52,11 +52,7 @@ class HashJoinPlanNode : public AbstractJoinPlanNode {
      * Build the hash join plan node
      * @return plan node
      */
-    std::unique_ptr<HashJoinPlanNode> Build() {
-      return std::unique_ptr<HashJoinPlanNode>(
-          new HashJoinPlanNode(std::move(children_), std::move(output_schema_), join_type_, join_predicate_,
-                               std::move(left_hash_keys_), std::move(right_hash_keys_)));
-    }
+    std::unique_ptr<HashJoinPlanNode> Build();
 
    protected:
     /**

--- a/src/include/planner/plannodes/index_join_plan_node.h
+++ b/src/include/planner/plannodes/index_join_plan_node.h
@@ -37,11 +37,7 @@ class IndexJoinPlanNode : public AbstractJoinPlanNode {
      * Build the nested loop join plan node
      * @return plan node
      */
-    std::unique_ptr<IndexJoinPlanNode> Build() {
-      return std::unique_ptr<IndexJoinPlanNode>(new IndexJoinPlanNode(
-          std::move(children_), std::move(output_schema_), join_type_, join_predicate_, index_oid_, table_oid_,
-          scan_type_, std::move(lo_index_cols_), std::move(hi_index_cols_), index_size_));
-    }
+    std::unique_ptr<IndexJoinPlanNode> Build();
 
     /**
      * Sets the scan type
@@ -121,14 +117,7 @@ class IndexJoinPlanNode : public AbstractJoinPlanNode {
                     common::ManagedPointer<parser::AbstractExpression> predicate, catalog::index_oid_t index_oid,
                     catalog::table_oid_t table_oid, IndexScanType scan_type,
                     std::unordered_map<catalog::indexkeycol_oid_t, IndexExpression> &&lo_cols,
-                    std::unordered_map<catalog::indexkeycol_oid_t, IndexExpression> &&hi_cols, uint64_t index_size)
-      : AbstractJoinPlanNode(std::move(children), std::move(output_schema), join_type, predicate),
-        index_oid_(index_oid),
-        table_oid_(table_oid),
-        scan_type_(scan_type),
-        lo_index_cols_(std::move(lo_cols)),
-        hi_index_cols_(std::move(hi_cols)),
-        index_size_(index_size) {}
+                    std::unordered_map<catalog::indexkeycol_oid_t, IndexExpression> &&hi_cols, uint64_t index_size);
 
  public:
   /**
@@ -193,19 +182,7 @@ class IndexJoinPlanNode : public AbstractJoinPlanNode {
    * Collect all column oids in this expression
    * @return the vector of unique columns oids
    */
-  std::vector<catalog::col_oid_t> CollectInputOids() const {
-    std::vector<catalog::col_oid_t> result;
-    // Scan predicate
-    if (GetJoinPredicate() != nullptr) CollectOids(&result, GetJoinPredicate().Get());
-    // Output expressions
-    for (const auto &col : GetOutputSchema()->GetColumns()) {
-      CollectOids(&result, col.GetExpr().Get());
-    }
-    // Remove duplicates
-    std::unordered_set<catalog::col_oid_t> s(result.begin(), result.end());
-    result.assign(s.begin(), s.end());
-    return result;
-  }
+  std::vector<catalog::col_oid_t> CollectInputOids() const;
 
  private:
   void CollectOids(std::vector<catalog::col_oid_t> *result, const parser::AbstractExpression *expr) const {

--- a/src/include/planner/plannodes/index_scan_plan_node.h
+++ b/src/include/planner/plannodes/index_scan_plan_node.h
@@ -114,12 +114,7 @@ class IndexScanPlanNode : public AbstractScanPlanNode {
      * Build the Index scan plan node
      * @return plan node
      */
-    std::unique_ptr<IndexScanPlanNode> Build() {
-      return std::unique_ptr<IndexScanPlanNode>(new IndexScanPlanNode(
-          std::move(children_), std::move(output_schema_), scan_predicate_, std::move(column_oids_), is_for_update_,
-          database_oid_, index_oid_, table_oid_, scan_type_, std::move(lo_index_cols_), std::move(hi_index_cols_),
-          scan_limit_, scan_has_limit_, scan_offset_, scan_has_offset_, index_size_, table_num_tuple_));
-    }
+    std::unique_ptr<IndexScanPlanNode> Build();
 
    private:
     IndexScanType scan_type_;
@@ -155,17 +150,7 @@ class IndexScanPlanNode : public AbstractScanPlanNode {
                     std::unordered_map<catalog::indexkeycol_oid_t, IndexExpression> &&lo_index_cols,
                     std::unordered_map<catalog::indexkeycol_oid_t, IndexExpression> &&hi_index_cols,
                     uint32_t scan_limit, bool scan_has_limit, uint32_t scan_offset, bool scan_has_offset,
-                    uint64_t index_size, uint64_t table_num_tuple)
-      : AbstractScanPlanNode(std::move(children), std::move(output_schema), predicate, is_for_update, database_oid,
-                             scan_limit, scan_has_limit, scan_offset, scan_has_offset),
-        scan_type_(scan_type),
-        index_oid_(index_oid),
-        table_oid_(table_oid),
-        column_oids_(column_oids),
-        lo_index_cols_(std::move(lo_index_cols)),
-        hi_index_cols_(std::move(hi_index_cols)),
-        table_num_tuple_(table_num_tuple),
-        index_size_(index_size) {}
+                    uint64_t index_size, uint64_t table_num_tuple);
 
  public:
   /**

--- a/src/include/planner/plannodes/insert_plan_node.h
+++ b/src/include/planner/plannodes/insert_plan_node.h
@@ -83,14 +83,7 @@ class InsertPlanNode : public AbstractPlanNode {
      * Build the delete plan node
      * @return plan node
      */
-    std::unique_ptr<InsertPlanNode> Build() {
-      NOISEPAGE_ASSERT(!children_.empty() || !values_.empty(), "Can't have an empty insert plan");
-      NOISEPAGE_ASSERT(!children_.empty() || values_[0].size() == parameter_info_.size(),
-                       "Must have parameter info for each value");
-      return std::unique_ptr<InsertPlanNode>(new InsertPlanNode(std::move(children_), std::move(output_schema_),
-                                                                database_oid_, table_oid_, std::move(values_),
-                                                                std::move(parameter_info_)));
-    }
+    std::unique_ptr<InsertPlanNode> Build();
 
    protected:
     /**
@@ -135,12 +128,7 @@ class InsertPlanNode : public AbstractPlanNode {
   InsertPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children, std::unique_ptr<OutputSchema> output_schema,
                  catalog::db_oid_t database_oid, catalog::table_oid_t table_oid,
                  std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>> &&values,
-                 std::vector<catalog::col_oid_t> &&parameter_info)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)),
-        database_oid_(database_oid),
-        table_oid_(table_oid),
-        values_(std::move(values)),
-        parameter_info_(std::move(parameter_info)) {}
+                 std::vector<catalog::col_oid_t> &&parameter_info);
 
  public:
   DISALLOW_COPY_AND_MOVE(InsertPlanNode)

--- a/src/include/planner/plannodes/limit_plan_node.h
+++ b/src/include/planner/plannodes/limit_plan_node.h
@@ -50,10 +50,7 @@ class LimitPlanNode : public AbstractPlanNode {
      * Build the limit plan node
      * @return plan node
      */
-    std::unique_ptr<LimitPlanNode> Build() {
-      return std::unique_ptr<LimitPlanNode>(
-          new LimitPlanNode(std::move(children_), std::move(output_schema_), limit_, offset_));
-    }
+    std::unique_ptr<LimitPlanNode> Build();
 
    protected:
     /**
@@ -74,8 +71,7 @@ class LimitPlanNode : public AbstractPlanNode {
    * @param offset offset at which to limit from
    */
   LimitPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children, std::unique_ptr<OutputSchema> output_schema,
-                size_t limit, size_t offset)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)), limit_(limit), offset_(offset) {}
+                size_t limit, size_t offset);
 
  public:
   /**

--- a/src/include/planner/plannodes/nested_loop_join_plan_node.h
+++ b/src/include/planner/plannodes/nested_loop_join_plan_node.h
@@ -31,10 +31,7 @@ class NestedLoopJoinPlanNode : public AbstractJoinPlanNode {
      * Build the nested loop join plan node
      * @return plan node
      */
-    std::unique_ptr<NestedLoopJoinPlanNode> Build() {
-      return std::unique_ptr<NestedLoopJoinPlanNode>(
-          new NestedLoopJoinPlanNode(std::move(children_), std::move(output_schema_), join_type_, join_predicate_));
-    }
+    std::unique_ptr<NestedLoopJoinPlanNode> Build();
   };
 
  private:
@@ -46,8 +43,7 @@ class NestedLoopJoinPlanNode : public AbstractJoinPlanNode {
    */
   NestedLoopJoinPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
                          std::unique_ptr<OutputSchema> output_schema, LogicalJoinType join_type,
-                         common::ManagedPointer<parser::AbstractExpression> predicate)
-      : AbstractJoinPlanNode(std::move(children), std::move(output_schema), join_type, predicate) {}
+                         common::ManagedPointer<parser::AbstractExpression> predicate);
 
  public:
   /**

--- a/src/include/planner/plannodes/order_by_plan_node.h
+++ b/src/include/planner/plannodes/order_by_plan_node.h
@@ -70,10 +70,7 @@ class OrderByPlanNode : public AbstractPlanNode {
      * Build the order by plan node
      * @return plan node
      */
-    std::unique_ptr<OrderByPlanNode> Build() {
-      return std::unique_ptr<OrderByPlanNode>(new OrderByPlanNode(std::move(children_), std::move(output_schema_),
-                                                                  std::move(sort_keys_), has_limit_, limit_, offset_));
-    }
+    std::unique_ptr<OrderByPlanNode> Build();
 
    protected:
     /**
@@ -106,12 +103,7 @@ class OrderByPlanNode : public AbstractPlanNode {
    */
   OrderByPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
                   std::unique_ptr<OutputSchema> output_schema, std::vector<SortKey> sort_keys, bool has_limit,
-                  size_t limit, size_t offset)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)),
-        sort_keys_(std::move(sort_keys)),
-        has_limit_(has_limit),
-        limit_(limit),
-        offset_(offset) {}
+                  size_t limit, size_t offset);
 
  public:
   /**

--- a/src/include/planner/plannodes/output_schema.h
+++ b/src/include/planner/plannodes/output_schema.h
@@ -6,7 +6,7 @@
 #include <vector>
 
 #include "common/constants.h"
-#include "common/hash_util.h"
+#include "common/hash_defs.h"
 #include "common/json_header.h"
 #include "common/macros.h"
 #include "common/strong_typedef.h"

--- a/src/include/planner/plannodes/projection_plan_node.h
+++ b/src/include/planner/plannodes/projection_plan_node.h
@@ -31,10 +31,7 @@ class ProjectionPlanNode : public AbstractPlanNode {
      * Build the projection plan node
      * @return plan node
      */
-    std::unique_ptr<ProjectionPlanNode> Build() {
-      return std::unique_ptr<ProjectionPlanNode>(
-          new ProjectionPlanNode(std::move(children_), std::move(output_schema_)));
-    }
+    std::unique_ptr<ProjectionPlanNode> Build();
   };
 
  private:
@@ -43,8 +40,7 @@ class ProjectionPlanNode : public AbstractPlanNode {
    * @param output_schema Schema representing the structure of the output of this plan node
    */
   explicit ProjectionPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
-                              std::unique_ptr<OutputSchema> output_schema)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)) {}
+                              std::unique_ptr<OutputSchema> output_schema);
 
  public:
   /**

--- a/src/include/planner/plannodes/seq_scan_plan_node.h
+++ b/src/include/planner/plannodes/seq_scan_plan_node.h
@@ -55,11 +55,7 @@ class SeqScanPlanNode : public AbstractScanPlanNode {
      * Build the sequential scan plan node
      * @return plan node
      */
-    std::unique_ptr<SeqScanPlanNode> Build() {
-      return std::unique_ptr<SeqScanPlanNode>(new SeqScanPlanNode(
-          std::move(children_), std::move(output_schema_), scan_predicate_, std::move(column_oids_), is_for_update_,
-          database_oid_, table_oid_, scan_limit_, scan_has_limit_, scan_offset_, scan_has_offset_));
-    }
+    std::unique_ptr<SeqScanPlanNode> Build();
 
    protected:
     /**
@@ -88,11 +84,7 @@ class SeqScanPlanNode : public AbstractScanPlanNode {
                   common::ManagedPointer<parser::AbstractExpression> predicate,
                   std::vector<catalog::col_oid_t> &&column_oids, bool is_for_update, catalog::db_oid_t database_oid,
                   catalog::table_oid_t table_oid, uint32_t scan_limit, bool scan_has_limit, uint32_t scan_offset,
-                  bool scan_has_offset)
-      : AbstractScanPlanNode(std::move(children), std::move(output_schema), predicate, is_for_update, database_oid,
-                             scan_limit, scan_has_limit, scan_offset, scan_has_offset),
-        column_oids_(std::move(column_oids)),
-        table_oid_(table_oid) {}
+                  bool scan_has_offset);
 
  public:
   /**

--- a/src/parser/expression/aggregate_expression.cpp
+++ b/src/parser/expression/aggregate_expression.cpp
@@ -1,5 +1,7 @@
 #include "parser/expression/aggregate_expression.h"
 
+#include "common/hash_util.h"
+#include "binder/sql_node_visitor.h"
 #include "common/json.h"
 #include "spdlog/fmt/fmt.h"
 
@@ -54,6 +56,16 @@ std::vector<std::unique_ptr<AbstractExpression>> AggregateExpression::FromJson(c
   exprs.insert(exprs.end(), std::make_move_iterator(e1.begin()), std::make_move_iterator(e1.end()));
   distinct_ = j.at("distinct").get<bool>();
   return exprs;
+}
+
+void AggregateExpression::Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) {
+  v->Visit(common::ManagedPointer(this));
+}
+
+common::hash_t AggregateExpression::Hash() const {
+  common::hash_t hash = AbstractExpression::Hash();
+  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(distinct_));
+  return hash;
 }
 
 DEFINE_JSON_BODY_DECLARATIONS(AggregateExpression);

--- a/src/parser/expression/aggregate_expression.cpp
+++ b/src/parser/expression/aggregate_expression.cpp
@@ -1,7 +1,7 @@
 #include "parser/expression/aggregate_expression.h"
 
-#include "common/hash_util.h"
 #include "binder/sql_node_visitor.h"
+#include "common/hash_util.h"
 #include "common/json.h"
 #include "spdlog/fmt/fmt.h"
 

--- a/src/parser/expression/case_expression.cpp
+++ b/src/parser/expression/case_expression.cpp
@@ -1,5 +1,7 @@
 #include "parser/expression/case_expression.h"
 
+#include "binder/sql_node_visitor.h"
+#include "common/hash_util.h"
 #include "common/json.h"
 
 namespace noisepage::parser {
@@ -22,6 +24,13 @@ std::vector<std::unique_ptr<AbstractExpression>> CaseExpression::WhenClause::Fro
   exprs.insert(exprs.end(), std::make_move_iterator(deserialized_then.non_owned_exprs_.begin()),
                std::make_move_iterator(deserialized_then.non_owned_exprs_.end()));
   return exprs;
+}
+
+common::hash_t CaseExpression::WhenClause::Hash() const {
+  common::hash_t hash = condition_->Hash();
+  hash = common::HashUtil::CombineHashes(hash, condition_->Hash());
+  hash = common::HashUtil::CombineHashes(hash, then_->Hash());
+  return hash;
 }
 
 common::hash_t CaseExpression::Hash() const {
@@ -82,6 +91,10 @@ std::vector<std::unique_ptr<AbstractExpression>> CaseExpression::FromJson(const 
   exprs.insert(exprs.end(), std::make_move_iterator(e2.non_owned_exprs_.begin()),
                std::make_move_iterator(e2.non_owned_exprs_.end()));
   return exprs;
+}
+
+void CaseExpression::Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) {
+  v->Visit(common::ManagedPointer(this));
 }
 
 DEFINE_JSON_BODY_DECLARATIONS(CaseExpression::WhenClause);

--- a/src/parser/expression/column_value_expression.cpp
+++ b/src/parser/expression/column_value_expression.cpp
@@ -1,5 +1,7 @@
 #include "parser/expression/column_value_expression.h"
 
+#include "binder/sql_node_visitor.h"
+#include "common/hash_util.h"
 #include "common/json.h"
 
 namespace noisepage::parser {
@@ -43,6 +45,10 @@ void ColumnValueExpression::DeriveExpressionName() {
     this->SetExpressionName(this->GetAlias());
   else
     this->SetExpressionName(column_name_);
+}
+
+void ColumnValueExpression::Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) {
+  v->Visit(common::ManagedPointer(this));
 }
 
 nlohmann::json ColumnValueExpression::ToJson() const {

--- a/src/parser/expression/comparison_expression.cpp
+++ b/src/parser/expression/comparison_expression.cpp
@@ -1,5 +1,6 @@
 #include "parser/expression/comparison_expression.h"
 
+#include "binder/sql_node_visitor.h"
 #include "common/json.h"
 
 namespace noisepage::parser {
@@ -17,6 +18,10 @@ std::unique_ptr<AbstractExpression> ComparisonExpression::CopyWithChildren(
   auto expr = std::make_unique<ComparisonExpression>(GetExpressionType(), std::move(children));
   expr->SetMutableStateForCopy(*this);
   return expr;
+}
+
+void ComparisonExpression::Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) {
+  v->Visit(common::ManagedPointer(this));
 }
 
 DEFINE_JSON_BODY_DECLARATIONS(ComparisonExpression);

--- a/src/parser/expression/conjunction_expression.cpp
+++ b/src/parser/expression/conjunction_expression.cpp
@@ -1,5 +1,6 @@
 #include "parser/expression/conjunction_expression.h"
 
+#include "binder/sql_node_visitor.h"
 #include "common/json.h"
 
 namespace noisepage::parser {
@@ -17,6 +18,10 @@ std::unique_ptr<AbstractExpression> ConjunctionExpression::CopyWithChildren(
   auto expr = std::make_unique<ConjunctionExpression>(GetExpressionType(), std::move(children));
   expr->SetMutableStateForCopy(*this);
   return expr;
+}
+
+void ConjunctionExpression::Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) {
+  v->Visit(common::ManagedPointer(this));
 }
 
 DEFINE_JSON_BODY_DECLARATIONS(ConjunctionExpression);

--- a/src/parser/expression/constant_value_expression.cpp
+++ b/src/parser/expression/constant_value_expression.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "binder/sql_node_visitor.h"
 #include "common/hash_util.h"
 #include "common/json.h"
 #include "execution/sql/runtime_types.h"
@@ -340,6 +341,10 @@ std::vector<std::unique_ptr<AbstractExpression>> ConstantValueExpression::FromJs
   Validate();
 
   return exprs;
+}
+
+void ConstantValueExpression::Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) {
+  v->Visit(common::ManagedPointer(this));
 }
 
 DEFINE_JSON_BODY_DECLARATIONS(ConstantValueExpression);

--- a/src/parser/expression/default_value_expression.cpp
+++ b/src/parser/expression/default_value_expression.cpp
@@ -1,5 +1,6 @@
 #include "parser/expression/default_value_expression.h"
 
+#include "binder/sql_node_visitor.h"
 #include "common/json.h"
 
 namespace noisepage::parser {
@@ -8,6 +9,10 @@ std::unique_ptr<AbstractExpression> DefaultValueExpression::Copy() const {
   auto expr = std::make_unique<DefaultValueExpression>();
   expr->SetMutableStateForCopy(*this);
   return expr;
+}
+
+void DefaultValueExpression::Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) {
+  v->Visit(common::ManagedPointer(this));
 }
 
 DEFINE_JSON_BODY_DECLARATIONS(DefaultValueExpression);

--- a/src/parser/expression/derived_value_expression.cpp
+++ b/src/parser/expression/derived_value_expression.cpp
@@ -1,5 +1,7 @@
 #include "parser/expression/derived_value_expression.h"
 
+#include "binder/sql_node_visitor.h"
+#include "common/hash_util.h"
 #include "common/json.h"
 
 namespace noisepage::parser {
@@ -22,6 +24,10 @@ bool DerivedValueExpression::operator==(const AbstractExpression &rhs) const {
   auto const &other = dynamic_cast<const DerivedValueExpression &>(rhs);
   if (GetTupleIdx() != other.GetTupleIdx()) return false;
   return GetValueIdx() == other.GetValueIdx();
+}
+
+void DerivedValueExpression::Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) {
+  v->Visit(common::ManagedPointer(this));
 }
 
 nlohmann::json DerivedValueExpression::ToJson() const {

--- a/src/parser/expression/function_expression.cpp
+++ b/src/parser/expression/function_expression.cpp
@@ -1,5 +1,7 @@
 #include "parser/expression/function_expression.h"
 
+#include "binder/sql_node_visitor.h"
+#include "common/hash_util.h"
 #include "common/json.h"
 
 namespace noisepage::parser {
@@ -33,6 +35,16 @@ std::vector<std::unique_ptr<AbstractExpression>> FunctionExpression::FromJson(co
   exprs.insert(exprs.end(), std::make_move_iterator(e1.begin()), std::make_move_iterator(e1.end()));
   func_name_ = j.at("func_name").get<std::string>();
   return exprs;
+}
+
+void FunctionExpression::Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) {
+  v->Visit(common::ManagedPointer(this));
+}
+
+common::hash_t FunctionExpression::Hash() const {
+  common::hash_t hash = AbstractExpression::Hash();
+  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(func_name_));
+  return hash;
 }
 
 DEFINE_JSON_BODY_DECLARATIONS(FunctionExpression);

--- a/src/parser/expression/operator_expression.cpp
+++ b/src/parser/expression/operator_expression.cpp
@@ -1,5 +1,6 @@
 #include "parser/expression/operator_expression.h"
 
+#include "binder/sql_node_visitor.h"
 #include "common/json.h"
 
 namespace noisepage::parser {
@@ -36,6 +37,10 @@ void OperatorExpression::DeriveReturnValueType() {
   const auto &type = (*max_type_child)->GetReturnValueType();
   NOISEPAGE_ASSERT(type <= type::TypeId::DECIMAL, "Invalid operand type in Operator Expression.");
   this->SetReturnValueType(type);
+}
+
+void OperatorExpression::Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) {
+  v->Visit(common::ManagedPointer(this));
 }
 
 DEFINE_JSON_BODY_DECLARATIONS(OperatorExpression);

--- a/src/parser/expression/parameter_value_expression.cpp
+++ b/src/parser/expression/parameter_value_expression.cpp
@@ -1,5 +1,7 @@
 #include "parser/expression/parameter_value_expression.h"
 
+#include "binder/sql_node_visitor.h"
+#include "common/hash_util.h"
 #include "common/json.h"
 
 namespace noisepage::parser {
@@ -22,6 +24,16 @@ std::vector<std::unique_ptr<AbstractExpression>> ParameterValueExpression::FromJ
   exprs.insert(exprs.end(), std::make_move_iterator(e1.begin()), std::make_move_iterator(e1.end()));
   value_idx_ = j.at("value_idx").get<uint32_t>();
   return exprs;
+}
+
+void ParameterValueExpression::Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) {
+  v->Visit(common::ManagedPointer(this));
+}
+
+common::hash_t ParameterValueExpression::Hash() const {
+  common::hash_t hash = AbstractExpression::Hash();
+  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(value_idx_));
+  return hash;
 }
 
 DEFINE_JSON_BODY_DECLARATIONS(ParameterValueExpression);

--- a/src/parser/expression/star_expression.cpp
+++ b/src/parser/expression/star_expression.cpp
@@ -1,5 +1,6 @@
 #include "parser/expression/star_expression.h"
 
+#include "binder/sql_node_visitor.h"
 #include "common/json.h"
 
 namespace noisepage::parser {
@@ -8,6 +9,10 @@ std::unique_ptr<AbstractExpression> StarExpression::Copy() const {
   auto expr = std::make_unique<StarExpression>();
   expr->SetMutableStateForCopy(*this);
   return expr;
+}
+
+void StarExpression::Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) {
+  v->Visit(common::ManagedPointer(this));
 }
 
 DEFINE_JSON_BODY_DECLARATIONS(StarExpression);

--- a/src/parser/expression/table_star_expression.cpp
+++ b/src/parser/expression/table_star_expression.cpp
@@ -1,5 +1,6 @@
 #include "parser/expression/table_star_expression.h"
 
+#include "binder/sql_node_visitor.h"
 #include "common/json.h"
 
 namespace noisepage::parser {
@@ -10,6 +11,10 @@ std::unique_ptr<AbstractExpression> TableStarExpression::Copy() const {
   expr->target_table_specified_ = target_table_specified_;
   expr->target_table_ = target_table_;
   return expr;
+}
+
+void TableStarExpression::Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) {
+  v->Visit(common::ManagedPointer(this));
 }
 
 DEFINE_JSON_BODY_DECLARATIONS(TableStarExpression);

--- a/src/parser/expression/type_cast_expression.cpp
+++ b/src/parser/expression/type_cast_expression.cpp
@@ -1,5 +1,6 @@
 #include "parser/expression/type_cast_expression.h"
 
+#include "binder/sql_node_visitor.h"
 #include "common/json.h"
 
 namespace noisepage::parser {
@@ -17,6 +18,10 @@ std::unique_ptr<AbstractExpression> TypeCastExpression::CopyWithChildren(
   auto expr = std::make_unique<TypeCastExpression>(GetReturnValueType(), std::move(children));
   expr->SetMutableStateForCopy(*this);
   return expr;
+}
+
+void TypeCastExpression::Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) {
+  v->Visit(common::ManagedPointer(this));
 }
 
 DEFINE_JSON_BODY_DECLARATIONS(TypeCastExpression);

--- a/src/planner/plannodes/abstract_join_plan_node.cpp
+++ b/src/planner/plannodes/abstract_join_plan_node.cpp
@@ -5,8 +5,16 @@
 #include <vector>
 
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+AbstractJoinPlanNode::AbstractJoinPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                           std::unique_ptr<OutputSchema> output_schema, LogicalJoinType join_type,
+                                           common::ManagedPointer<parser::AbstractExpression> predicate)
+    : AbstractPlanNode(std::move(children), std::move(output_schema)),
+      join_type_(join_type),
+      join_predicate_(predicate) {}
 
 bool AbstractJoinPlanNode::operator==(const AbstractPlanNode &rhs) const {
   if (!AbstractPlanNode::operator==(rhs)) return false;

--- a/src/planner/plannodes/abstract_scan_plan_node.cpp
+++ b/src/planner/plannodes/abstract_scan_plan_node.cpp
@@ -6,8 +6,23 @@
 
 #include "catalog/catalog_defs.h"
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+AbstractScanPlanNode::AbstractScanPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                           std::unique_ptr<OutputSchema> output_schema,
+                                           common::ManagedPointer<parser::AbstractExpression> predicate,
+                                           bool is_for_update, catalog::db_oid_t database_oid, uint32_t scan_limit,
+                                           bool scan_has_limit, uint32_t scan_offset, bool scan_has_offset)
+    : AbstractPlanNode(std::move(children), std::move(output_schema)),
+      scan_predicate_(predicate),
+      is_for_update_(is_for_update),
+      database_oid_(database_oid),
+      scan_limit_(scan_limit),
+      scan_has_limit_(scan_has_limit),
+      scan_offset_(scan_offset),
+      scan_has_offset_(scan_has_offset) {}
 
 common::hash_t AbstractScanPlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();

--- a/src/planner/plannodes/aggregate_plan_node.cpp
+++ b/src/planner/plannodes/aggregate_plan_node.cpp
@@ -5,8 +5,27 @@
 #include <vector>
 
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<AggregatePlanNode> AggregatePlanNode::Builder::Build() {
+  return std::unique_ptr<AggregatePlanNode>(new AggregatePlanNode(std::move(children_), std::move(output_schema_),
+                                                                  std::move(groupby_terms_), having_clause_predicate_,
+                                                                  std::move(aggregate_terms_), aggregate_strategy_));
+}
+
+AggregatePlanNode::AggregatePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                     std::unique_ptr<OutputSchema> output_schema,
+                                     std::vector<GroupByTerm> groupby_terms,
+                                     common::ManagedPointer<parser::AbstractExpression> having_clause_predicate,
+                                     std::vector<AggregateTerm> aggregate_terms,
+                                     AggregateStrategyType aggregate_strategy)
+    : AbstractPlanNode(std::move(children), std::move(output_schema)),
+      groupby_terms_(std::move(groupby_terms)),
+      having_clause_predicate_(having_clause_predicate),
+      aggregate_terms_(std::move(aggregate_terms)),
+      aggregate_strategy_(aggregate_strategy) {}
 
 common::hash_t AggregatePlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();

--- a/src/planner/plannodes/analyze_plan_node.cpp
+++ b/src/planner/plannodes/analyze_plan_node.cpp
@@ -7,8 +7,22 @@
 
 #include "catalog/catalog_defs.h"
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<AnalyzePlanNode> AnalyzePlanNode::Builder::Build() {
+  return std::unique_ptr<AnalyzePlanNode>(new AnalyzePlanNode(std::move(children_), std::move(output_schema_),
+                                                              database_oid_, table_oid_, std::move(column_oids_)));
+}
+
+AnalyzePlanNode::AnalyzePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                 std::unique_ptr<OutputSchema> output_schema, catalog::db_oid_t database_oid,
+                                 catalog::table_oid_t table_oid, std::vector<catalog::col_oid_t> &&column_oids)
+    : AbstractPlanNode(std::move(children), std::move(output_schema)),
+      database_oid_(database_oid),
+      table_oid_(table_oid),
+      column_oids_(std::move(column_oids)) {}
 
 common::hash_t AnalyzePlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();

--- a/src/planner/plannodes/create_database_plan_node.cpp
+++ b/src/planner/plannodes/create_database_plan_node.cpp
@@ -6,8 +6,18 @@
 #include <vector>
 
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<CreateDatabasePlanNode> CreateDatabasePlanNode::Builder::Build() {
+  return std::unique_ptr<CreateDatabasePlanNode>(
+      new CreateDatabasePlanNode(std::move(children_), std::move(output_schema_), std::move(database_name_)));
+}
+
+CreateDatabasePlanNode::CreateDatabasePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                               std::unique_ptr<OutputSchema> output_schema, std::string database_name)
+    : AbstractPlanNode(std::move(children), std::move(output_schema)), database_name_(std::move(database_name)) {}
 
 common::hash_t CreateDatabasePlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
@@ -39,7 +49,6 @@ std::vector<std::unique_ptr<parser::AbstractExpression>> CreateDatabasePlanNode:
   database_name_ = j.at("database_name").get<std::string>();
   return exprs;
 }
-
 DEFINE_JSON_BODY_DECLARATIONS(CreateDatabasePlanNode);
 
 }  // namespace noisepage::planner

--- a/src/planner/plannodes/create_function_plan_node.cpp
+++ b/src/planner/plannodes/create_function_plan_node.cpp
@@ -5,8 +5,35 @@
 #include <vector>
 
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<CreateFunctionPlanNode> CreateFunctionPlanNode::Builder::Build() {
+  return std::unique_ptr<CreateFunctionPlanNode>(new CreateFunctionPlanNode(
+      std::move(children_), std::move(output_schema_), database_oid_, namespace_oid_, language_,
+      std::move(function_param_names_), std::move(function_param_types_), std::move(function_body_), is_replace_,
+      std::move(function_name_), return_type_, param_count_));
+}
+
+CreateFunctionPlanNode::CreateFunctionPlanNode(
+    std::vector<std::unique_ptr<AbstractPlanNode>> &&children, std::unique_ptr<OutputSchema> output_schema,
+    catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid, parser::PLType language,
+    std::vector<std::string> &&function_param_names,
+    std::vector<parser::BaseFunctionParameter::DataType> &&function_param_types,
+    std::vector<std::string> &&function_body, bool is_replace, std::string function_name,
+    parser::BaseFunctionParameter::DataType return_type, int param_count)
+    : AbstractPlanNode(std::move(children), std::move(output_schema)),
+      database_oid_(database_oid),
+      namespace_oid_(namespace_oid),
+      language_(language),
+      function_param_names_(std::move(function_param_names)),
+      function_param_types_(std::move(function_param_types)),
+      function_body_(std::move(function_body)),
+      is_replace_(is_replace),
+      function_name_(std::move(function_name)),
+      return_type_(return_type),
+      param_count_(param_count) {}
 
 common::hash_t CreateFunctionPlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();

--- a/src/planner/plannodes/create_index_plan_node.cpp
+++ b/src/planner/plannodes/create_index_plan_node.cpp
@@ -6,8 +6,25 @@
 #include <vector>
 
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<CreateIndexPlanNode> CreateIndexPlanNode::Builder::Build() {
+  return std::unique_ptr<CreateIndexPlanNode>(new CreateIndexPlanNode(std::move(children_), std::move(output_schema_),
+                                                                      namespace_oid_, table_oid_,
+                                                                      std::move(index_name_), std::move(schema_)));
+}
+
+CreateIndexPlanNode::CreateIndexPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                         std::unique_ptr<OutputSchema> output_schema,
+                                         catalog::namespace_oid_t namespace_oid, catalog::table_oid_t table_oid,
+                                         std::string index_name, std::unique_ptr<catalog::IndexSchema> schema)
+    : AbstractPlanNode(std::move(children), std::move(output_schema)),
+      namespace_oid_(namespace_oid),
+      table_oid_(table_oid),
+      index_name_(std::move(index_name)),
+      schema_(std::move(schema)) {}
 
 common::hash_t CreateIndexPlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
@@ -68,7 +85,6 @@ std::vector<std::unique_ptr<parser::AbstractExpression>> CreateIndexPlanNode::Fr
   index_name_ = j.at("index_name").get<std::string>();
   return exprs;
 }
-
 DEFINE_JSON_BODY_DECLARATIONS(CreateIndexPlanNode);
 
 }  // namespace noisepage::planner

--- a/src/planner/plannodes/create_namespace_plan_node.cpp
+++ b/src/planner/plannodes/create_namespace_plan_node.cpp
@@ -7,8 +7,19 @@
 
 #include "common/json.h"
 #include "parser/parser_defs.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<CreateNamespacePlanNode> CreateNamespacePlanNode::Builder::Build() {
+  return std::unique_ptr<CreateNamespacePlanNode>(
+      new CreateNamespacePlanNode(std::move(children_), std::move(output_schema_), std::move(namespace_name_)));
+}
+
+CreateNamespacePlanNode::CreateNamespacePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                                 std::unique_ptr<OutputSchema> output_schema,
+                                                 std::string namespace_name)
+    : AbstractPlanNode(std::move(children), std::move(output_schema)), namespace_name_(std::move(namespace_name)) {}
 
 common::hash_t CreateNamespacePlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
@@ -41,7 +52,6 @@ std::vector<std::unique_ptr<parser::AbstractExpression>> CreateNamespacePlanNode
   namespace_name_ = j.at("namespace_name").get<std::string>();
   return exprs;
 }
-
 DEFINE_JSON_BODY_DECLARATIONS(CreateNamespacePlanNode);
 
 }  // namespace noisepage::planner

--- a/src/planner/plannodes/create_table_plan_node.cpp
+++ b/src/planner/plannodes/create_table_plan_node.cpp
@@ -6,8 +6,34 @@
 #include <vector>
 
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<CreateTablePlanNode> CreateTablePlanNode::Builder::Build() {
+  return std::unique_ptr<CreateTablePlanNode>(
+      new CreateTablePlanNode(std::move(children_), std::move(output_schema_), namespace_oid_, std::move(table_name_),
+                              std::move(table_schema_), block_store_, has_primary_key_, std::move(primary_key_),
+                              std::move(foreign_keys_), std::move(con_uniques_), std::move(con_checks_)));
+}
+
+CreateTablePlanNode::CreateTablePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                         std::unique_ptr<OutputSchema> output_schema,
+                                         catalog::namespace_oid_t namespace_oid, std::string table_name,
+                                         std::unique_ptr<catalog::Schema> table_schema,
+                                         common::ManagedPointer<storage::BlockStore> block_store, bool has_primary_key,
+                                         PrimaryKeyInfo primary_key, std::vector<ForeignKeyInfo> &&foreign_keys,
+                                         std::vector<UniqueInfo> &&con_uniques, std::vector<CheckInfo> &&con_checks)
+    : AbstractPlanNode(std::move(children), std::move(output_schema)),
+      namespace_oid_(namespace_oid),
+      table_name_(std::move(table_name)),
+      table_schema_(std::move(table_schema)),
+      block_store_(block_store),
+      has_primary_key_(has_primary_key),
+      primary_key_(std::move(primary_key)),
+      foreign_keys_(std::move(foreign_keys)),
+      con_uniques_(std::move(con_uniques)),
+      con_checks_(std::move(con_checks)) {}
 
 nlohmann::json PrimaryKeyInfo::ToJson() const {
   nlohmann::json j;

--- a/src/planner/plannodes/create_view_plan_node.cpp
+++ b/src/planner/plannodes/create_view_plan_node.cpp
@@ -6,8 +6,25 @@
 #include <vector>
 
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<CreateViewPlanNode> CreateViewPlanNode::Builder::Build() {
+  return std::unique_ptr<CreateViewPlanNode>(new CreateViewPlanNode(std::move(children_), std::move(output_schema_),
+                                                                    database_oid_, namespace_oid_,
+                                                                    std::move(view_name_), std::move(view_query_)));
+}
+
+CreateViewPlanNode::CreateViewPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                       std::unique_ptr<OutputSchema> output_schema, catalog::db_oid_t database_oid,
+                                       catalog::namespace_oid_t namespace_oid, std::string view_name,
+                                       std::unique_ptr<parser::SelectStatement> view_query)
+    : AbstractPlanNode(std::move(children), std::move(output_schema)),
+      database_oid_(database_oid),
+      namespace_oid_(namespace_oid),
+      view_name_(std::move(view_name)),
+      view_query_(std::move(view_query)) {}
 
 common::hash_t CreateViewPlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
@@ -73,7 +90,6 @@ std::vector<std::unique_ptr<parser::AbstractExpression>> CreateViewPlanNode::Fro
   }
   return exprs;
 }
-
 DEFINE_JSON_BODY_DECLARATIONS(CreateViewPlanNode);
 
 }  // namespace noisepage::planner

--- a/src/planner/plannodes/csv_scan_plan_node.cpp
+++ b/src/planner/plannodes/csv_scan_plan_node.cpp
@@ -4,9 +4,32 @@
 #include <string>
 #include <vector>
 
+#include "common/hash_util.h"
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<CSVScanPlanNode> CSVScanPlanNode::Builder::Build() {
+  return std::unique_ptr<CSVScanPlanNode>(
+      new CSVScanPlanNode(std::move(children_), std::move(output_schema_), nullptr /* predicate */, is_for_update_,
+                          database_oid_, file_name_, delimiter_, quote_, escape_, value_types_, scan_limit_,
+                          scan_has_limit_, scan_offset_, scan_has_offset_));
+}
+
+CSVScanPlanNode::CSVScanPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                 std::unique_ptr<OutputSchema> output_schema,
+                                 common::ManagedPointer<parser::AbstractExpression> predicate, bool is_for_update,
+                                 catalog::db_oid_t database_oid, std::string file_name, char delimiter, char quote,
+                                 char escape, std::vector<type::TypeId> value_types, uint32_t scan_limit,
+                                 bool scan_has_limit, uint32_t scan_offset, bool scan_has_offset)
+    : AbstractScanPlanNode(std::move(children), std::move(output_schema), predicate, is_for_update, database_oid,
+                           scan_limit, scan_has_limit, scan_offset, scan_has_offset),
+      file_name_(std::move(file_name)),
+      delimiter_(delimiter),
+      quote_(quote),
+      escape_(escape),
+      value_types_(std::move(value_types)) {}
 
 common::hash_t CSVScanPlanNode::Hash() const {
   common::hash_t hash = AbstractScanPlanNode::Hash();

--- a/src/planner/plannodes/delete_plan_node.cpp
+++ b/src/planner/plannodes/delete_plan_node.cpp
@@ -5,10 +5,23 @@
 #include <vector>
 
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
 
 // TODO(Gus,Wen) Add SetParameters
+
+std::unique_ptr<DeletePlanNode> DeletePlanNode::Builder::Build() {
+  return std::unique_ptr<DeletePlanNode>(
+      new DeletePlanNode(std::move(children_), std::make_unique<OutputSchema>(), database_oid_, table_oid_));
+}
+
+DeletePlanNode::DeletePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                               std::unique_ptr<OutputSchema> output_schema, catalog::db_oid_t database_oid,
+                               catalog::table_oid_t table_oid)
+    : AbstractPlanNode(std::move(children), std::move(output_schema)),
+      database_oid_(database_oid),
+      table_oid_(table_oid) {}
 
 common::hash_t DeletePlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();

--- a/src/planner/plannodes/drop_database_plan_node.cpp
+++ b/src/planner/plannodes/drop_database_plan_node.cpp
@@ -6,8 +6,18 @@
 #include <vector>
 
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<DropDatabasePlanNode> DropDatabasePlanNode::Builder::Build() {
+  return std::unique_ptr<DropDatabasePlanNode>(
+      new DropDatabasePlanNode(std::move(children_), std::move(output_schema_), database_oid_));
+}
+
+DropDatabasePlanNode::DropDatabasePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                           std::unique_ptr<OutputSchema> output_schema, catalog::db_oid_t database_oid)
+    : AbstractPlanNode(std::move(children), std::move(output_schema)), database_oid_(database_oid) {}
 
 common::hash_t DropDatabasePlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
@@ -39,7 +49,6 @@ std::vector<std::unique_ptr<parser::AbstractExpression>> DropDatabasePlanNode::F
   database_oid_ = j.at("database_oid").get<catalog::db_oid_t>();
   return exprs;
 }
-
 DEFINE_JSON_BODY_DECLARATIONS(DropDatabasePlanNode);
 
 }  // namespace noisepage::planner

--- a/src/planner/plannodes/drop_index_plan_node.cpp
+++ b/src/planner/plannodes/drop_index_plan_node.cpp
@@ -6,8 +6,18 @@
 #include <vector>
 
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<DropIndexPlanNode> DropIndexPlanNode::Builder::Build() {
+  return std::unique_ptr<DropIndexPlanNode>(
+      new DropIndexPlanNode(std::move(children_), std::move(output_schema_), index_oid_));
+}
+
+DropIndexPlanNode::DropIndexPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                     std::unique_ptr<OutputSchema> output_schema, catalog::index_oid_t index_oid)
+    : AbstractPlanNode(std::move(children), std::move(output_schema)), index_oid_(index_oid) {}
 
 common::hash_t DropIndexPlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
@@ -38,7 +48,6 @@ std::vector<std::unique_ptr<parser::AbstractExpression>> DropIndexPlanNode::From
   index_oid_ = j.at("index_oid").get<catalog::index_oid_t>();
   return exprs;
 }
-
 DEFINE_JSON_BODY_DECLARATIONS(DropIndexPlanNode);
 
 }  // namespace noisepage::planner

--- a/src/planner/plannodes/drop_namespace_plan_node.cpp
+++ b/src/planner/plannodes/drop_namespace_plan_node.cpp
@@ -6,8 +6,19 @@
 #include <vector>
 
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<DropNamespacePlanNode> DropNamespacePlanNode::Builder::Build() {
+  return std::unique_ptr<DropNamespacePlanNode>(
+      new DropNamespacePlanNode(std::move(children_), std::move(output_schema_), namespace_oid_));
+}
+
+DropNamespacePlanNode::DropNamespacePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                             std::unique_ptr<OutputSchema> output_schema,
+                                             catalog::namespace_oid_t namespace_oid)
+    : AbstractPlanNode(std::move(children), std::move(output_schema)), namespace_oid_(namespace_oid) {}
 
 common::hash_t DropNamespacePlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();

--- a/src/planner/plannodes/drop_table_plan_node.cpp
+++ b/src/planner/plannodes/drop_table_plan_node.cpp
@@ -6,8 +6,18 @@
 #include <vector>
 
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<DropTablePlanNode> DropTablePlanNode::Builder::Build() {
+  return std::unique_ptr<DropTablePlanNode>(
+      new DropTablePlanNode(std::move(children_), std::move(output_schema_), table_oid_));
+}
+
+DropTablePlanNode::DropTablePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                     std::unique_ptr<OutputSchema> output_schema, catalog::table_oid_t table_oid)
+    : AbstractPlanNode(std::move(children), std::move(output_schema)), table_oid_(table_oid) {}
 
 common::hash_t DropTablePlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
@@ -39,7 +49,6 @@ std::vector<std::unique_ptr<parser::AbstractExpression>> DropTablePlanNode::From
   table_oid_ = j.at("table_oid").get<catalog::table_oid_t>();
   return exprs;
 }
-
 DEFINE_JSON_BODY_DECLARATIONS(DropTablePlanNode);
 
 }  // namespace noisepage::planner

--- a/src/planner/plannodes/drop_trigger_plan_node.cpp
+++ b/src/planner/plannodes/drop_trigger_plan_node.cpp
@@ -6,8 +6,25 @@
 #include <vector>
 
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<DropTriggerPlanNode> DropTriggerPlanNode::Builder::Build() {
+  return std::unique_ptr<DropTriggerPlanNode>(new DropTriggerPlanNode(
+      std::move(children_), std::move(output_schema_), database_oid_, namespace_oid_, trigger_oid_, if_exists_));
+}
+
+DropTriggerPlanNode::DropTriggerPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                         std::unique_ptr<OutputSchema> output_schema, catalog::db_oid_t database_oid,
+                                         catalog::namespace_oid_t namespace_oid, catalog::trigger_oid_t trigger_oid,
+                                         bool if_exists)
+    : AbstractPlanNode(std::move(children), std::move(output_schema)),
+      database_oid_(database_oid),
+      namespace_oid_(namespace_oid),
+      trigger_oid_(trigger_oid),
+      if_exists_(if_exists) {}
+
 common::hash_t DropTriggerPlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
 
@@ -67,7 +84,6 @@ std::vector<std::unique_ptr<parser::AbstractExpression>> DropTriggerPlanNode::Fr
   if_exists_ = j.at("if_exists").get<bool>();
   return exprs;
 }
-
 DEFINE_JSON_BODY_DECLARATIONS(DropTriggerPlanNode);
 
 }  // namespace noisepage::planner

--- a/src/planner/plannodes/drop_view_plan_node.cpp
+++ b/src/planner/plannodes/drop_view_plan_node.cpp
@@ -6,8 +6,23 @@
 #include <vector>
 
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<DropViewPlanNode> DropViewPlanNode::Builder::Build() {
+  return std::unique_ptr<DropViewPlanNode>(
+      new DropViewPlanNode(std::move(children_), std::move(output_schema_), database_oid_, view_oid_, if_exists_));
+}
+
+DropViewPlanNode::DropViewPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                   std::unique_ptr<OutputSchema> output_schema, catalog::db_oid_t database_oid,
+                                   catalog::view_oid_t view_oid, bool if_exists)
+    : AbstractPlanNode(std::move(children), std::move(output_schema)),
+      database_oid_(database_oid),
+      view_oid_(view_oid),
+      if_exists_(if_exists) {}
+
 common::hash_t DropViewPlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
 
@@ -59,7 +74,6 @@ std::vector<std::unique_ptr<parser::AbstractExpression>> DropViewPlanNode::FromJ
   if_exists_ = j.at("if_exists").get<bool>();
   return exprs;
 }
-
 DEFINE_JSON_BODY_DECLARATIONS(DropViewPlanNode);
 
 }  // namespace noisepage::planner

--- a/src/planner/plannodes/export_external_file_plan_node.cpp
+++ b/src/planner/plannodes/export_external_file_plan_node.cpp
@@ -4,9 +4,26 @@
 #include <string>
 #include <vector>
 
+#include "common/hash_util.h"
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<ExportExternalFilePlanNode> ExportExternalFilePlanNode::Builder::Build() {
+  return std::unique_ptr<ExportExternalFilePlanNode>(
+      new ExportExternalFilePlanNode(std::move(children_), format_, file_name_, delimiter_, quote_, escape_));
+}
+
+ExportExternalFilePlanNode::ExportExternalFilePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                                       parser::ExternalFileFormat format, std::string file_name,
+                                                       char delimiter, char quote, char escape)
+    : AbstractPlanNode(std::move(children), nullptr),
+      format_(format),
+      file_name_(std::move(file_name)),
+      delimiter_(delimiter),
+      quote_(quote),
+      escape_(escape) {}
 
 common::hash_t ExportExternalFilePlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
@@ -73,5 +90,4 @@ std::vector<std::unique_ptr<parser::AbstractExpression>> ExportExternalFilePlanN
 }
 
 DEFINE_JSON_BODY_DECLARATIONS(ExportExternalFilePlanNode);
-
 }  // namespace noisepage::planner

--- a/src/planner/plannodes/hash_join_plan_node.cpp
+++ b/src/planner/plannodes/hash_join_plan_node.cpp
@@ -5,8 +5,15 @@
 #include <vector>
 
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<HashJoinPlanNode> HashJoinPlanNode::Builder::Build() {
+  return std::unique_ptr<HashJoinPlanNode>(new HashJoinPlanNode(std::move(children_), std::move(output_schema_),
+                                                                join_type_, join_predicate_, std::move(left_hash_keys_),
+                                                                std::move(right_hash_keys_)));
+}
 
 common::hash_t HashJoinPlanNode::Hash() const {
   common::hash_t hash = AbstractJoinPlanNode::Hash();

--- a/src/planner/plannodes/hash_join_plan_node.cpp
+++ b/src/planner/plannodes/hash_join_plan_node.cpp
@@ -15,6 +15,15 @@ std::unique_ptr<HashJoinPlanNode> HashJoinPlanNode::Builder::Build() {
                                                                 std::move(right_hash_keys_)));
 }
 
+HashJoinPlanNode::HashJoinPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                   std::unique_ptr<OutputSchema> output_schema, LogicalJoinType join_type,
+                                   common::ManagedPointer<parser::AbstractExpression> predicate,
+                                   std::vector<common::ManagedPointer<parser::AbstractExpression>> &&left_hash_keys,
+                                   std::vector<common::ManagedPointer<parser::AbstractExpression>> &&right_hash_keys)
+    : AbstractJoinPlanNode(std::move(children), std::move(output_schema), join_type, predicate),
+      left_hash_keys_(std::move(left_hash_keys)),
+      right_hash_keys_(std::move(right_hash_keys)) {}
+
 common::hash_t HashJoinPlanNode::Hash() const {
   common::hash_t hash = AbstractJoinPlanNode::Hash();
 

--- a/src/planner/plannodes/index_join_plan_node.cpp
+++ b/src/planner/plannodes/index_join_plan_node.cpp
@@ -5,8 +5,31 @@
 
 #include "common/hash_util.h"
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<IndexJoinPlanNode> IndexJoinPlanNode::Builder::Build() {
+  return std::unique_ptr<IndexJoinPlanNode>(
+      new IndexJoinPlanNode(std::move(children_), std::move(output_schema_), join_type_, join_predicate_, index_oid_,
+                            table_oid_, scan_type_, std::move(lo_index_cols_), std::move(hi_index_cols_), index_size_));
+}
+
+IndexJoinPlanNode::IndexJoinPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                     std::unique_ptr<OutputSchema> output_schema, LogicalJoinType join_type,
+                                     common::ManagedPointer<parser::AbstractExpression> predicate,
+                                     catalog::index_oid_t index_oid, catalog::table_oid_t table_oid,
+                                     IndexScanType scan_type,
+                                     std::unordered_map<catalog::indexkeycol_oid_t, IndexExpression> &&lo_cols,
+                                     std::unordered_map<catalog::indexkeycol_oid_t, IndexExpression> &&hi_cols,
+                                     uint64_t index_size)
+    : AbstractJoinPlanNode(std::move(children), std::move(output_schema), join_type, predicate),
+      index_oid_(index_oid),
+      table_oid_(table_oid),
+      scan_type_(scan_type),
+      lo_index_cols_(std::move(lo_cols)),
+      hi_index_cols_(std::move(hi_cols)),
+      index_size_(index_size) {}
 
 common::hash_t IndexJoinPlanNode::Hash() const { return AbstractJoinPlanNode::Hash(); }
 
@@ -34,6 +57,20 @@ std::vector<std::unique_ptr<parser::AbstractExpression>> IndexJoinPlanNode::From
   index_oid_ = j.at("index_oid").get<catalog::index_oid_t>();
   table_oid_ = j.at("table_oid").get<catalog::table_oid_t>();
   return exprs;
+}
+
+std::vector<catalog::col_oid_t> IndexJoinPlanNode::CollectInputOids() const {
+  std::vector<catalog::col_oid_t> result;
+  // Scan predicate
+  if (GetJoinPredicate() != nullptr) CollectOids(&result, GetJoinPredicate().Get());
+  // Output expressions
+  for (const auto &col : GetOutputSchema()->GetColumns()) {
+    CollectOids(&result, col.GetExpr().Get());
+  }
+  // Remove duplicates
+  std::unordered_set<catalog::col_oid_t> s(result.begin(), result.end());
+  result.assign(s.begin(), s.end());
+  return result;
 }
 
 DEFINE_JSON_BODY_DECLARATIONS(IndexJoinPlanNode);

--- a/src/planner/plannodes/index_scan_plan_node.cpp
+++ b/src/planner/plannodes/index_scan_plan_node.cpp
@@ -5,8 +5,34 @@
 
 #include "common/hash_util.h"
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<IndexScanPlanNode> IndexScanPlanNode::Builder::Build() {
+  return std::unique_ptr<IndexScanPlanNode>(new IndexScanPlanNode(
+      std::move(children_), std::move(output_schema_), scan_predicate_, std::move(column_oids_), is_for_update_,
+      database_oid_, index_oid_, table_oid_, scan_type_, std::move(lo_index_cols_), std::move(hi_index_cols_),
+      scan_limit_, scan_has_limit_, scan_offset_, scan_has_offset_, index_size_, table_num_tuple_));
+}
+
+IndexScanPlanNode::IndexScanPlanNode(
+    std::vector<std::unique_ptr<AbstractPlanNode>> &&children, std::unique_ptr<OutputSchema> output_schema,
+    common::ManagedPointer<parser::AbstractExpression> predicate, std::vector<catalog::col_oid_t> &&column_oids,
+    bool is_for_update, catalog::db_oid_t database_oid, catalog::index_oid_t index_oid, catalog::table_oid_t table_oid,
+    IndexScanType scan_type, std::unordered_map<catalog::indexkeycol_oid_t, IndexExpression> &&lo_index_cols,
+    std::unordered_map<catalog::indexkeycol_oid_t, IndexExpression> &&hi_index_cols, uint32_t scan_limit,
+    bool scan_has_limit, uint32_t scan_offset, bool scan_has_offset, uint64_t index_size, uint64_t table_num_tuple)
+    : AbstractScanPlanNode(std::move(children), std::move(output_schema), predicate, is_for_update, database_oid,
+                           scan_limit, scan_has_limit, scan_offset, scan_has_offset),
+      scan_type_(scan_type),
+      index_oid_(index_oid),
+      table_oid_(table_oid),
+      column_oids_(column_oids),
+      lo_index_cols_(std::move(lo_index_cols)),
+      hi_index_cols_(std::move(hi_index_cols)),
+      table_num_tuple_(table_num_tuple),
+      index_size_(index_size) {}
 
 common::hash_t IndexScanPlanNode::Hash() const {
   common::hash_t hash = AbstractScanPlanNode::Hash();

--- a/src/planner/plannodes/limit_plan_node.cpp
+++ b/src/planner/plannodes/limit_plan_node.cpp
@@ -5,8 +5,18 @@
 
 #include "common/hash_util.h"
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<LimitPlanNode> LimitPlanNode::Builder::Build() {
+  return std::unique_ptr<LimitPlanNode>(
+      new LimitPlanNode(std::move(children_), std::move(output_schema_), limit_, offset_));
+}
+
+LimitPlanNode::LimitPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                             std::unique_ptr<OutputSchema> output_schema, size_t limit, size_t offset)
+    : AbstractPlanNode(std::move(children), std::move(output_schema)), limit_(limit), offset_(offset) {}
 
 common::hash_t LimitPlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();

--- a/src/planner/plannodes/nested_loop_join_plan_node.cpp
+++ b/src/planner/plannodes/nested_loop_join_plan_node.cpp
@@ -5,8 +5,19 @@
 #include <vector>
 
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<NestedLoopJoinPlanNode> NestedLoopJoinPlanNode::Builder::Build() {
+  return std::unique_ptr<NestedLoopJoinPlanNode>(
+      new NestedLoopJoinPlanNode(std::move(children_), std::move(output_schema_), join_type_, join_predicate_));
+}
+
+NestedLoopJoinPlanNode::NestedLoopJoinPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                               std::unique_ptr<OutputSchema> output_schema, LogicalJoinType join_type,
+                                               common::ManagedPointer<parser::AbstractExpression> predicate)
+    : AbstractJoinPlanNode(std::move(children), std::move(output_schema), join_type, predicate) {}
 
 common::hash_t NestedLoopJoinPlanNode::Hash() const { return AbstractJoinPlanNode::Hash(); }
 

--- a/src/planner/plannodes/order_by_plan_node.cpp
+++ b/src/planner/plannodes/order_by_plan_node.cpp
@@ -4,9 +4,25 @@
 #include <utility>
 #include <vector>
 
+#include "common/hash_util.h"
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<OrderByPlanNode> OrderByPlanNode::Builder::Build() {
+  return std::unique_ptr<OrderByPlanNode>(new OrderByPlanNode(std::move(children_), std::move(output_schema_),
+                                                              std::move(sort_keys_), has_limit_, limit_, offset_));
+}
+
+OrderByPlanNode::OrderByPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                 std::unique_ptr<OutputSchema> output_schema, std::vector<SortKey> sort_keys,
+                                 bool has_limit, size_t limit, size_t offset)
+    : AbstractPlanNode(std::move(children), std::move(output_schema)),
+      sort_keys_(std::move(sort_keys)),
+      has_limit_(has_limit),
+      limit_(limit),
+      offset_(offset) {}
 
 common::hash_t OrderByPlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
@@ -94,7 +110,6 @@ std::vector<std::unique_ptr<parser::AbstractExpression>> OrderByPlanNode::FromJs
   offset_ = j.at("offset").get<size_t>();
   return exprs;
 }
-
 DEFINE_JSON_BODY_DECLARATIONS(OrderByPlanNode);
 
 }  // namespace noisepage::planner

--- a/src/planner/plannodes/projection_plan_node.cpp
+++ b/src/planner/plannodes/projection_plan_node.cpp
@@ -4,8 +4,17 @@
 #include <vector>
 
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<ProjectionPlanNode> ProjectionPlanNode::Builder::Build() {
+  return std::unique_ptr<ProjectionPlanNode>(new ProjectionPlanNode(std::move(children_), std::move(output_schema_)));
+}
+
+ProjectionPlanNode::ProjectionPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                       std::unique_ptr<OutputSchema> output_schema)
+    : AbstractPlanNode(std::move(children), std::move(output_schema)) {}
 
 common::hash_t ProjectionPlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();

--- a/src/planner/plannodes/seq_scan_plan_node.cpp
+++ b/src/planner/plannodes/seq_scan_plan_node.cpp
@@ -6,8 +6,26 @@
 
 #include "common/hash_util.h"
 #include "common/json.h"
+#include "planner/plannodes/output_schema.h"
 
 namespace noisepage::planner {
+
+std::unique_ptr<SeqScanPlanNode> SeqScanPlanNode::Builder::Build() {
+  return std::unique_ptr<SeqScanPlanNode>(new SeqScanPlanNode(
+      std::move(children_), std::move(output_schema_), scan_predicate_, std::move(column_oids_), is_for_update_,
+      database_oid_, table_oid_, scan_limit_, scan_has_limit_, scan_offset_, scan_has_offset_));
+}
+
+SeqScanPlanNode::SeqScanPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
+                                 std::unique_ptr<OutputSchema> output_schema,
+                                 common::ManagedPointer<parser::AbstractExpression> predicate,
+                                 std::vector<catalog::col_oid_t> &&column_oids, bool is_for_update,
+                                 catalog::db_oid_t database_oid, catalog::table_oid_t table_oid, uint32_t scan_limit,
+                                 bool scan_has_limit, uint32_t scan_offset, bool scan_has_offset)
+    : AbstractScanPlanNode(std::move(children), std::move(output_schema), predicate, is_for_update, database_oid,
+                           scan_limit, scan_has_limit, scan_offset, scan_has_offset),
+      column_oids_(std::move(column_oids)),
+      table_oid_(table_oid) {}
 
 common::hash_t SeqScanPlanNode::Hash() const {
   common::hash_t hash = AbstractScanPlanNode::Hash();
@@ -38,7 +56,6 @@ std::vector<std::unique_ptr<parser::AbstractExpression>> SeqScanPlanNode::FromJs
   table_oid_ = j.at("table_oid").get<catalog::table_oid_t>();
   return exprs;
 }
-
 DEFINE_JSON_BODY_DECLARATIONS(SeqScanPlanNode);
 
 }  // namespace noisepage::planner

--- a/test/planner/plan_node_test.cpp
+++ b/test/planner/plan_node_test.cpp
@@ -15,6 +15,7 @@
 #include "planner/plannodes/csv_scan_plan_node.h"
 #include "planner/plannodes/drop_database_plan_node.h"
 #include "planner/plannodes/hash_join_plan_node.h"
+#include "planner/plannodes/output_schema.h"
 #include "planner/plannodes/seq_scan_plan_node.h"
 #include "test_util/test_harness.h"
 


### PR DESCRIPTION
# Forward declare more stuff in expressions, plan nodes, error data.

## Description

We do **not** see a speed improvement with unity builds on. I think the reason unity builds help us so much is because we're not forward declaring things properly - globbing everything together lets the `#pragma once` in our headers kind of save us there.

Though I expect to see a speed improvement with unity builds off.

Given the lack of improvement, I don't know if we want to merge this.