### PR TITLE
Add documentation for preventing Run / Debug from CLion from crashing on ASAN Container Overflow

### DIFF
--- a/docs/dev_troubleshooting.md
+++ b/docs/dev_troubleshooting.md
@@ -40,9 +40,31 @@ You might be attempting to force CLion to use the compilers from LLVM instead of
 
 The fix for this is to specify the C and C++ compilers with environment variables instead of using the toolchain selection UI from within CLion. In your build configurations, set the `CC` and `CXX` environment variables and point them at the `clang` and `clang++` binaries in `/usr/local/Cellar/llvm@8/8.0.1_3/bin/`, respectively.
 
-**Issue:** In debug builds, launching the database from within CLion is immediately followed by a program crash with AddressSanitizer reporting a container overflow on an instance of `std::string`.
+**Issue:** In debug builds, launching the database from within CLion is immediately followed by a program crash with AddressSanitizer reporting a container overflow on an instance of `std::string` (or perhaps another STL container).
 
-**Fix:** There is a known issue with AddressSanitizer false positives on OSX. Theoretically, one should be able to disable checks for container overflow by specifying the environment variable `ASAN_OPTIONS=detect_container_overflow=0` in the Debug/Run configuration within CLion. In practice, we have found that there are instances in which CLion fails to recognize this environment variable, resulting in the database server crashing upon startup even with the proper environment specified. _This is an open issue._
+**Fix:** There is a known issue with AddressSanitizer false positives on OSX that stems from use of the libc++ standard library implementation. Because of this, we must disable AddressSanitizer's container overflow checks. If you are running NoisePage from the commandline, setting an environment variable should be sufficient to address this issue:
+
+```
+export ASAN_OPTIONS=detect_container_overflow=0
+```
+
+or, if you don't want to make the changes persistent for your shell session:
+
+```
+ASAN_OPTIONS=detect_container_overflow=0 ./noisepage [...]
+```
+
+When building and running within CLion, however, there appears to be some quirk of the interaction between the IDE and the AddressSanitizer runtime that results in ASan not respecting any environment variables we set in the `Run / Debug` configurations, meaning that the program will continue to crash as a result of this false positive even when the environment variable is set. To circumvent this, navigate to _Preferences_ > _Dynamic Analysis Tools_ > _Sanitizers_ and add the option `detect_container_overflow=0` to the AddressSanitizer entry. Launching NoisePage from CLion with AddressSanitizer enabled should now succeed.
+
+**Issue:** When an AddressSanitizer error is encountered when running or debugging within CLion, the IDE complains that "the LLVM symbolizer cannot be found."
+
+**Fix:** Set the path the the `llvm-symbolizer` binary as an environment variable in your `Debug` build configuration. For example:
+
+```
+ASAN_SYMBOLIZER_PATH=/usr/local/opt/llvm@8/Toolchains/LLVM8.0.1.xctoolchain/usr/bin/llvm-symbolizer
+```
+
+Notice that the provided path includes the filename for the binary itself.
 
 ## Ubuntu
 


### PR DESCRIPTION
# Prevent Run / Debug from CLion from Crashing on Asan Container Overflow

## Description

I was experiencing issues wherein attempting to disable Asan's container overflow checks with an environment variable would fail when running or debugging the application from within CLion - the IDE appears not to respect the environment variable for some reason (no matter how hard I tried to make it...). Fortunately, CLion provides another way to set options for various sanitizers that I just came across. This PR just adds this finding to the troubleshooting documentation.

## Remaining tasks

None.

## Performance

N/A

## Further work

None