### PR TITLE
Artifact Stats: Binary Size Collector #1365

### DIFF
--- a/script/testing/artifact_stats/README.md
+++ b/script/testing/artifact_stats/README.md
@@ -8,12 +8,12 @@ These metrics are non-operational measurements of the DBMS.
 - (coming soon) binary size
 
 ## How to add a metric
-1) Create a file for your collector in `/script/testing/artifact_stats/artifact_stats_collectors` 
+1) Create a file for your collector in `/script/testing/artifact_stats/collectors` 
 2) Create a sub class of the `BaseArtifactStatsCollector` class.
-    - See `artifact_stats_collectors/compile_time.py` for a simple example
-    - See `artifact_stats_collectors/memory_on_start.py` for an example that requires running the DBMS.
+    - See `collectors/compile_time.py` for a simple example
+    - See `collectors/memory_on_start.py` for an example that requires running the DBMS.
     - See [BaseArtifactStatsCollector](#BaseArtifactStatsCollector) for more details.
-3) Import the new collector in `/script/testing/artifact_stats/artifact_stats_collectors/__init__.py`
+3) Import the new collector in `/script/testing/artifact_stats/collectors/__init__.py`
 4) Test it out by running `/script/testing/artifact_stats/run_artifact_stats.py` and see if your metric has been added to the artifact stats.
 
 ## Script

--- a/script/testing/artifact_stats/collectors/__init__.py
+++ b/script/testing/artifact_stats/collectors/__init__.py
@@ -1,2 +1,3 @@
 from .compile_time import CompileTimeCollector
 from .memory_on_start import MemoryOnStartCollector
+from .binary_size import BinarySizeCollector

--- a/script/testing/artifact_stats/collectors/binary_size.py
+++ b/script/testing/artifact_stats/collectors/binary_size.py
@@ -1,0 +1,12 @@
+import os
+
+from artifact_stats.base_artifact_stats_collector import BaseArtifactStatsCollector
+from util.db_server import get_build_path
+
+class BinarySizeCollector(BaseArtifactStatsCollector):
+    
+    def run_collector(self):
+        """ Measure the size of the DBMS binary """        
+        binary_path = get_build_path(build_type='release')
+        self.metrics['binary_size'] = os.path.getsize(binary_path)
+        return 0


### PR DESCRIPTION
# Binary Size Collector

## Description
New collector to keep track of the size of our binary in the nightly builds. This is to make sure that we don't balloon up the size of our binary over time. This resolves #1365.

https://youtu.be/X_p6HLNNfl0