### PR TITLE
Add port resource constraints to catalog_sql_test.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -977,7 +977,7 @@ endfunction()
 # Be careful that your prefixes are really unique, otherwise a test will be run multiple times.
 
 add_jumbotest("test/binder" "")
-add_jumbotest("test/catalog" "")
+add_jumbotest("test/catalog" "catalog_sql_test;")
 add_jumbotest("test/common" "bitmap_test;concurrent_bitmap_test;rusage_monitor_test;")
 add_jumbotest("test/execution" "ast;compiler_test;index_create_test;index_iterator_test;sql;storage_interface_test;util;vm;")
 add_jumbotest("test/integration" "")
@@ -996,6 +996,7 @@ add_jumbotest("test/type" "")
 # Read up on CTest resource groups: https://cmake.org/cmake/help/latest/manual/ctest.1.html#resource-allocation
 # All tests that try to launch the server on port 15721 must declare that here.
 set_tests_properties(
+        catalog_sql_test jumbotest_catalog_catalog_sql_test
         metrics_test jumbotest_metrics_metrics_test
         network_test jumbotest_network_network_test
         traffic_cop_test jumbotest_traffic_cop_traffic_cop_test


### PR DESCRIPTION
# Add port resource constraints to catalog_sql_test.

## Description

For test parallelism to work, each test that hogs some common resource (network ports, paths to some files, etc) must declare it [here](https://github.com/cmu-db/noisepage/blob/240dc30eb9874f27dd2e88a7e380274c5de44072/CMakeLists.txt#L998).

`catalog_sql_test` was added in a recent PR. I'm not sure where to document this so that everyone writing tests that manually bring up `DBMain` and `RunServer()` (hopefully uncommon and limited to stuff which can't go through SQL trace files) can find it. Ideas for where to document this?

No point sending this through CI.