### PR TITLE
Pipeline Metrics/Counters in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -177,7 +177,7 @@ pipeline {
                         sh 'cd build && timeout 1h ninja jumbotests'
                         sh 'cd build && timeout 1h ninja check-tpl'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple', label: 'UnitTest (Simple)'
-                        sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple --server-args="--pipeline_metrics_enable=True --pipeline_metrics_interval=0 --counters_enable=True"', label: 'UnitTest (Simple with pipeline metric and counterss)'
+                        sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple --server-args="--pipeline_metrics_enable=True --pipeline_metrics_interval=0 --counters_enable=True"', label: 'UnitTest (Simple with pipeline metrics and counters)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended', label: 'UnitTest (Extended)'
                     }
                     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -177,6 +177,7 @@ pipeline {
                         sh 'cd build && timeout 1h ninja jumbotests'
                         sh 'cd build && timeout 1h ninja check-tpl'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple', label: 'UnitTest (Simple)'
+                        sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple --server-args="--pipeline_metrics_enable=True --pipeline_metrics_interval=0 --counters_enable=True"', label: 'UnitTest (Simple with pipeline metric and counterss)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended', label: 'UnitTest (Extended)'
                     }
                     post {

--- a/script/testing/junit/utils.py
+++ b/script/testing/junit/utils.py
@@ -23,6 +23,8 @@ def parse_command_line_args():
     aparser.add_argument("--prepare-threshold",
                          type=int,
                          help="Threshold under the 'extended' query mode")
+    aparser.add_argument("--server-args",
+                         help="Server Commandline Args")
 
     args = vars(aparser.parse_args())
 

--- a/src/execution/compiler/operator/sort_translator.cpp
+++ b/src/execution/compiler/operator/sort_translator.cpp
@@ -60,15 +60,15 @@ SortTranslator::SortTranslator(const planner::OrderByPlanNode &plan, Compilation
 
   if (build_pipeline_.IsParallel() && IsPipelineMetricsEnabled()) {
     parallel_starttlsort_hook_fn_ =
-        GetCodeGen()->MakeFreshIdentifier(GetPipeline()->CreatePipelineFunctionName("StartTLSortHook"));
+        GetCodeGen()->MakeFreshIdentifier(build_pipeline_.CreatePipelineFunctionName("StartTLSortHook"));
     parallel_starttlmerge_hook_fn_ =
-        GetCodeGen()->MakeFreshIdentifier(GetPipeline()->CreatePipelineFunctionName("StartTLMergeHook"));
+        GetCodeGen()->MakeFreshIdentifier(build_pipeline_.CreatePipelineFunctionName("StartTLMergeHook"));
     parallel_endtlsort_hook_fn_ =
-        GetCodeGen()->MakeFreshIdentifier(GetPipeline()->CreatePipelineFunctionName("EndTLSortHook"));
+        GetCodeGen()->MakeFreshIdentifier(build_pipeline_.CreatePipelineFunctionName("EndTLSortHook"));
     parallel_endtlmerge_hook_fn_ =
-        GetCodeGen()->MakeFreshIdentifier(GetPipeline()->CreatePipelineFunctionName("EndTLMergeHook"));
+        GetCodeGen()->MakeFreshIdentifier(build_pipeline_.CreatePipelineFunctionName("EndTLMergeHook"));
     parallel_endsinglesorter_hook_fn_ =
-        GetCodeGen()->MakeFreshIdentifier(GetPipeline()->CreatePipelineFunctionName("EndSingleSorterHook"));
+        GetCodeGen()->MakeFreshIdentifier(build_pipeline_.CreatePipelineFunctionName("EndSingleSorterHook"));
   }
 }
 

--- a/src/execution/compiler/operator/static_aggregation_translator.cpp
+++ b/src/execution/compiler/operator/static_aggregation_translator.cpp
@@ -275,7 +275,7 @@ void StaticAggregationTranslator::FinishPipelineWork(const Pipeline &pipeline, F
     } else {
       RecordCounters(pipeline, function);
     }
-  } else {
+  } else if (!pipeline.IsParallel()) {
     RecordCounters(pipeline, function);
   }
 }

--- a/src/include/optimizer/optimizer_context.h
+++ b/src/include/optimizer/optimizer_context.h
@@ -189,6 +189,15 @@ class OptimizerContext {
     NOISEPAGE_ASSERT(ret, "Root expr should always be inserted");
   }
 
+  /**
+   * Registers expr to be deleted on txn_ commit/abort
+   * @param expr Expression to register
+   */
+  void RegisterExprWithTxn(parser::AbstractExpression *expr) {
+    txn_->RegisterCommitAction([=]() { delete expr; });
+    txn_->RegisterAbortAction([=]() { delete expr; });
+  }
+
  private:
   Memo memo_;
   RuleSet rule_set_;


### PR DESCRIPTION
# Pipeline Metrics and Counters in Jenkins

## Description
PR enables pipeline metrics and counters for junit tests (in simple mode) at the `ubuntu-20.04/gcc-9.3 (Debug/ASAN/jumbotests)` Jenkins stage. The PR also fixes some pipeline recording for nested queries and also a memory leak within the optimizer.