### PR TITLE
Fix UPDATE foo SET a=a in the binder.

### DIFF
--- a/script/testing/junit/traces/update.test
+++ b/script/testing/junit/traces/update.test
@@ -145,3 +145,22 @@ SELECT * FROM update4 WHERE c1=2
 
 statement ok
 DROP TABLE update4
+
+statement ok
+CREATE TABLE update5 (a int)
+
+statement ok
+INSERT INTO update5 (a) VALUES (1),(2),(3);
+
+statement ok
+UPDATE update5 SET a=a;
+
+query I nosort
+SELECT a FROM update5;
+----
+1
+2
+3
+
+statement ok
+DROP TABLE update5

--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -588,7 +588,8 @@ void BindNodeVisitor::Visit(common::ManagedPointer<parser::ColumnValueExpression
   BINDER_LOG_TRACE("Visiting ColumnValueExpression ...");
   SqlNodeVisitor::Visit(expr);
 
-  sherpa_->CheckDesiredType(expr.CastManagedPointerTo<parser::AbstractExpression>());
+  // Before checking with the schema, cache the desired type that expr should have.
+  auto desired_type = sherpa_->GetDesiredType(expr.CastManagedPointerTo<parser::AbstractExpression>());
 
   // TODO(Ling): consider remove precondition check if the *_oid_ will never be initialized till binder
   //  That is, the object would not be initialized using ColumnValueExpression(database_oid, table_oid, column_oid)
@@ -626,8 +627,12 @@ void BindNodeVisitor::Visit(common::ManagedPointer<parser::ColumnValueExpression
       }
     }
   }
-  // The schema is authoritative on what the type of this ColumnValueExpression should be.
-  sherpa_->SetDesiredType(expr.CastManagedPointerTo<parser::AbstractExpression>(), expr->GetReturnValueType());
+
+  // The schema is authoritative on what the type of this ColumnValueExpression should be, UNLESS
+  // some specific type was already requested.
+  desired_type = desired_type == type::TypeId::INVALID ? expr->GetReturnValueType() : desired_type;
+  sherpa_->SetDesiredType(expr.CastManagedPointerTo<parser::AbstractExpression>(), desired_type);
+  sherpa_->CheckDesiredType(expr.CastManagedPointerTo<parser::AbstractExpression>());
 }
 
 void BindNodeVisitor::Visit(common::ManagedPointer<parser::ComparisonExpression> expr) {


### PR DESCRIPTION
# Fix UPDATE foo SET a=a in the binder.

## Description

There was a binding error for updates of the form `UPDATE foo SET a=a` because the check for `a`'s type happened before `a` was given a type from the schema.

Comes with a test.

Thanks @17zhangw for pointing out the bug.