### PR TITLE
Fix SET parallel_execution which was not hooked up to execution.

### DIFF
--- a/src/execution/exec/execution_settings.cpp
+++ b/src/execution/exec/execution_settings.cpp
@@ -5,6 +5,7 @@ namespace noisepage::execution::exec {
 
 void ExecutionSettings::UpdateFromSettingsManager(common::ManagedPointer<settings::SettingsManager> settings) {
   if (settings) {
+    is_parallel_execution_enabled_ = settings->GetBool(settings::Param::parallel_execution);
     number_of_parallel_execution_threads_ = settings->GetInt(settings::Param::num_parallel_execution_threads);
     is_counters_enabled_ = settings->GetBool(settings::Param::counters_enable);
     is_pipeline_metrics_enabled_ = settings->GetBool(settings::Param::pipeline_metrics_enable);

--- a/src/include/common/constants.h
+++ b/src/include/common/constants.h
@@ -100,7 +100,7 @@ struct Constants {
   static constexpr const float ADAPTIVE_PRED_ORDER_SAMPLE_FREQ = 0.1;
 
   /**
-   * Flag indicating if parallel execution is supported.
+   * Flag indicating if parallel execution is enabled.
    */
   static constexpr const bool IS_PARALLEL_EXECUTION_ENABLED = true;
 


### PR DESCRIPTION
# Fix SET parallel_execution which was not hooked up to execution.

## Description

We had a `parallel_execution` setting described as "Whether parallel execution for scans is enabled" which does not work as described. This is because it wasn't connected to the `SettingsManager`.

I notice some CI pipelines are setting this flag -- specifically `tpcc_parallel_disabled` -- parallel scans should really be disabled for real now.

I don't know how to write tests for this. If we had EXPLAIN tpl, this would work:

```
CREATE TABLE foo (a int);
/** By default, parallel execution is on. */
EXPLAIN tpl SELECT * FROM foo;  /** Test that ParallelWork in output. */
SET parallel_execution TO false;
EXPLAIN tpl SELECT * FROM foo;  /** Test that SerialWork in output. */
SET parallel_execution TO true;
EXPLAIN tpl SELECT * FROM foo;  /** Test that ParallelWork in output. */
```

Right now, tested manually.

I don't think there's a point in running this through CI but we're not starved on resources right now, so we might as well.

@17zhangw 指詰め

Also thanks to @rohanaggarwal7997 for asking the question which opened up this rabbit hole! good catch