### PR TITLE
Add error message when GenerateTrace fails

### DIFF
--- a/script/testing/junit/src/GenerateTrace.java
+++ b/script/testing/junit/src/GenerateTrace.java
@@ -44,7 +44,10 @@ public class GenerateTrace {
                 statement = conn.createStatement();
                 statement.execute(line);
                 label = Constants.STATEMENT_OK;
-            } catch (Throwable e){
+            } catch (SQLException e) {
+                System.err.println("Error executing SQL Statement: '" + line + "'; " + e.getMessage());
+                label = Constants.STATEMENT_ERROR;
+            } catch (Throwable e) {
                 label = Constants.STATEMENT_ERROR;
             }
 
@@ -145,6 +148,7 @@ public class GenerateTrace {
             }
         }
         writer.close();
+        br.close();
     }
 
     public static void writeToFile(FileWriter writer, String str) throws IOException {


### PR DESCRIPTION
## Description
When generating a test trace file, if there's an error executing the SQL statement (either syntax or any other), then it will fail silently and cause a NullPointerException later on. This commit just adds an error message that makes it easier to debug when GenerateTrace fails. Note, this doesn't actually cause it to fail any earlier and it will still fail with a NullPointerException later on, it just adds an error message earlier.

The one downside is that if you are creating a test where you expect a lot of errors then the output will be a little noisy. I think it's a worthwhile trade-off because generating a trace is usually just a one time activity so a noisy output isn't a huge deal, especially if you're expecting sql statements to fail. Let me know thoughts in the comments.

### Remaining Tasks
N/A

## Performance
N/A

## Further Work
N/A