### PR TITLE
Fix update.test Tracefile

### DIFF
--- a/script/testing/junit/sql/update.sql
+++ b/script/testing/junit/sql/update.sql
@@ -4,7 +4,7 @@ CREATE TABLE update1 (c1 int, c2 timestamp);
 INSERT INTO update1 (c1, c2) VALUES (1, '2020-01-02 12:23:34.567893');
 INSERT INTO update1 (c1, c2) VALUES (2, '2020-01-02 11:22:33.721052');
 UPDATE update1 SET c2 = '2020-01-03 11:22:33.721058' WHERE c1 = 2;
-SELECT * from update1 ORDER BY c1 ASC;
+SELECT * from update1;
 DROP TABLE update1;
 
 
@@ -13,7 +13,7 @@ INSERT INTO update2 (c1, c2) VALUES (1, 1);
 INSERT INTO update2 (c1, c2) VALUES (22, 22);
 INSERT INTO update2 (c1, c2) VALUES (23, 33);
 UPDATE update2 SET c2 = 4 WHERE c1 = 22;
-SELECT * FROM update2 ORDER BY c2;
+SELECT * FROM update2;
 SELECT * FROM update2 WHERE c2=22;
 SELECT c2 FROM update2 WHERE c1=23;
 DROP TABLE update2;
@@ -24,11 +24,11 @@ INSERT INTO update3 (c1, c2) VALUES (1, 1.0);
 INSERT INTO update3 (c1, c2) VALUES (2, 2.0);
 INSERT INTO update3 (c1, c2) VALUES (3, 3.0);
 UPDATE update3 SET c2 = 4.0 WHERE c1 = 2;
-SELECT * FROM update3 ORDER BY c1;
+SELECT * FROM update3;
 SELECT * FROM update3 WHERE c2=2.0;
 SELECT c2 FROM update3 WHERE c1=2;
 UPDATE update3 SET c1=2 WHERE c2=1.0;
-SELECT * FROM update3 WHERE c1=2 ORDER BY c1, c2;
+SELECT * FROM update3 WHERE c1=2;
 DROP TABLE update3;
 
 
@@ -36,18 +36,18 @@ CREATE TABLE update4 (c1 int, c2 float, c3 varchar);
 INSERT INTO update4 (c1, c2, c3) VALUES (1, 1.0, '1');
 INSERT INTO update4 (c1, c2, c3) VALUES (3, 3.0, '3');
 UPDATE update4 SET c2 = 4.0 WHERE c1 = 2;
-SELECT * FROM update4 ORDER BY c3;
-SELECT * FROM update4 WHERE c2=2.0 ORDER BY c3;
-SELECT * FROM update4 WHERE c2=2.0 AND c3='2' ORDER BY c3;
-SELECT c1 FROM update4 WHERE c2=2.0 OR c3='1' ORDER BY c3;
-SELECT * FROM update4 WHERE c2=2.0 AND c3='2' OR c1=1 ORDER BY c3;
-SELECT c2 FROM update4 WHERE c1=2 ORDER BY c3;
+SELECT * FROM update4;
+SELECT * FROM update4 WHERE c2=2.0;
+SELECT * FROM update4 WHERE c2=2.0 AND c3='2';
+SELECT c1 FROM update4 WHERE c2=2.0 OR c3='1';
+SELECT * FROM update4 WHERE c2=2.0 AND c3='2' OR c1=1;
+SELECT c2 FROM update4 WHERE c1=2;
 UPDATE update4 SET c1=2 WHERE c2=1.0;
-SELECT * FROM update4 WHERE c1=2 ORDER BY c3;
+SELECT * FROM update4 WHERE c1=2;
 DROP TABLE update4;
 
 CREATE TABLE update5 (a int)
 INSERT INTO update5 (a) VALUES (1),(2),(3);
 UPDATE update5 SET a=a;
-SELECT a FROM update5 ORDER BY a;
+SELECT a FROM update5;
 DROP TABLE update5

--- a/script/testing/junit/sql/update.sql
+++ b/script/testing/junit/sql/update.sql
@@ -1,5 +1,5 @@
 -- Generate tracefile with:
---     ant generate-trace -Dpath=sql/update.sql -Ddb-url=jdbc:postgresql://localhost/postgres -Ddb-user=postgres -Ddb-password="postgres" -Doutput-name=update.test && sed -i 's/nosort/rowsort/' traces/update.test
+--     ant generate-trace -Dpath=sql/update.sql -Ddb-url=jdbc:postgresql://localhost/postgres -Ddb-user=postgres -Ddb-password="postgres" -Doutput-name=update.test
 CREATE TABLE update1 (c1 int, c2 timestamp);
 INSERT INTO update1 (c1, c2) VALUES (1, '2020-01-02 12:23:34.567893');
 INSERT INTO update1 (c1, c2) VALUES (2, '2020-01-02 11:22:33.721052');

--- a/script/testing/junit/sql/update.sql
+++ b/script/testing/junit/sql/update.sql
@@ -1,213 +1,53 @@
-statement ok
 -- Generate tracefile with:
-
-statement ok
---     ant generate-trace -Dpath=sql/update.sql -Ddb-url=jdbc:postgresql://localhost/postgres -Ddb-user=postgres -Ddb-password="postgres" -Doutput-name=update.test && sed -i 's/rowsort/rowsort/' traces/update.test
-
-statement ok
+--     ant generate-trace -Dpath=sql/update.sql -Ddb-url=jdbc:postgresql://localhost/postgres -Ddb-user=postgres -Ddb-password="postgres" -Doutput-name=update.test && sed -i 's/nosort/rowsort/' traces/update.test
 CREATE TABLE update1 (c1 int, c2 timestamp);
-
-statement ok
 INSERT INTO update1 (c1, c2) VALUES (1, '2020-01-02 12:23:34.567893');
-
-statement ok
 INSERT INTO update1 (c1, c2) VALUES (2, '2020-01-02 11:22:33.721052');
-
-statement ok
 UPDATE update1 SET c2 = '2020-01-03 11:22:33.721058' WHERE c1 = 2;
-
-query I rowsort
 SELECT * from update1 ORDER BY c1 ASC;
-----
-1
-2020-01-02 12:23:34.567893
-2
-2020-01-03 11:22:33.721058
-
-statement ok
 DROP TABLE update1;
 
-statement ok
 
-
-statement ok
-
-
-statement ok
 CREATE TABLE update2 (c1 int, c2 INTEGER);
-
-statement ok
 INSERT INTO update2 (c1, c2) VALUES (1, 1);
-
-statement ok
 INSERT INTO update2 (c1, c2) VALUES (22, 22);
-
-statement ok
 INSERT INTO update2 (c1, c2) VALUES (23, 33);
-
-statement ok
 UPDATE update2 SET c2 = 4 WHERE c1 = 22;
-
-query II rowsort
 SELECT * FROM update2 ORDER BY c2;
-----
-1
-1
-22
-4
-23
-33
-
-query II rowsort
 SELECT * FROM update2 WHERE c2=22;
-----
-
-query I rowsort
 SELECT c2 FROM update2 WHERE c1=23;
-----
-33
-
-statement ok
 DROP TABLE update2;
 
-statement ok
 
-
-statement ok
-
-
-statement ok
 CREATE TABLE update3 (c1 int, c2 float);
-
-statement ok
 INSERT INTO update3 (c1, c2) VALUES (1, 1.0);
-
-statement ok
 INSERT INTO update3 (c1, c2) VALUES (2, 2.0);
-
-statement ok
 INSERT INTO update3 (c1, c2) VALUES (3, 3.0);
-
-statement ok
 UPDATE update3 SET c2 = 4.0 WHERE c1 = 2;
-
-query IR rowsort
 SELECT * FROM update3 ORDER BY c1;
-----
-1
-1
-2
-4
-3
-3
-
-query IR rowsort
 SELECT * FROM update3 WHERE c2=2.0;
-----
-
-query R rowsort
 SELECT c2 FROM update3 WHERE c1=2;
-----
-4
-
-statement ok
 UPDATE update3 SET c1=2 WHERE c2=1.0;
-
-query IR rowsort
 SELECT * FROM update3 WHERE c1=2 ORDER BY c1, c2;
-----
-2
-1
-2
-4
-
-statement ok
 DROP TABLE update3;
 
-statement ok
 
-
-statement ok
-
-
-statement ok
 CREATE TABLE update4 (c1 int, c2 float, c3 varchar);
-
-statement ok
 INSERT INTO update4 (c1, c2, c3) VALUES (1, 1.0, '1');
-
-statement ok
 INSERT INTO update4 (c1, c2, c3) VALUES (3, 3.0, '3');
-
-statement ok
 UPDATE update4 SET c2 = 4.0 WHERE c1 = 2;
-
-query IRT rowsort
 SELECT * FROM update4 ORDER BY c3;
-----
-1
-1
-1
-3
-3
-3
-
-query IRT rowsort
 SELECT * FROM update4 WHERE c2=2.0 ORDER BY c3;
-----
-
-query IRT rowsort
 SELECT * FROM update4 WHERE c2=2.0 AND c3='2' ORDER BY c3;
-----
-
-query I rowsort
 SELECT c1 FROM update4 WHERE c2=2.0 OR c3='1' ORDER BY c3;
-----
-1
-
-query IRT rowsort
 SELECT * FROM update4 WHERE c2=2.0 AND c3='2' OR c1=1 ORDER BY c3;
-----
-1
-1
-1
-
-query R rowsort
 SELECT c2 FROM update4 WHERE c1=2 ORDER BY c3;
-----
-
-statement ok
 UPDATE update4 SET c1=2 WHERE c2=1.0;
-
-query IRT rowsort
 SELECT * FROM update4 WHERE c1=2 ORDER BY c3;
-----
-2
-1
-1
-
-statement ok
 DROP TABLE update4;
 
-statement ok
-
-
-statement ok
 CREATE TABLE update5 (a int)
-
-statement ok
 INSERT INTO update5 (a) VALUES (1),(2),(3);
-
-statement ok
 UPDATE update5 SET a=a;
-
-query I rowsort
 SELECT a FROM update5 ORDER BY a;
-----
-1
-2
-3
-
-statement ok
 DROP TABLE update5
-

--- a/script/testing/junit/src/GenerateTrace.java
+++ b/script/testing/junit/src/GenerateTrace.java
@@ -66,7 +66,17 @@ public class GenerateTrace {
                         System.out.println(colTypeName + " column invalid");
                     }
                 }
-                String query_sort = Constants.QUERY + " " + typeString + " nosort";
+
+                String sortOption;
+                if (line.contains("ORDER BY")) {
+                    // These rows are already sorted by the SQL and need to match exactly
+                    sortOption = "nosort";
+                } else {
+                    // Need to create a canonical ordering...
+                    sortOption = "rowsort";
+                    mog.sortMode = "rowsort";
+                }
+                String query_sort = Constants.QUERY + " " + typeString + " " + sortOption;
                 writeToFile(writer, query_sort);
                 writeToFile(writer, line);
                 writeToFile(writer, Constants.SEPARATION);

--- a/script/testing/junit/traces/update.test
+++ b/script/testing/junit/traces/update.test
@@ -17,7 +17,7 @@ statement ok
 UPDATE update1 SET c2 = '2020-01-03 11:22:33.721058' WHERE c1 = 2;
 
 query I rowsort
-SELECT * from update1 ORDER BY c1 ASC;
+SELECT * from update1;
 ----
 1
 2020-01-02 12:23:34.567893
@@ -49,14 +49,14 @@ statement ok
 UPDATE update2 SET c2 = 4 WHERE c1 = 22;
 
 query II rowsort
-SELECT * FROM update2 ORDER BY c2;
+SELECT * FROM update2;
 ----
 1
 1
-22
-4
 23
 33
+22
+4
 
 query II rowsort
 SELECT * FROM update2 WHERE c2=22;
@@ -92,14 +92,14 @@ statement ok
 UPDATE update3 SET c2 = 4.0 WHERE c1 = 2;
 
 query IR rowsort
-SELECT * FROM update3 ORDER BY c1;
+SELECT * FROM update3;
 ----
 1
 1
+3
+3
 2
 4
-3
-3
 
 query IR rowsort
 SELECT * FROM update3 WHERE c2=2.0;
@@ -114,12 +114,12 @@ statement ok
 UPDATE update3 SET c1=2 WHERE c2=1.0;
 
 query IR rowsort
-SELECT * FROM update3 WHERE c1=2 ORDER BY c1, c2;
+SELECT * FROM update3 WHERE c1=2;
 ----
 2
-1
-2
 4
+2
+1
 
 statement ok
 DROP TABLE update3;
@@ -143,7 +143,7 @@ statement ok
 UPDATE update4 SET c2 = 4.0 WHERE c1 = 2;
 
 query IRT rowsort
-SELECT * FROM update4 ORDER BY c3;
+SELECT * FROM update4;
 ----
 1
 1
@@ -153,34 +153,34 @@ SELECT * FROM update4 ORDER BY c3;
 3
 
 query IRT rowsort
-SELECT * FROM update4 WHERE c2=2.0 ORDER BY c3;
+SELECT * FROM update4 WHERE c2=2.0;
 ----
 
 query IRT rowsort
-SELECT * FROM update4 WHERE c2=2.0 AND c3='2' ORDER BY c3;
+SELECT * FROM update4 WHERE c2=2.0 AND c3='2';
 ----
 
 query I rowsort
-SELECT c1 FROM update4 WHERE c2=2.0 OR c3='1' ORDER BY c3;
+SELECT c1 FROM update4 WHERE c2=2.0 OR c3='1';
 ----
 1
 
 query IRT rowsort
-SELECT * FROM update4 WHERE c2=2.0 AND c3='2' OR c1=1 ORDER BY c3;
+SELECT * FROM update4 WHERE c2=2.0 AND c3='2' OR c1=1;
 ----
 1
 1
 1
 
 query R rowsort
-SELECT c2 FROM update4 WHERE c1=2 ORDER BY c3;
+SELECT c2 FROM update4 WHERE c1=2;
 ----
 
 statement ok
 UPDATE update4 SET c1=2 WHERE c2=1.0;
 
 query IRT rowsort
-SELECT * FROM update4 WHERE c1=2 ORDER BY c3;
+SELECT * FROM update4 WHERE c1=2;
 ----
 2
 1
@@ -202,7 +202,7 @@ statement ok
 UPDATE update5 SET a=a;
 
 query I rowsort
-SELECT a FROM update5 ORDER BY a;
+SELECT a FROM update5;
 ----
 1
 2

--- a/script/testing/junit/traces/update.test
+++ b/script/testing/junit/traces/update.test
@@ -2,7 +2,7 @@ statement ok
 -- Generate tracefile with:
 
 statement ok
---     ant generate-trace -Dpath=sql/update.sql -Ddb-url=jdbc:postgresql://localhost/postgres -Ddb-user=postgres -Ddb-password="postgres" -Doutput-name=update.test && sed -i 's/rowsort/rowsort/' traces/update.test
+--     ant generate-trace -Dpath=sql/update.sql -Ddb-url=jdbc:postgresql://localhost/postgres -Ddb-user=postgres -Ddb-password="postgres" -Doutput-name=update.test && sed -i 's/nosort/rowsort/' traces/update.test
 
 statement ok
 CREATE TABLE update1 (c1 int, c2 timestamp);
@@ -53,10 +53,10 @@ SELECT * FROM update2;
 ----
 1
 1
-23
-33
 22
 4
+23
+33
 
 query II rowsort
 SELECT * FROM update2 WHERE c2=22;
@@ -96,10 +96,10 @@ SELECT * FROM update3;
 ----
 1
 1
-3
-3
 2
 4
+3
+3
 
 query IR rowsort
 SELECT * FROM update3 WHERE c2=2.0;
@@ -117,9 +117,9 @@ query IR rowsort
 SELECT * FROM update3 WHERE c1=2;
 ----
 2
-4
-2
 1
+2
+4
 
 statement ok
 DROP TABLE update3;

--- a/script/testing/junit/traces/update.test
+++ b/script/testing/junit/traces/update.test
@@ -36,7 +36,7 @@ statement ok
 UPDATE update2 SET c2 = 4 WHERE c1 = 22
 
 query II nosort
-SELECT * FROM update2
+SELECT * FROM update2 ORDER BY c2
 ----
 6 values hashing to 190677788c9e53a2716f40ca4a10e132
 
@@ -68,7 +68,7 @@ statement ok
 UPDATE update3 SET c2 = 4.0 WHERE c1 = 2
 
 query IR nosort
-SELECT * FROM update3
+SELECT * FROM update3 ORDER BY c1
 ----
 6 values hashing to c83c2a26476216903b2d54eb9f5d1b01
 
@@ -85,7 +85,7 @@ statement ok
 UPDATE update3 SET c1=2 WHERE c2=1.0
 
 query IR nosort
-SELECT * FROM update3 WHERE c1=2
+SELECT * FROM update3 WHERE c1=2 ORDER BY c1, c2
 ----
 4 values hashing to 68dbc538b31e461cd48daa116345fc9c
 
@@ -108,30 +108,30 @@ statement ok
 UPDATE update4 SET c2 = 4.0 WHERE c1 = 2
 
 query IRT nosort
-SELECT * FROM update4
+SELECT * FROM update4 ORDER BY c3
 ----
 9 values hashing to d6eb3cbabeb480aef68da6106902c619
 
 query IRT nosort
-SELECT * FROM update4 WHERE c2=2.0
+SELECT * FROM update4 WHERE c2=2.0 ORDER BY c3
 ----
 
 query IRT nosort
-SELECT * FROM update4 WHERE c2=2.0 AND c3='2'
+SELECT * FROM update4 WHERE c2=2.0 AND c3='2' ORDER BY c3
 ----
 
 query I nosort
-SELECT c1 FROM update4 WHERE c2=2.0 OR c3='1'
+SELECT c1 FROM update4 WHERE c2=2.0 OR c3='1' ORDER BY c3
 ----
 1 values hashing to b026324c6904b2a9cb4b88d6d61c81d1
 
 query IRT nosort
-SELECT * FROM update4 WHERE c2=2.0 AND c3='2' OR c1=1
+SELECT * FROM update4 WHERE c2=2.0 AND c3='2' OR c1=1 ORDER BY c3
 ----
 3 values hashing to 280262bb00bfccfa4c24774d8faccde2
 
 query R nosort
-SELECT c2 FROM update4 WHERE c1=2
+SELECT c2 FROM update4 WHERE c1=2 ORDER BY c3
 ----
 1 values hashing to 48a24b70a0b376535542b996af517398
 
@@ -139,7 +139,7 @@ statement ok
 UPDATE update4 SET c1=2 WHERE c2=1.0
 
 query IRT nosort
-SELECT * FROM update4 WHERE c1=2
+SELECT * FROM update4 WHERE c1=2 ORDER BY c3
 ----
 6 values hashing to c9ebc146b67fa6b443f8da2bbc9c9d8c
 


### PR DESCRIPTION
# Fix `update.test` Tracefile

Fixes #1284 

## Description

This is another set of tests that falsely assumed that Noisepage and Postgres would return identical tuple orders on unsorted data.  To fix this, this PR removes hashed results which are both hard to debug and implicitly assume a sort order, and instead relies on the "rowsort" option (replacing "nosort") to force the sorting of both the result set and expected in Java.

Additionally, this PR includes the original SQL file along with the command to generate it to facilitate any future updates or new tests in the future.

## Further work

This appears to be a larger issue throughout all of the tracefiles and probably needs a to be replicated across the other JUnit tests.