### PR TITLE
Add support for type cast expressions.

### DIFF
--- a/script/testing/junit/traces/select.test
+++ b/script/testing/junit/traces/select.test
@@ -1175,3 +1175,36 @@ SELECT tb.* FROM t, tt tb;
 40
 50
 50
+
+query T
+SELECT true;
+----
+t
+
+query T
+SELECT '2020-11-07'::date;
+----
+2020-11-07
+
+statement ok
+CREATE TABLE foo (a date);
+
+statement ok
+INSERT INTO foo VALUES ('2020-11-07'::date);
+
+statement ok
+INSERT INTO foo VALUES ('2020-11-08'::date);
+
+query T rowsort
+select * from foo where a > '2020-11-07'::date;
+----
+2020-11-08
+
+query T rowsort
+SELECT * FROM foo WHERE a >= '2020-11-07'::date;
+----
+2020-11-07
+2020-11-08
+
+statement ok
+DROP TABLE foo;

--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -664,14 +664,6 @@ void BindNodeVisitor::Visit(common::ManagedPointer<parser::ConjunctionExpression
     sherpa_->SetDesiredType(child, type::TypeId::BOOLEAN);
   }
   SqlNodeVisitor::Visit(expr);
-
-  // If any of the operands are typecasts, the typecast children should have been casted by now. Pull the children up.
-  for (size_t i = 0; i < expr->GetChildrenSize(); ++i) {
-    auto child = expr->GetChild(i);
-    if (parser::ExpressionType::OPERATOR_CAST == child->GetExpressionType()) {
-      expr->SetChild(i, child->GetChild(0));
-    }
-  }
 }
 
 void BindNodeVisitor::Visit(common::ManagedPointer<parser::ConstantValueExpression> expr) {

--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -650,6 +650,8 @@ void BindNodeVisitor::Visit(common::ManagedPointer<parser::ComparisonExpression>
   for (size_t i = 0; i < expr->GetChildrenSize(); ++i) {
     auto child = expr->GetChild(i);
     if (parser::ExpressionType::OPERATOR_CAST == child->GetExpressionType()) {
+      NOISEPAGE_ASSERT(parser::ExpressionType::VALUE_CONSTANT == child->GetChild(0)->GetExpressionType(),
+                       "We can only pull up ConstantValueExpression.");
       expr->SetChild(i, child->GetChild(0));
     }
   }

--- a/src/binder/binder_util.cpp
+++ b/src/binder/binder_util.cpp
@@ -90,13 +90,20 @@ void BinderUtil::CheckAndTryPromoteType(const common::ManagedPointer<parser::Con
             break;
           }
           case type::TypeId::TINYINT: {
+            size_t size;
             int64_t int_val;
             try {
-              int_val = std::stol(std::string(str_view));
+              int_val = std::stol(std::string(str_view), &size);
             } catch (const std::out_of_range &e) {
               throw BINDER_EXCEPTION(fmt::format("tinyint out of range, string to convert was {}", str_view),
                                      common::ErrorCode::ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE);
             }
+
+            if (size != str_view.size()) {
+              throw BINDER_EXCEPTION(fmt::format("invalid input format for type tinyint: \"{}\"", str_view),
+                                     common::ErrorCode::ERRCODE_INVALID_TEXT_REPRESENTATION);
+            }
+
             if (!IsRepresentable<int8_t>(int_val)) {
               throw BINDER_EXCEPTION(fmt::format("tinyint out of range, string to convert was {}", str_view),
                                      common::ErrorCode::ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE);
@@ -105,13 +112,20 @@ void BinderUtil::CheckAndTryPromoteType(const common::ManagedPointer<parser::Con
             break;
           }
           case type::TypeId::SMALLINT: {
+            size_t size;
             int64_t int_val;
             try {
-              int_val = std::stol(std::string(str_view));
+              int_val = std::stol(std::string(str_view), &size);
             } catch (const std::out_of_range &e) {
               throw BINDER_EXCEPTION(fmt::format("smallint out of range, string to convert was {}", str_view),
                                      common::ErrorCode::ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE);
             }
+
+            if (size != str_view.size()) {
+              throw BINDER_EXCEPTION(fmt::format("invalid input format for type smallint: \"{}\"", str_view),
+                                     common::ErrorCode::ERRCODE_INVALID_TEXT_REPRESENTATION);
+            }
+
             if (!IsRepresentable<int16_t>(int_val)) {
               throw BINDER_EXCEPTION(fmt::format("smallint out of range, string to convert was {}", str_view),
                                      common::ErrorCode::ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE);
@@ -120,13 +134,20 @@ void BinderUtil::CheckAndTryPromoteType(const common::ManagedPointer<parser::Con
             break;
           }
           case type::TypeId::INTEGER: {
+            size_t size;
             int64_t int_val;
             try {
-              int_val = std::stol(std::string(str_view));
+              int_val = std::stol(std::string(str_view), &size);
             } catch (const std::out_of_range &e) {
               throw BINDER_EXCEPTION(fmt::format("integer out of range, string to convert was {}", str_view),
                                      common::ErrorCode::ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE);
             }
+
+            if (size != str_view.size()) {
+              throw BINDER_EXCEPTION(fmt::format("invalid input format for type integer: \"{}\"", str_view),
+                                     common::ErrorCode::ERRCODE_INVALID_TEXT_REPRESENTATION);
+            }
+
             if (!IsRepresentable<int32_t>(int_val)) {
               throw BINDER_EXCEPTION(fmt::format("integer out of range, string to convert was {}", str_view),
                                      common::ErrorCode::ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE);
@@ -135,13 +156,20 @@ void BinderUtil::CheckAndTryPromoteType(const common::ManagedPointer<parser::Con
             break;
           }
           case type::TypeId::BIGINT: {
+            size_t size;
             int64_t int_val;
             try {
-              int_val = std::stol(std::string(str_view));
+              int_val = std::stol(std::string(str_view), &size);
             } catch (const std::out_of_range &e) {
               throw BINDER_EXCEPTION(fmt::format("bigint out of range, string to convert was {}", str_view),
                                      common::ErrorCode::ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE);
             }
+
+            if (size != str_view.size()) {
+              throw BINDER_EXCEPTION(fmt::format("invalid input format for type bigint: \"{}\"", str_view),
+                                     common::ErrorCode::ERRCODE_INVALID_TEXT_REPRESENTATION);
+            }
+
             if (!IsRepresentable<int64_t>(int_val)) {
               throw BINDER_EXCEPTION(fmt::format("bigint out of range, string to convert was {}", str_view),
                                      common::ErrorCode::ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE);

--- a/src/include/parser/expression/type_cast_expression.h
+++ b/src/include/parser/expression/type_cast_expression.h
@@ -12,7 +12,7 @@ namespace noisepage::parser {
  *
  * For constants, TypeCastExpression should not exist beyond the optimizer, and the child should be used instead.
  * The role of a TypeCastExpression is to annotate the type of expr from above in the BinderSherpa.
- * For example, Postgres does not allow CAST('1+1' AS BIGINT) nor '1+1'::BIGINT, throwing error 22P02.
+ * For example, Postgres does not allow CAST('1+1' AS BIGINT), throwing error 22P02.
  *
  * However, for non-constant expressions such as the following trace,
  *   CREATE TABLE foo (a INTEGER);

--- a/src/include/parser/expression/type_cast_expression.h
+++ b/src/include/parser/expression/type_cast_expression.h
@@ -9,9 +9,16 @@
 namespace noisepage::parser {
 /**
  * TypeCastExpression represents cast expressions of the form CAST(expr) or expr::TYPE.
- * TypeCastExpression should not exist beyond the optimizer, and the child should be used instead.
+ *
+ * For constants, TypeCastExpression should not exist beyond the optimizer, and the child should be used instead.
  * The role of a TypeCastExpression is to annotate the type of expr from above in the BinderSherpa.
  * For example, Postgres does not allow CAST('1+1' AS BIGINT) nor '1+1'::BIGINT, throwing error 22P02.
+ *
+ * However, for non-constant expressions such as the following trace,
+ *   CREATE TABLE foo (a INTEGER);
+ *   INSERT INTO foo VALUES (1);
+ *   SELECT a::DECIMAL FROM foo;
+ * Then the casting must be done at execution time. As of 2020/11/14, non-constant expressions are not supported.
  */
 class TypeCastExpression : public AbstractExpression {
   // TODO(Ling):  Do we need a separate class for operator_cast? We can put it in operatorExpression

--- a/src/include/parser/expression/type_cast_expression.h
+++ b/src/include/parser/expression/type_cast_expression.h
@@ -9,6 +9,9 @@
 namespace noisepage::parser {
 /**
  * TypeCastExpression represents cast expressions of the form CAST(expr) or expr::TYPE.
+ * TypeCastExpression should not exist beyond the optimizer, and the child should be used instead.
+ * The role of a TypeCastExpression is to annotate the type of expr from above in the BinderSherpa.
+ * For example, Postgres does not allow CAST('1+1' AS BIGINT) nor '1+1'::BIGINT, throwing error 22P02.
  */
 class TypeCastExpression : public AbstractExpression {
   // TODO(Ling):  Do we need a separate class for operator_cast? We can put it in operatorExpression

--- a/src/include/parser/expression_util.h
+++ b/src/include/parser/expression_util.h
@@ -20,6 +20,7 @@
 #include "parser/expression/function_expression.h"
 #include "parser/expression/operator_expression.h"
 #include "parser/expression/parameter_value_expression.h"
+#include "parser/expression/type_cast_expression.h"
 
 namespace noisepage::parser {
 
@@ -479,6 +480,9 @@ class ExpressionUtil {
       auto def_cond = EvaluateExpression(expr_maps, case_expr->GetDefaultClause());
       auto type = case_expr->GetReturnValueType();
       return std::make_unique<CaseExpression>(type, std::move(clauses), std::move(def_cond));
+    } else if (expr->GetExpressionType() == ExpressionType::OPERATOR_CAST) {
+      NOISEPAGE_ASSERT(children_size == 1, "TypeCastExpression should have exactly 1 child.");
+      return expr->GetChild(0)->Copy();
     }
 
     return expr->CopyWithChildren(std::move(children));


### PR DESCRIPTION
# Add support for type cast expressions.

## Description

Fix #1219.

This enables `::` casting and also allows for `select true` which I believe @tanujnay112 may have wanted?

I think `::`-casting worked in the past because we pulled out the TypeCastExpression's contents, which is behavior that was probably rolled back with the binder cleanup (sherpa). This PR brings that back with the justification of Postgres not allowing you to do anything interesting in casts, as far as I can tell:

```
postgres=# select '1+1'::bigint;
ERROR:  invalid input syntax for type bigint: "1+1"
LINE 1: select '1+1'::bigint;
               ^
postgres=# select cast('1+1' as bigint);
ERROR:  invalid input syntax for type bigint: "1+1"
LINE 1: select cast('1+1' as bigint);
                    ^
postgres=# \errverbose
ERROR:  22P02: invalid input syntax for type bigint: "1+1"
LINE 1: select cast('1+1' as bigint);
                    ^
LOCATION:  scanint8, int8.c:126
```


With this PR:

```
noisepage=# select true;
 ?column? 
----------
 t
(1 row)

noisepage=# SELECT '2020-11-07'::date;
  ?column?  
------------
 2020-11-07
(1 row)

noisepage=# CREATE TABLE foo (a date);
CREATE TABLE
noisepage=# INSERT INTO foo VALUES ('2020-11-07'::date);
INSERT 0 1
noisepage=# INSERT INTO foo VALUES ('2020-11-08'::date);
INSERT 0 1
noisepage=# select * from foo where a > '2020-11-07'::date;
     a      
------------
 2020-11-08
(1 row)

noisepage=# SELECT * FROM foo WHERE a >= '2020-11-07'::date;
     a      
------------
 2020-11-07
 2020-11-08
(2 rows)
```

## Gripes

I'm still not a very big fan of the visitor pattern strewn all over the frontend, wherein we have the problem of

1. you visit, visit...
2. you visited a TypeCastExpression
3. you want to replace a TypeCastExpression with its child now
4. but you only have a pointer to the TypeCastExpression, not its parent -- how do you replace it? as far as I can tell, right now you can't.

This PR also hops on the general optimizer "when in doubt, make a copy" wagon in EvaluateExpression.

Marking as in-progress until it passes CI.