### PR TITLE
Remove duplicate files for run-clang-tidy.py.

### DIFF
--- a/build-support/run-clang-tidy.py
+++ b/build-support/run-clang-tidy.py
@@ -264,6 +264,10 @@ def main():
     # NoisePage hack: don't check third party dependencies.
     files = [filepath for filepath in files if '/_deps/' not in filepath]
 
+    # Remove any duplicates from the files list. In theory that shouldn't happen, but we've seen it when there are
+    # quirks in the build targets
+    files = list(set(files))
+
     max_task = args.j
     if max_task == 0:
         max_task = multiprocessing.cpu_count()


### PR DESCRIPTION
## Description
While running `clang-tidy` I noticed duplicate output for .cpp files, which shouldn't happen -- headers yes. I confirmed this by modifying `run-clang-tidy.py` file to print the length and duplicates in the files list, and then de-dupe it like so:
```
    print(len(files))
    print({x: files.count(x) for x in files if files.count(x) > 1})

    files = list(set(files))

    print(len(files))
    print({x: files.count(x) for x in files if files.count(x) > 1})
```

This was the output:
```

731
{u'/tmp/tmp.Wzh2ZL3dbo/test/common/rusage_monitor_test.cpp': 2, u'/tmp/tmp.Wzh2ZL3dbo/test/execution/error_reporter_test.cpp': 2,
...
588
{}
```
All of the duplicates were in the test folder, which I suspect is due to jumbotests. We should investigate that separately. This is sort of a band-aid for an upstream issue in our `compiler_commands.json`, I think.

## Further work
Figure out why we have .cpp files for tests multiple times in `compiler_commands.json`.