### PR TITLE
Populate Microbenchmark Data

### DIFF
--- a/Jenkinsfile-nightly
+++ b/Jenkinsfile-nightly
@@ -71,7 +71,7 @@ pipeline {
 
                 script { // TODO: This script block is temporary to get some initial data into microbenchmarks
                     def iterations = 4
-                    for(int i = 0;i < iterations; i++)
+                    for(int i = 0;i < iterations; i++){
                         // The micro_bench configuration has to be consistent because we currently check against previous runs with the same config
                         //  # of Threads: 4
                         //  WAL Path: Ramdisk

--- a/Jenkinsfile-nightly
+++ b/Jenkinsfile-nightly
@@ -70,7 +70,8 @@ pipeline {
                 ninja''', label: 'Compiling'
 
                 script { // TODO: This script block is temporary to get some initial data into microbenchmarks
-                    (1..4).each{
+                    def iterations = 4
+                    for(int i = 0;i < iterations; i++)
                         // The micro_bench configuration has to be consistent because we currently check against previous runs with the same config
                         //  # of Threads: 4
                         //  WAL Path: Ramdisk

--- a/Jenkinsfile-nightly
+++ b/Jenkinsfile-nightly
@@ -17,7 +17,7 @@ pipeline {
 
     stages {
         stage('Performance') {
-            when {false}
+            when  {equals expected: true, actual: false}
             agent { label 'benchmark' }
             steps {
                 sh 'echo $NODE_NAME'

--- a/Jenkinsfile-nightly
+++ b/Jenkinsfile-nightly
@@ -17,7 +17,6 @@ pipeline {
 
     stages {
         stage('Performance') {
-            when  {equals expected: true, actual: false}
             agent { label 'benchmark' }
             steps {
                 sh 'echo $NODE_NAME'

--- a/Jenkinsfile-nightly
+++ b/Jenkinsfile-nightly
@@ -70,8 +70,7 @@ pipeline {
                 ninja''', label: 'Compiling'
 
                 script { // TODO: This script block is temporary to get some initial data into microbenchmarks
-                    def iterations = (1..4)
-                    for(i in iterations){
+                    (1..4).each{
                         // The micro_bench configuration has to be consistent because we currently check against previous runs with the same config
                         //  # of Threads: 4
                         //  WAL Path: Ramdisk

--- a/Jenkinsfile-nightly
+++ b/Jenkinsfile-nightly
@@ -17,6 +17,7 @@ pipeline {
 
     stages {
         stage('Performance') {
+            when {false}
             agent { label 'benchmark' }
             steps {
                 sh 'echo $NODE_NAME'

--- a/Jenkinsfile-nightly
+++ b/Jenkinsfile-nightly
@@ -68,16 +68,26 @@ pipeline {
                 cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DNOISEPAGE_USE_ASAN=OFF -DNOISEPAGE_USE_JEMALLOC=ON -DNOISEPAGE_BUILD_TESTS=OFF ..
                 ninja''', label: 'Compiling'
 
-                // The micro_bench configuration has to be consistent because we currently check against previous runs with the same config
-                //  # of Threads: 4
-                //  WAL Path: Ramdisk
-                sh script:'''
-                cd script/testing
-                python3 microbench/run_microbench.py --run --num-threads=4 --benchmark-path $(pwd)/../../build/benchmark --logfile-path=/mnt/ramdisk/benchmark.log --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
-                ''', label:'Microbenchmark'
+                script { // TODO: This script block is temporary to get some initial data into microbenchmarks
+                    def iterations = (1..4)
+                    for(i in iterations){
+                        // The micro_bench configuration has to be consistent because we currently check against previous runs with the same config
+                        //  # of Threads: 4
+                        //  WAL Path: Ramdisk
+                        sh script:'''
+                        cd script/testing
+                        python3 microbench/run_microbench.py --run --num-threads=4 --benchmark-path $(pwd)/../../build/benchmark --logfile-path=/mnt/ramdisk/benchmark.log --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
+                        ''', label:'Microbenchmark'
 
-                archiveArtifacts 'script/testing/*.json'
-                junit 'script/testing/*.xml'
+                        archiveArtifacts 'script/testing/*.json'
+                        junit 'script/testing/*.xml'
+                        // This next line can be removed when the loop is removed
+                        sh 'rm script/testing/*.json'
+                        sh 'rm script/testing/*.xml'
+                    }
+
+                }
+
             }
             post {
                 cleanup {


### PR DESCRIPTION
# Populate Microbenchmark Data

## Description
This adds a loop that will run the microbenchmark data 4 times each night. This will add 1:30 to the nightly job. This means that the nightly build will run from ~2 am - 6 am. If merged today we should have enough data by Monday, at which point I can remove the loop from the Jenkinsfile.

Here is proof that it works: http://jenkins.db.cs.cmu.edu:8080/blue/organizations/jenkins/testing-team%2Fterrier-nightly/detail/populate-microbench-data/5/pipeline

## Further work
Once we have 20 entries in the database (currently at 7) I will remove this change. 