### PR TITLE
Fix the casting when accessing atttypid in pg_attribute.

### DIFF
--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -545,8 +545,9 @@ bool DatabaseCatalog::CreateColumn(const common::ManagedPointer<transaction::Tra
       redo->Delta()->AccessForceNotNull(pg_attribute_all_cols_prm_[postgres::ATTRELID_COL_OID]));
   auto name_entry = reinterpret_cast<storage::VarlenEntry *>(
       redo->Delta()->AccessForceNotNull(pg_attribute_all_cols_prm_[postgres::ATTNAME_COL_OID]));
-  auto type_entry = reinterpret_cast<type::TypeId *>(
-      redo->Delta()->AccessForceNotNull(pg_attribute_all_cols_prm_[postgres::ATTTYPID_COL_OID]));
+  auto type_entry = reinterpret_cast<uint32_t *>(redo->Delta()->AccessForceNotNull(
+      pg_attribute_all_cols_prm_[postgres::ATTTYPID_COL_OID]));  // TypeId is a uint8_t enum class, but in the schema
+                                                                 // it's INTEGER (32-bit)
   auto len_entry = reinterpret_cast<uint16_t *>(
       redo->Delta()->AccessForceNotNull(pg_attribute_all_cols_prm_[postgres::ATTLEN_COL_OID]));
   auto notnull_entry = reinterpret_cast<bool *>(
@@ -558,7 +559,7 @@ bool DatabaseCatalog::CreateColumn(const common::ManagedPointer<transaction::Tra
   const auto name_varlen = storage::StorageUtil::CreateVarlen(col.Name());
 
   *name_entry = name_varlen;
-  *type_entry = col.Type();
+  *type_entry = static_cast<uint32_t>(col.Type());
   // TODO(Amadou): Figure out what really goes here for varlen. Unclear if it's attribute size (16) or varlen length
   *len_entry = (col.Type() == type::TypeId::VARCHAR || col.Type() == type::TypeId::VARBINARY) ? col.MaxVarlenSize()
                                                                                               : col.AttrSize();
@@ -2457,13 +2458,15 @@ std::pair<void *, postgres::ClassKind> DatabaseCatalog::GetClassSchemaPtrKind(
 
 template <typename Column, typename ColOid>
 Column DatabaseCatalog::MakeColumn(storage::ProjectedRow *const pr, const storage::ProjectionMap &pr_map) {
-  auto col_oid = *reinterpret_cast<uint32_t *>(pr->AccessForceNotNull(pr_map.at(postgres::ATTNUM_COL_OID)));
-  auto col_name =
+  const auto col_oid = *reinterpret_cast<uint32_t *>(pr->AccessForceNotNull(pr_map.at(postgres::ATTNUM_COL_OID)));
+  const auto col_name =
       reinterpret_cast<storage::VarlenEntry *>(pr->AccessForceNotNull(pr_map.at(postgres::ATTNAME_COL_OID)));
-  auto col_type = *reinterpret_cast<type::TypeId *>(pr->AccessForceNotNull(pr_map.at(postgres::ATTTYPID_COL_OID)));
-  auto col_len = *reinterpret_cast<uint16_t *>(pr->AccessForceNotNull(pr_map.at(postgres::ATTLEN_COL_OID)));
-  auto col_null = !(*reinterpret_cast<bool *>(pr->AccessForceNotNull(pr_map.at(postgres::ATTNOTNULL_COL_OID))));
-  auto *col_expr = reinterpret_cast<storage::VarlenEntry *>(pr->AccessForceNotNull(pr_map.at(postgres::ADSRC_COL_OID)));
+  const auto col_type = static_cast<type::TypeId>(*reinterpret_cast<uint32_t *>(pr->AccessForceNotNull(pr_map.at(
+      postgres::ATTTYPID_COL_OID))));  // TypeId is a uint8_t enum class, but in the schema it's INTEGER (32-bit)
+  const auto col_len = *reinterpret_cast<uint16_t *>(pr->AccessForceNotNull(pr_map.at(postgres::ATTLEN_COL_OID)));
+  const auto col_null = !(*reinterpret_cast<bool *>(pr->AccessForceNotNull(pr_map.at(postgres::ATTNOTNULL_COL_OID))));
+  const auto *const col_expr =
+      reinterpret_cast<storage::VarlenEntry *>(pr->AccessForceNotNull(pr_map.at(postgres::ADSRC_COL_OID)));
 
   // TODO(WAN): Why are we deserializing expressions to make a catalog column? This is potentially busted.
   // Our JSON library is also not the most performant.
@@ -2473,7 +2476,7 @@ Column DatabaseCatalog::MakeColumn(storage::ProjectedRow *const pr, const storag
   auto expr = std::move(deserialized.result_);
   NOISEPAGE_ASSERT(deserialized.non_owned_exprs_.empty(), "Congrats, you get to refactor the catalog API.");
 
-  std::string name(reinterpret_cast<const char *>(col_name->Content()), col_name->Size());
+  const std::string name(reinterpret_cast<const char *>(col_name->Content()), col_name->Size());
   Column col = (col_type == type::TypeId::VARCHAR || col_type == type::TypeId::VARBINARY)
                    ? Column(name, col_type, col_len, col_null, *expr)
                    : Column(name, col_type, col_null, *expr);


### PR DESCRIPTION
#fix 1322. We were accessing the memory as a `type::TypeId` (uint8_t) but it's actually a uint32_t in the schema for pg_attribute.

```
noisepage=# create table t1(c1 int, c2 varchar, c3 int, c4 int, c5 timestamp);
CREATE TABLE
Time: 6.804 ms
noisepage=# SELECT attname,atttypid,nextcoloid FROM pg_attribute JOIN pg_class ON attrelid = reloid WHERE relname = 't1';
 attname | atttypid | nextcoloid 
---------+----------+------------
 c1      |        4 |          6
 c2      |        9 |          6
 c3      |        4 |          6
 c4      |        4 |          6
 c5      |        7 |          6
(5 rows)

Time: 13.904 ms
noisepage=# 

```