### PR TITLE
Prevent optimizer from issuing plans with range scans on hashmap indexes

### DIFF
--- a/src/optimizer/index_util.cpp
+++ b/src/optimizer/index_util.cpp
@@ -181,6 +181,13 @@ bool IndexUtil::CheckPredicates(
     // Generally on multi-column indexes, exact would result in comparing against unspecified attribute.
     // Only try to do an exact key lookup if potentially all attributes are specified.
     scan_type = planner::IndexScanType::Exact;
+  } else if (schema.Type() == storage::index::IndexType::HASHMAP) {
+    // This is a range-based scan, but this is a hashmap so it cannot satisfy the predicate.
+    //
+    // TODO(John): Ideally this check should be based off of lookups in the catalog.  However, we do not
+    // support dynamically defined index types nor do we have `pg_op*` catalog tables to store the necessary
+    // data.  For now, this check is sufficient for what the optimizer is doing.
+    return false;
   }
 
   for (auto &col : schema.GetColumns()) {

--- a/src/optimizer/index_util.cpp
+++ b/src/optimizer/index_util.cpp
@@ -181,13 +181,6 @@ bool IndexUtil::CheckPredicates(
     // Generally on multi-column indexes, exact would result in comparing against unspecified attribute.
     // Only try to do an exact key lookup if potentially all attributes are specified.
     scan_type = planner::IndexScanType::Exact;
-  } else if (schema.Type() == storage::index::IndexType::HASHMAP) {
-    // This is a range-based scan, but this is a hashmap so it cannot satisfy the predicate.
-    //
-    // TODO(John): Ideally this check should be based off of lookups in the catalog.  However, we do not
-    // support dynamically defined index types nor do we have `pg_op*` catalog tables to store the necessary
-    // data.  For now, this check is sufficient for what the optimizer is doing.
-    return false;
   }
 
   for (auto &col : schema.GetColumns()) {
@@ -229,6 +222,15 @@ bool IndexUtil::CheckPredicates(
       bounds->insert(std::make_pair(
           oid, std::vector<planner::IndexExpression>{planner::IndexExpression(nullptr), open_lows[oid]}));
     }
+  }
+
+  if (schema.Type() == storage::index::IndexType::HASHMAP && scan_type != planner::IndexScanType::Exact) {
+    // This is a range-based scan, but this is a hashmap so it cannot satisfy the predicate.
+    //
+    // TODO(John): Ideally this check should be based off of lookups in the catalog.  However, we do not
+    // support dynamically defined index types nor do we have `pg_op*` catalog tables to store the necessary
+    // data.  For now, this check is sufficient for what the optimizer is doing.
+    return false;
   }
 
   *idx_scan_type = scan_type;

--- a/test/catalog/catalog_sql_test.cpp
+++ b/test/catalog/catalog_sql_test.cpp
@@ -1,0 +1,75 @@
+#include <memory>
+#include <pqxx/pqxx>  // NOLINT
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "common/settings.h"
+#include "gtest/gtest.h"
+#include "main/db_main.h"
+#include "test_util/test_harness.h"
+
+namespace noisepage::catalog {
+
+// These are end-to-end tests of the catalog which cannot be performed with the
+// JUnit trace framework because we expect divergent behavior from PostgreSQL
+// since there are slight differences between the implementations of both
+// catalogs (most noticeably OIDs).
+class CatalogSqlTests : public TerrierTest {
+ protected:
+  void SetUp() override {
+    std::unordered_map<settings::Param, settings::ParamInfo> param_map;
+    noisepage::settings::SettingsManager::ConstructParamMap(param_map);
+
+    db_main_ = noisepage::DBMain::Builder()
+                   .SetSettingsParameterMap(std::move(param_map))
+                   .SetUseSettingsManager(true)
+                   .SetUseGC(true)
+                   .SetUseCatalog(true)
+                   .SetUseGCThread(true)
+                   .SetUseTrafficCop(true)
+                   .SetUseStatsStorage(true)
+                   .SetUseLogging(true)
+                   .SetUseNetwork(true)
+                   .SetUseExecution(true)
+                   .Build();
+
+    db_main_->GetNetworkLayer()->GetServer()->RunServer();
+
+    port_ = static_cast<uint16_t>(db_main_->GetSettingsManager()->GetInt(settings::Param::port));
+  }
+
+  std::unique_ptr<DBMain> db_main_;
+  uint16_t port_;
+};
+
+TEST_F(CatalogSqlTests, OidCheck) {
+  try {
+    pqxx::connection connection(
+        fmt::format("host=127.0.0.1 port={0} user={1} sslmode=disable application_name=psql", port_, DEFAULT_DATABASE));
+
+    pqxx::work txn1(connection);
+    pqxx::result r = txn1.exec("SELECT reloid FROM pg_class WHERE reloid >= 1000;");
+    EXPECT_EQ(r.size(), 0);  // All of the bootstrapped tables should have catalog OIDs
+    txn1.commit();
+  } catch (const std::exception &e) {
+    EXPECT_TRUE(false);
+  }
+}
+
+TEST_F(CatalogSqlTests, OptimizerHashmapTest) {
+  // This directly tests for #1132 because the catalog is the only place hashmaps can exist at the moment.
+  try {
+    pqxx::connection connection(
+        fmt::format("host=127.0.0.1 port={0} user={1} sslmode=disable application_name=psql", port_, DEFAULT_DATABASE));
+
+    pqxx::work txn1(connection);
+    pqxx::result r = txn1.exec("SELECT relname FROM pg_class WHERE relkind = 114 AND relnamespace = 15;");
+    r = txn1.exec("SELECT * FROM pg_catalog.pg_class WHERE reloid > 1;");
+    txn1.commit();
+  } catch (const std::exception &e) {
+    EXPECT_TRUE(false);
+  }
+}
+}  // namespace noisepage::catalog


### PR DESCRIPTION
# Heading

Fixes #1132 

## Description

The optimizer was implicitly assuming that all indexes supported all modes of querying.  Therefore, it would create plans that called for range scans on hashmap indexes and cause the system to crash at runtime.  This PR inserts a check inside `IndexUtil::CheckPredicates` that ensures we force a negative response if the predicate would require this situation.

## Further work

Ideally, this should be a more general check which allows adding additional index types like PostgreSQL does.  However, that would require implementing several more catalog tables and logic to have the optimizer query that information when checking predicates.