### PR TITLE
Add support for SQL IN operator in WHERE clauses.

### DIFF
--- a/script/testing/junit/traces/select.test
+++ b/script/testing/junit/traces/select.test
@@ -1225,9 +1225,6 @@ statement ok
 DROP TABLE t;
 
 statement ok
-DROP TABLE t;
-
-statement ok
 DROP TABLE tt;
 
 statement ok

--- a/script/testing/junit/traces/select.test
+++ b/script/testing/junit/traces/select.test
@@ -1175,3 +1175,49 @@ SELECT tb.* FROM t, tt tb;
 40
 50
 50
+
+statement ok
+DROP TABLE t;
+
+statement ok
+DROP TABLE tt;
+
+statement ok
+CREATE TABLE t (a INT, b VARCHAR(32));
+
+statement ok
+INSERT INTO t VALUES (1, 'a'), (2, 'nananananabanana'), (3, 'catdogelephantfishgiraffehorse'), (4, 'd');
+
+query I rowsort
+SELECT a FROM t WHERE a IN (1);
+----
+1
+
+query I rowsort
+SELECT a FROM t WHERE a IN (2,3);
+----
+2
+3
+
+query I rowsort
+SELECT a FROM t WHERE b IN ('a','nananananabanana');
+----
+1
+2
+
+query I rowsort
+SELECT a FROM t WHERE b IN ('nananananabanana','catdogelephantfishgiraffehorse');
+----
+2
+3
+
+query I rowsort
+SELECT a FROM t WHERE b IN ('a','nananananabanana','catdogelephantfishgiraffehorse','d');
+----
+1
+2
+3
+4
+
+statement ok
+DROP TABLE t;

--- a/src/execution/compiler/expression/comparison_translator.cpp
+++ b/src/execution/compiler/expression/comparison_translator.cpp
@@ -12,9 +12,14 @@ namespace noisepage::execution::compiler {
 ComparisonTranslator::ComparisonTranslator(const parser::ComparisonExpression &expr,
                                            CompilationContext *compilation_context)
     : ExpressionTranslator(expr, compilation_context) {
-  // Prepare the left and right expression subtrees for translation.
-  compilation_context->Prepare(*expr.GetChild(0));
-  compilation_context->Prepare(*expr.GetChild(1));
+  // Prepare all expression subtrees for translation.
+  NOISEPAGE_ASSERT(expr.GetChildrenSize() == 2 || expr.GetExpressionType() == parser::ExpressionType::COMPARE_IN,
+                   "Every ComparisonExpression should have exactly two children, except for COMPARE_IN.");
+  NOISEPAGE_ASSERT(expr.GetChildrenSize() >= 2 || expr.GetExpressionType() == parser::ExpressionType::COMPARE_IN,
+                   "Every COMPARE_IN ComparisonExpression should have at least two children.");
+  for (const auto &child : expr.GetChildren()) {
+    compilation_context->Prepare(*child);
+  }
 }
 
 ast::Expr *ComparisonTranslator::DeriveValue(WorkContext *ctx, const ColumnValueProvider *provider) const {
@@ -23,8 +28,18 @@ ast::Expr *ComparisonTranslator::DeriveValue(WorkContext *ctx, const ColumnValue
   auto right_val = ctx->DeriveValue(*GetExpression().GetChild(1), provider);
 
   switch (const auto expr_type = GetExpression().GetExpressionType(); expr_type) {
+    case parser::ExpressionType::COMPARE_IN: {
+      // Given "foo IN (1, 2, 3, ..., N)", produce "(foo == 1) OR (foo == 2) OR ... OR (foo == N)".
+      // Convention: child 0 is "foo", child 1 is the first listed value, and these are handled separately at the start.
+      auto *final_expr = codegen->Compare(parsing::Token::Type::EQUAL_EQUAL, left_val, right_val);
+      for (size_t i = 2; i < GetExpression().GetChildrenSize(); ++i) {
+        right_val = ctx->DeriveValue(*GetExpression().GetChild(i), provider);
+        auto *curr_expr = codegen->Compare(parsing::Token::Type::EQUAL_EQUAL, left_val, right_val);
+        final_expr = codegen->BinaryOp(parsing::Token::Type::OR, final_expr, curr_expr);
+      }
+      return final_expr;
+    }
     case parser::ExpressionType::COMPARE_EQUAL:
-    case parser::ExpressionType::COMPARE_IN:
       return codegen->Compare(parsing::Token::Type::EQUAL_EQUAL, left_val, right_val);
     case parser::ExpressionType::COMPARE_GREATER_THAN:
       return codegen->Compare(parsing::Token::Type::GREATER, left_val, right_val);

--- a/src/execution/compiler/expression/comparison_translator.cpp
+++ b/src/execution/compiler/expression/comparison_translator.cpp
@@ -15,7 +15,8 @@ ComparisonTranslator::ComparisonTranslator(const parser::ComparisonExpression &e
   // Prepare all expression subtrees for translation.
   NOISEPAGE_ASSERT(expr.GetChildrenSize() == 2 || expr.GetExpressionType() == parser::ExpressionType::COMPARE_IN,
                    "Every ComparisonExpression should have exactly two children, except for COMPARE_IN.");
-  NOISEPAGE_ASSERT(expr.GetChildrenSize() >= 2 || expr.GetExpressionType() == parser::ExpressionType::COMPARE_IN,
+  NOISEPAGE_ASSERT((expr.GetExpressionType() != parser::ExpressionType::COMPARE_IN) ||
+                       (expr.GetChildrenSize() >= 2 && expr.GetExpressionType() == parser::ExpressionType::COMPARE_IN),
                    "Every COMPARE_IN ComparisonExpression should have at least two children.");
   for (const auto &child : expr.GetChildren()) {
     compilation_context->Prepare(*child);

--- a/src/execution/compiler/operator/seq_scan_translator.cpp
+++ b/src/execution/compiler/operator/seq_scan_translator.cpp
@@ -130,12 +130,14 @@ void SeqScanTranslator::GenerateFilterClauseFunctions(util::RegionVector<ast::Fu
       auto translator = GetCompilationContext()->LookupTranslator(*predicate->GetChild(1));
       auto col_index = GetColOidIndex(cve->GetColumnOid());
       auto const_val = translator->DeriveValue(nullptr, nullptr);
-      builder.Append(codegen->VPIFilter(exec_ctx,                        // The execution context
-                                        vector_proj,                     // The vector projection
-                                        predicate->GetExpressionType(),  // Comparison type
-                                        col_index,                       // Column index
-                                        const_val,                       // Constant value
-                                        tid_list));                      // TID list
+      auto cmp_type = predicate->GetExpressionType();
+      cmp_type = cmp_type == parser::ExpressionType::COMPARE_IN ? parser::ExpressionType::COMPARE_EQUAL : cmp_type;
+      builder.Append(codegen->VPIFilter(exec_ctx,     // The execution context
+                                        vector_proj,  // The vector projection
+                                        cmp_type,     // Comparison type
+                                        col_index,    // Column index
+                                        const_val,    // Constant value
+                                        tid_list));   // TID list
     } else if (parser::ExpressionUtil::IsColumnCompareWithParam(*predicate)) {
       // TODO(WAN): temporary hacky implementation, poke Prashanth...
       auto cve = predicate->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -413,6 +413,15 @@ std::unique_ptr<AbstractExpression> PostgresParser::AExprTransform(ParseResult *
     children.emplace_back(ExprTransform(parse_result, root->rexpr_, nullptr));
   } else if (root->kind_ == AEXPR_OP && root->type_ == T_TypeCast) {
     target_type = ExpressionType::OPERATOR_CAST;
+  } else if (root->kind_ == AEXPR_IN) {
+    // Expression "FOO in (X, Y, ..., Z)". By convention, FOO is the first child and the other children are the IN list.
+    target_type = ExpressionType::COMPARE_IN;
+    children.emplace_back(ExprTransform(parse_result, root->lexpr_, nullptr));
+    auto *in_list = reinterpret_cast<List *>(root->rexpr_);
+    for (auto cell = in_list->head; cell != nullptr; cell = cell->next) {
+      auto node = static_cast<Node *>(cell->data.ptr_value);
+      children.emplace_back(ExprTransform(parse_result, node, nullptr));
+    }
   } else {
     auto name = (reinterpret_cast<value *>(root->name_->head->data.ptr_value))->val_.str_;
     target_type = StringToExpressionType(name);


### PR DESCRIPTION
# Add support for SQL IN operator in WHERE clauses.

## Description

Fix #1221 by adding support for the SQL IN operator in WHERE clauses.

- `... WHERE foo IN (1)` will be treated the same way as `foo = 1`, including vectorized stuff.
- `... WHERE foo IN (1,2,...,N)` will be treated as `(foo = 1) OR (foo = 2) OR ... OR (foo = N)`.

Also fixes some tables not getting dropped in `select.test`. And adds a couple of tests.

Just picking random things off the TPC-H list. We're actually very close.

Will flip to ready-for-review if passes CI.