### PR TITLE
Fix UPDATE behavior when SET clauses reference other columns.

### DIFF
--- a/script/testing/junit/traces/update.test
+++ b/script/testing/junit/traces/update.test
@@ -211,3 +211,41 @@ SELECT a FROM update5;
 statement ok
 DROP TABLE update5
 
+statement ok
+CREATE TABLE update6 (a INT, b INT, c INT);
+
+statement ok
+INSERT INTO update6 VALUES (1, 2, 3);
+
+statement ok
+UPDATE update6 SET a = b + 1, b = a + 1, c = c;
+
+query III rowsort
+SELECT * FROM update6;
+----
+3
+2
+3
+
+statement ok
+UPDATE update6 SET b = a + 1, c = a + b, a = b + 1;
+
+query III rowsort
+SELECT * FROM update6;
+----
+3
+4
+5
+
+statement ok
+UPDATE update6 SET b = a + c;
+
+query III rowsort
+SELECT * FROM update6;
+----
+3
+8
+5
+
+statement ok
+DROP TABLE update6

--- a/src/execution/compiler/operator/update_translator.cpp
+++ b/src/execution/compiler/operator/update_translator.cpp
@@ -184,7 +184,8 @@ void UpdateTranslator::GenSetTablePR(FunctionBuilder *builder, WorkContext *cont
       const auto idx = table_pm_.find(oid)->second;
 
       ast::Expr *child_expr = provider->GetTableColumn(oid);
-      ast::Expr *set_pr = GetCodeGen()->PRSet(GetCodeGen()->MakeExpr(update_pr_), col.Type(), col.Nullable(), idx, child_expr, true);
+      ast::Expr *set_pr =
+          GetCodeGen()->PRSet(GetCodeGen()->MakeExpr(update_pr_), col.Type(), col.Nullable(), idx, child_expr, true);
       builder->Append(GetCodeGen()->MakeStmt(set_pr));
     }
   }

--- a/src/optimizer/plan_generator.cpp
+++ b/src/optimizer/plan_generator.cpp
@@ -900,8 +900,10 @@ void PlanGenerator::Visit(const Update *op) {
     if (update_col_offsets.find(col_id) != update_col_offsets.end())
       throw SYNTAX_EXCEPTION("Multiple assignments to same column");
 
+    // We need to EvaluateExpression since column value expressions in the update
+    // clause should refer to column values coming from the child.
     update_col_offsets.insert(col_id);
-    auto upd_value = update->GetUpdateValue()->Copy().release();
+    auto upd_value = parser::ExpressionUtil::EvaluateExpression(children_expr_map_, update->GetUpdateValue()).release();
     builder.AddSetClause(std::make_pair(col_id, common::ManagedPointer(upd_value)));
 
     update_column_names.insert(update->GetColumnName());

--- a/test/optimizer/tpcc_plan_delivery_test.cpp
+++ b/test/optimizer/tpcc_plan_delivery_test.cpp
@@ -301,8 +301,7 @@ TEST_F(TpccPlanDeliveryTests, UpdateCustomBalanceDeliveryCount) {
       EXPECT_EQ(update->GetSetClauses()[idx].first, update_oids[idx]);
       auto expr = update->GetSetClauses()[idx].second;
       EXPECT_EQ(expr->GetExpressionType(), parser::ExpressionType::OPERATOR_PLUS);
-      auto dve = expr->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
-      EXPECT_EQ(dve->GetColumnOid(), update_oids[idx]);
+      EXPECT_EQ(expr->GetChild(0)->GetExpressionType(), parser::ExpressionType::VALUE_TUPLE);
 
       auto cve = expr->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
       EXPECT_EQ(cve->Peek<int64_t>(), 1);

--- a/test/optimizer/tpcc_plan_neworder_test.cpp
+++ b/test/optimizer/tpcc_plan_neworder_test.cpp
@@ -53,8 +53,7 @@ TEST_F(TpccPlanNewOrderTests, UpdateDistrict) {
     EXPECT_EQ(update->GetSetClauses()[0].first, schema.GetColumn("d_next_o_id").Oid());
     auto expr = update->GetSetClauses()[0].second.CastManagedPointerTo<parser::OperatorExpression>();
     EXPECT_EQ(expr->GetExpressionType(), parser::ExpressionType::OPERATOR_PLUS);
-    auto dve = expr->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
-    EXPECT_EQ(dve->GetColumnOid(), schema.GetColumn("d_next_o_id").Oid());
+    EXPECT_EQ(expr->GetChild(0)->GetExpressionType(), parser::ExpressionType::VALUE_TUPLE);
     EXPECT_EQ(expr->GetChild(1)->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
     auto cve = expr->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
     EXPECT_EQ(cve->Peek<int64_t>(), 1);
@@ -141,8 +140,7 @@ TEST_F(TpccPlanNewOrderTests, UpdateStock) {
     {
       auto expr = update->GetSetClauses()[1].second.CastManagedPointerTo<parser::OperatorExpression>();
       EXPECT_EQ(expr->GetExpressionType(), parser::ExpressionType::OPERATOR_PLUS);
-      auto dve = expr->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
-      EXPECT_EQ(dve->GetColumnOid(), schema.GetColumn("s_ytd").Oid());
+      EXPECT_EQ(expr->GetChild(0)->GetExpressionType(), parser::ExpressionType::VALUE_TUPLE);
       EXPECT_EQ(expr->GetChild(1)->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
       auto cve = expr->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
       EXPECT_EQ(cve->Peek<int64_t>(), 1);
@@ -151,8 +149,7 @@ TEST_F(TpccPlanNewOrderTests, UpdateStock) {
     {
       auto expr = update->GetSetClauses()[2].second.CastManagedPointerTo<parser::OperatorExpression>();
       EXPECT_EQ(expr->GetExpressionType(), parser::ExpressionType::OPERATOR_PLUS);
-      auto dve = expr->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
-      EXPECT_EQ(dve->GetColumnOid(), schema.GetColumn("s_order_cnt").Oid());
+      EXPECT_EQ(expr->GetChild(0)->GetExpressionType(), parser::ExpressionType::VALUE_TUPLE);
       EXPECT_EQ(expr->GetChild(1)->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
       auto cve = expr->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
       EXPECT_EQ(cve->Peek<int64_t>(), 1);
@@ -161,8 +158,7 @@ TEST_F(TpccPlanNewOrderTests, UpdateStock) {
     {
       auto expr = update->GetSetClauses()[3].second.CastManagedPointerTo<parser::OperatorExpression>();
       EXPECT_EQ(expr->GetExpressionType(), parser::ExpressionType::OPERATOR_PLUS);
-      auto dve = expr->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
-      EXPECT_EQ(dve->GetColumnOid(), schema.GetColumn("s_remote_cnt").Oid());
+      EXPECT_EQ(expr->GetChild(0)->GetExpressionType(), parser::ExpressionType::VALUE_TUPLE);
       EXPECT_EQ(expr->GetChild(1)->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
       auto cve = expr->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
       EXPECT_EQ(cve->Peek<int64_t>(), 1);

--- a/test/optimizer/tpcc_plan_payment_test.cpp
+++ b/test/optimizer/tpcc_plan_payment_test.cpp
@@ -29,8 +29,7 @@ TEST_F(TpccPlanPaymentTests, UpdateWarehouse) {
     EXPECT_EQ(update->GetSetClauses()[0].first, schema.GetColumn("w_ytd").Oid());
     auto expr = update->GetSetClauses()[0].second;
     EXPECT_EQ(expr->GetExpressionType(), parser::ExpressionType::OPERATOR_PLUS);
-    auto dve = expr->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
-    EXPECT_EQ(dve->GetColumnOid(), schema.GetColumn("w_ytd").Oid());
+    EXPECT_EQ(expr->GetChild(0)->GetExpressionType(), parser::ExpressionType::VALUE_TUPLE);
 
     // Idx Scan, full output schema
     EXPECT_EQ(update->GetChildren().size(), 1);
@@ -85,8 +84,7 @@ TEST_F(TpccPlanPaymentTests, UpdateDistrict) {
     EXPECT_EQ(update->GetSetClauses()[0].first, schema.GetColumn("d_ytd").Oid());
     auto expr = update->GetSetClauses()[0].second;
     EXPECT_EQ(expr->GetExpressionType(), parser::ExpressionType::OPERATOR_PLUS);
-    auto dve = expr->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
-    EXPECT_EQ(dve->GetColumnOid(), schema.GetColumn("d_ytd").Oid());
+    EXPECT_EQ(expr->GetChild(0)->GetExpressionType(), parser::ExpressionType::VALUE_TUPLE);
 
     // Idx Scan, full output schema
     EXPECT_EQ(update->GetChildren().size(), 1);


### PR DESCRIPTION
## Description

Fix #1366, which indicates an error with respect to how set clauses are codegen'ed. This PR fixes the issue by codegen'ing the SET clauses to refer to the original tuple (i.e the tuple presented by the child plan node). For columns that are not updated by any SET clause, the value from the original tuple is copied into the new tuple.