### PR TITLE
Add support for NOT IN.

### DIFF
--- a/script/testing/junit/traces/select.test
+++ b/script/testing/junit/traces/select.test
@@ -1245,6 +1245,12 @@ SELECT a FROM t WHERE a IN (2,3);
 3
 
 query I rowsort
+SELECT a FROM t WHERE a NOT IN (2,3);
+----
+1
+4
+
+query I rowsort
 SELECT a FROM t WHERE b IN ('a','nananananabanana');
 ----
 1
@@ -1255,6 +1261,13 @@ SELECT a FROM t WHERE b IN ('nananananabanana','catdogelephantfishgiraffehorse')
 ----
 2
 3
+
+query I rowsort
+SELECT a FROM t WHERE b NOT IN ('a');
+----
+2
+3
+4
 
 query I rowsort
 SELECT a FROM t WHERE b IN ('a','nananananabanana','catdogelephantfishgiraffehorse','d');


### PR DESCRIPTION
# Add support for NOT IN.

## Description

I thought it was weird that we didn't support IN. We do as of #1326, I think @gautam20197 you may have been running an old version.

Then I thought it was weird that IN and NOT IN returned exactly the same results.

```
noisepage=# select * from foo where a in (2);
 a 
---
 1
noisepage=# select * from foo where a not in (2);
 a 
---
 1
```

Then I realized I didn't remember ever seeing anything related to NOT IN in the codebase.
And that's because both IN and NOT IN comes in from the Postgres parser as a AEXPR_IN expression with almost everything identical -- you distinguish between the two by the name.

IN is called "=" and NOT IN is called "<>".

I expect this to pass CI, marking ready for review.