### PR TITLE
Fix clang-tidy.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,6 +51,7 @@ pipeline {
                         sh 'cd build && timeout 20m ninja check-format'
                         sh 'cd build && timeout 20m ninja check-lint'
                         sh 'cd build && timeout 20m ninja check-censored'
+                        sh 'cd build && ninja check-clang-tidy'
                     }
                     post {
                         cleanup {
@@ -74,6 +75,7 @@ pipeline {
                         sh 'cd build && timeout 20m ninja check-format'
                         sh 'cd build && timeout 20m ninja check-lint'
                         sh 'cd build && timeout 20m ninja check-censored'
+                        sh 'cd build && ninja check-clang-tidy'
                     }
                     post {
                         cleanup {
@@ -101,6 +103,7 @@ pipeline {
                         sh 'cd build && timeout 20m ninja check-format'
                         sh 'cd build && timeout 20m ninja check-lint'
                         sh 'cd build && timeout 20m ninja check-censored'
+                        sh 'cd build && ninja check-clang-tidy'
                     }
                     post {
                         cleanup {
@@ -132,7 +135,6 @@ pipeline {
                         cmake -GNinja -DNOISEPAGE_UNITY_BUILD=ON -DNOISEPAGE_TEST_PARALLELISM=1 -DCMAKE_BUILD_TYPE=Debug -DNOISEPAGE_USE_ASAN=ON -DNOISEPAGE_BUILD_BENCHMARKS=OFF -DNOISEPAGE_USE_JUMBOTESTS=OFF ..
                         ninja''', label: 'Compiling'
 
-                        sh 'cd build && ninja check-clang-tidy'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
@@ -169,7 +171,6 @@ pipeline {
                         cmake -GNinja -DNOISEPAGE_UNITY_BUILD=ON -DNOISEPAGE_TEST_PARALLELISM=$(nproc) -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DNOISEPAGE_USE_ASAN=ON -DNOISEPAGE_BUILD_BENCHMARKS=OFF -DNOISEPAGE_USE_JUMBOTESTS=ON .. 
                         ninja''', label: 'Compiling'
                         
-                        sh 'cd build && ninja check-clang-tidy'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
@@ -261,7 +262,6 @@ pipeline {
                         cmake -GNinja -DNOISEPAGE_UNITY_BUILD=ON -DNOISEPAGE_TEST_PARALLELISM=$(nproc) -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DNOISEPAGE_USE_ASAN=ON -DNOISEPAGE_BUILD_BENCHMARKS=OFF -DNOISEPAGE_USE_JUMBOTESTS=ON ..
                         ninja''', label: 'Compiling'
 
-                        sh 'cd build && ninja check-clang-tidy'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'


### PR DESCRIPTION
# Fix clang-tidy.

## Description

clang-tidy is busted with unity builds. To reproduce, grab current master: clang-tidy blows up on messenger with unity builds off, doesn't blow up with unity builds on. I don't understand why because in theory it scans over the same code anyway.

This PR:

- moves clang-tidy to the format stage. This should be good because (1) clang-tidy is deterministic, our tests are not, so this saves us time when restarting Test stage; (2) we have a ready-for-ci tag, so CI won't reach the format stage unless we want it to, so we don't have too much wasted resource consumption there
- fixes clang-tidy stuff that was not caught.

Thanks @jkosh44 for pointing out stuff was busted