### PR TITLE
Add SanctionedSharedPtr and refactor loggers to use it.

### DIFF
--- a/src/include/common/sanctioned_shared_pointer.h
+++ b/src/include/common/sanctioned_shared_pointer.h
@@ -34,6 +34,7 @@ namespace noisepage::common {
 template <class Underlying>
 class SanctionedSharedPtr {
  public:
+  /** A shared pointer. Watch out! */
   typedef std::shared_ptr<Underlying> Ptr;  // NOLINT
 };
 }  // namespace noisepage::common

--- a/src/include/common/sanctioned_shared_pointer.h
+++ b/src/include/common/sanctioned_shared_pointer.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <memory>
+
+namespace noisepage::common {
+
+/**
+ * A SanctionedSharedPtr is literally a shared pointer in every possible way.
+ *
+ * SanctionedSharedPtr exists to declare at a code-level that
+ *   1. I have thought deeply about ownership:
+ *      - Who owns the pointee?
+ *      - When is the pointee created?
+ *      - When should the pointee be freed?
+ *   2. I have thought deeply about memory management:
+ *      - I am not creating a shared pointer to "fix a memory leak" by hiding the leak under the carpet.
+ *      - I am creating a shared pointer because I genuinely believe that two or more objects need ownership of the
+ *        memory at the same instance in time.
+ *      - I certify that there are no cycles of shared pointers.
+ *   3. I am convinced that there is literally no other possible way to achieve my task except with a shared pointer.
+ *
+ * If and only if you can sign your name to the above points, then feel free to use the SanctionedSharedPtr.
+ * Please include the answers to the above questions where you include the SanctionedSharedPtr or in a README.
+ * Otherwise, please open a discussion for your issue.
+ *
+ * If you are using a SanctionedSharedPtr as a temporary hack, please fill in the above questions as far as is
+ * possible now and open a GitHub issue to keep track of it in the future.
+ *
+ * If you are reviewing code, please do not let anything merge using either shared_ptr or SanctionedSharedPtr
+ * without pressing hard on the above points. This is to prevent NoisePage from going the way of Peloton.
+ *
+ * @tparam Underlying The underlying type being wrapped by the shared pointer.
+ */
+template <class Underlying>
+class SanctionedSharedPtr {
+ public:
+  typedef std::shared_ptr<Underlying> Ptr;  // NOLINT
+};
+}  // namespace noisepage::common

--- a/src/include/loggers/README.md
+++ b/src/include/loggers/README.md
@@ -1,0 +1,26 @@
+## SanctionedSharedPtr usage in loggers.
+
+All of the `spdlog`-related `subcomponent_logger` loggers are a `SanctionedSharedPtr` instance to various sinks,
+ranging from an application-wide `spdlog::sinks::stdout_sink_mt` to custom `spdlog::logger` instances per class.
+
+Ownership:
+1. The shared pointers are owned by the `spdlog` third-party library.
+2. The shared pointers are created in the `InitSubcomponentLogger()` functions.
+3. The shared pointers are freed when `LoggersUtil::ShutDown()` is called.  
+
+Memory management:
+1. There are no memory leaks being hidden by making the shared pointers.
+2. The shared pointers are necessary because `spdlog` has a global registry that stores and owns all the loggers.
+   The registry hands shared pointers back out. This is a small lie, see note 1 below.
+3. The shared pointers are only initialized in `subcomponent_logger.cpp::InitSubcomponentLogger()`.
+   All functions merely access the shared pointers to invoke `spdlog` methods.
+   Therefore no cycles of shared pointers are possible. 
+
+Notes:
+1. For some reason, we do not use `spdlog`'s API for logger creation. Instead, we create loggers manually.
+   Normally, the process is: "hey `spdlog`, give me a logger" "sure, here's a shared pointer to it", where
+   `spdlog` handles the creation and registration of (optionally thread-safe) loggers.
+   Instead, we do: "we're manually creating a `spdlog` logger. we're manually registering a `spdlog` logger."
+   The `spdlog` registry is only used for flushing every logger with `spdlog::flush_every`.
+2. I am not convinced that our manual creation of `spdlog::logger` instances will produce thread-safe logging,
+   but since we haven't seen issues so far, I guess it is fine for now.  

--- a/src/include/loggers/binder_logger.h
+++ b/src/include/loggers/binder_logger.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <memory>
-
 #include "loggers/loggers_util.h"
 
 #ifdef NOISEPAGE_USE_LOGGING
 
 namespace noisepage::binder {
-extern std::shared_ptr<spdlog::logger> binder_logger;  // NOLINT
+extern common::SanctionedSharedPtr<spdlog::logger>::Ptr binder_logger;
 
 void InitBinderLogger();
 }  // namespace noisepage::binder

--- a/src/include/loggers/catalog_logger.h
+++ b/src/include/loggers/catalog_logger.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <memory>
-
 #include "loggers/loggers_util.h"
 
 #ifdef NOISEPAGE_USE_LOGGING
 
 namespace noisepage::catalog {
-extern std::shared_ptr<spdlog::logger> catalog_logger;  // NOLINT
+extern common::SanctionedSharedPtr<spdlog::logger>::Ptr catalog_logger;
 
 void InitCatalogLogger();
 }  // namespace noisepage::catalog

--- a/src/include/loggers/common_logger.h
+++ b/src/include/loggers/common_logger.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <memory>
-
 #include "loggers/loggers_util.h"
 
 #ifdef NOISEPAGE_USE_LOGGING
 
 namespace noisepage::common {
-extern std::shared_ptr<spdlog::logger> common_logger;  // NOLINT
+extern common::SanctionedSharedPtr<spdlog::logger>::Ptr common_logger;
 
 void InitCommonLogger();
 }  // namespace noisepage::common

--- a/src/include/loggers/execution_logger.h
+++ b/src/include/loggers/execution_logger.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <memory>
-
 #include "loggers/loggers_util.h"
 
 #ifdef NOISEPAGE_USE_LOGGING
 
 namespace noisepage::execution {
-extern std::shared_ptr<spdlog::logger> execution_logger;  // NOLINT
+extern common::SanctionedSharedPtr<spdlog::logger>::Ptr execution_logger;
 
 void InitExecutionLogger();
 }  // namespace noisepage::execution

--- a/src/include/loggers/index_logger.h
+++ b/src/include/loggers/index_logger.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <memory>
-
 #include "loggers/loggers_util.h"
 
 #ifdef NOISEPAGE_USE_LOGGING
 
 namespace noisepage::storage {
-extern std::shared_ptr<spdlog::logger> index_logger;  // NOLINT
+extern common::SanctionedSharedPtr<spdlog::logger>::Ptr index_logger;
 
 void InitIndexLogger();
 }  // namespace noisepage::storage

--- a/src/include/loggers/loggers_util.h
+++ b/src/include/loggers/loggers_util.h
@@ -1,16 +1,15 @@
 #pragma once
 
-#include <memory>
-
 // flush the debug logs, every <n> seconds
 #define DEBUG_LOG_FLUSH_INTERVAL 3
 
+#include "common/sanctioned_shared_pointer.h"
 #include "spdlog/fmt/ostr.h"
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/sinks/stdout_sinks.h"
 #include "spdlog/spdlog.h"
 
-extern std::shared_ptr<spdlog::sinks::stdout_sink_mt> default_sink;  // NOLINT
+extern noisepage::common::SanctionedSharedPtr<spdlog::sinks::stdout_sink_mt>::Ptr default_sink;
 
 namespace noisepage {
 

--- a/src/include/loggers/messenger_logger.h
+++ b/src/include/loggers/messenger_logger.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <memory>
-
 #include "loggers/loggers_util.h"
 
 #ifdef NOISEPAGE_USE_LOGGING
 
 namespace noisepage::messenger {
-extern std::shared_ptr<spdlog::logger> messenger_logger;  // NOLINT
+extern common::SanctionedSharedPtr<spdlog::logger>::Ptr messenger_logger;
 
 void InitMessengerLogger();
 }  // namespace noisepage::messenger

--- a/src/include/loggers/metrics_logger.h
+++ b/src/include/loggers/metrics_logger.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <memory>
-
 #include "loggers/loggers_util.h"
 
 #ifdef NOISEPAGE_USE_LOGGING
 
 namespace noisepage::metrics {
-extern std::shared_ptr<spdlog::logger> metrics_logger;  // NOLINT
+extern common::SanctionedSharedPtr<spdlog::logger>::Ptr metrics_logger;
 
 void InitMetricsLogger();
 }  // namespace noisepage::metrics

--- a/src/include/loggers/network_logger.h
+++ b/src/include/loggers/network_logger.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <memory>
-
 #include "loggers/loggers_util.h"
 
 #ifdef NOISEPAGE_USE_LOGGING
 
 namespace noisepage::network {
-extern std::shared_ptr<spdlog::logger> network_logger;  // NOLINT
+extern common::SanctionedSharedPtr<spdlog::logger>::Ptr network_logger;
 
 void InitNetworkLogger();
 }  // namespace noisepage::network

--- a/src/include/loggers/optimizer_logger.h
+++ b/src/include/loggers/optimizer_logger.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <memory>
-
 #include "loggers/loggers_util.h"
 
 #ifdef NOISEPAGE_USE_LOGGING
 
 namespace noisepage::optimizer {
-extern std::shared_ptr<spdlog::logger> optimizer_logger;  // NOLINT
+extern common::SanctionedSharedPtr<spdlog::logger>::Ptr optimizer_logger;
 
 void InitOptimizerLogger();
 }  // namespace noisepage::optimizer

--- a/src/include/loggers/parser_logger.h
+++ b/src/include/loggers/parser_logger.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <memory>
-
 #include "loggers/loggers_util.h"
 
 #ifdef NOISEPAGE_USE_LOGGING
 
 namespace noisepage::parser {
-extern std::shared_ptr<spdlog::logger> parser_logger;  // NOLINT
+extern common::SanctionedSharedPtr<spdlog::logger>::Ptr parser_logger;
 
 void InitParserLogger();
 }  // namespace noisepage::parser

--- a/src/include/loggers/settings_logger.h
+++ b/src/include/loggers/settings_logger.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <memory>
-
 #include "loggers/loggers_util.h"
 
 #ifdef NOISEPAGE_USE_LOGGING
 
 namespace noisepage::settings {
-extern std::shared_ptr<spdlog::logger> settings_logger;  // NOLINT
+extern common::SanctionedSharedPtr<spdlog::logger>::Ptr settings_logger;
 
 void InitSettingsLogger();
 }  // namespace noisepage::settings

--- a/src/include/loggers/storage_logger.h
+++ b/src/include/loggers/storage_logger.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <memory>
-
 #include "loggers/loggers_util.h"
 
 #ifdef NOISEPAGE_USE_LOGGING
 
 namespace noisepage::storage {
-extern std::shared_ptr<spdlog::logger> storage_logger;  // NOLINT
+extern common::SanctionedSharedPtr<spdlog::logger>::Ptr storage_logger;
 
 void InitStorageLogger();
 }  // namespace noisepage::storage

--- a/src/include/loggers/transaction_logger.h
+++ b/src/include/loggers/transaction_logger.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <memory>
-
 #include "loggers/loggers_util.h"
 
 #ifdef NOISEPAGE_USE_LOGGING
 
 namespace noisepage::transaction {
-extern std::shared_ptr<spdlog::logger> transaction_logger;  // NOLINT
+extern common::SanctionedSharedPtr<spdlog::logger>::Ptr transaction_logger;
 
 void InitTransactionLogger();
 }  // namespace noisepage::transaction

--- a/src/loggers/binder_logger.cpp
+++ b/src/loggers/binder_logger.cpp
@@ -1,10 +1,8 @@
 #include "loggers/binder_logger.h"
 
-#include <memory>
-
 namespace noisepage::binder {
 #ifdef NOISEPAGE_USE_LOGGING
-std::shared_ptr<spdlog::logger> binder_logger = nullptr;  // NOLINT
+common::SanctionedSharedPtr<spdlog::logger>::Ptr binder_logger = nullptr;
 
 void InitBinderLogger() {
   if (binder_logger == nullptr) {

--- a/src/loggers/catalog_logger.cpp
+++ b/src/loggers/catalog_logger.cpp
@@ -1,10 +1,8 @@
 #include "loggers/catalog_logger.h"
 
-#include <memory>
-
 namespace noisepage::catalog {
 #ifdef NOISEPAGE_USE_LOGGING
-std::shared_ptr<spdlog::logger> catalog_logger = nullptr;  // NOLINT
+common::SanctionedSharedPtr<spdlog::logger>::Ptr catalog_logger = nullptr;
 
 void InitCatalogLogger() {
   if (catalog_logger == nullptr) {

--- a/src/loggers/common_logger.cpp
+++ b/src/loggers/common_logger.cpp
@@ -1,10 +1,8 @@
 #include "loggers/common_logger.h"
 
-#include <memory>
-
 namespace noisepage::common {
 #ifdef NOISEPAGE_USE_LOGGING
-std::shared_ptr<spdlog::logger> common_logger = nullptr;  // NOLINT
+common::SanctionedSharedPtr<spdlog::logger>::Ptr common_logger = nullptr;
 
 void InitCommonLogger() {
   if (common_logger == nullptr) {

--- a/src/loggers/execution_logger.cpp
+++ b/src/loggers/execution_logger.cpp
@@ -1,10 +1,8 @@
 #include "loggers/execution_logger.h"
 
-#include <memory>
-
 namespace noisepage::execution {
 #ifdef NOISEPAGE_USE_LOGGING
-std::shared_ptr<spdlog::logger> execution_logger = nullptr;  // NOLINT
+common::SanctionedSharedPtr<spdlog::logger>::Ptr execution_logger = nullptr;
 
 void InitExecutionLogger() {
   if (execution_logger == nullptr) {

--- a/src/loggers/index_logger.cpp
+++ b/src/loggers/index_logger.cpp
@@ -1,10 +1,8 @@
 #include "loggers/index_logger.h"
 
-#include <memory>
-
 namespace noisepage::storage {
 #ifdef NOISEPAGE_USE_LOGGING
-std::shared_ptr<spdlog::logger> index_logger = nullptr;  // NOLINT
+common::SanctionedSharedPtr<spdlog::logger>::Ptr index_logger = nullptr;
 
 void InitIndexLogger() {
   if (index_logger == nullptr) {

--- a/src/loggers/loggers_util.cpp
+++ b/src/loggers/loggers_util.cpp
@@ -18,7 +18,7 @@
 #include "loggers/transaction_logger.h"
 
 #ifdef NOISEPAGE_USE_LOGGING
-std::shared_ptr<spdlog::sinks::stdout_sink_mt> default_sink = nullptr;  // NOLINT
+noisepage::common::SanctionedSharedPtr<spdlog::sinks::stdout_sink_mt>::Ptr default_sink = nullptr;
 #endif
 
 namespace noisepage {

--- a/src/loggers/messenger_logger.cpp
+++ b/src/loggers/messenger_logger.cpp
@@ -4,7 +4,7 @@
 
 namespace noisepage::messenger {
 #ifdef NOISEPAGE_USE_LOGGING
-std::shared_ptr<spdlog::logger> messenger_logger = nullptr;  // NOLINT
+common::SanctionedSharedPtr<spdlog::logger>::Ptr messenger_logger = nullptr;
 
 void InitMessengerLogger() {
   if (messenger_logger == nullptr) {

--- a/src/loggers/metrics_logger.cpp
+++ b/src/loggers/metrics_logger.cpp
@@ -1,10 +1,8 @@
 #include "loggers/metrics_logger.h"
 
-#include <memory>
-
 namespace noisepage::metrics {
 #ifdef NOISEPAGE_USE_LOGGING
-std::shared_ptr<spdlog::logger> metrics_logger = nullptr;  // NOLINT
+common::SanctionedSharedPtr<spdlog::logger>::Ptr metrics_logger = nullptr;
 
 void InitMetricsLogger() {
   if (metrics_logger == nullptr) {

--- a/src/loggers/network_logger.cpp
+++ b/src/loggers/network_logger.cpp
@@ -1,10 +1,8 @@
 #include "loggers/network_logger.h"
 
-#include <memory>
-
 namespace noisepage::network {
 #ifdef NOISEPAGE_USE_LOGGING
-std::shared_ptr<spdlog::logger> network_logger = nullptr;  // NOLINT
+common::SanctionedSharedPtr<spdlog::logger>::Ptr network_logger = nullptr;
 
 void InitNetworkLogger() {
   if (network_logger == nullptr) {

--- a/src/loggers/optimizer_logger.cpp
+++ b/src/loggers/optimizer_logger.cpp
@@ -1,10 +1,8 @@
 #include "loggers/optimizer_logger.h"
 
-#include <memory>
-
 namespace noisepage::optimizer {
 #ifdef NOISEPAGE_USE_LOGGING
-std::shared_ptr<spdlog::logger> optimizer_logger = nullptr;  // NOLINT
+common::SanctionedSharedPtr<spdlog::logger>::Ptr optimizer_logger = nullptr;
 
 void InitOptimizerLogger() {
   if (optimizer_logger == nullptr) {

--- a/src/loggers/parser_logger.cpp
+++ b/src/loggers/parser_logger.cpp
@@ -1,10 +1,8 @@
 #include "loggers/parser_logger.h"
 
-#include <memory>
-
 namespace noisepage::parser {
 #ifdef NOISEPAGE_USE_LOGGING
-std::shared_ptr<spdlog::logger> parser_logger = nullptr;  // NOLINT
+common::SanctionedSharedPtr<spdlog::logger>::Ptr parser_logger = nullptr;
 
 void InitParserLogger() {
   if (parser_logger == nullptr) {

--- a/src/loggers/settings_logger.cpp
+++ b/src/loggers/settings_logger.cpp
@@ -1,10 +1,8 @@
 #include "loggers/settings_logger.h"
 
-#include <memory>
-
 namespace noisepage::settings {
 #ifdef NOISEPAGE_USE_LOGGING
-std::shared_ptr<spdlog::logger> settings_logger = nullptr;  // NOLINT
+common::SanctionedSharedPtr<spdlog::logger>::Ptr settings_logger = nullptr;
 
 void InitSettingsLogger() {
   if (settings_logger == nullptr) {

--- a/src/loggers/storage_logger.cpp
+++ b/src/loggers/storage_logger.cpp
@@ -1,10 +1,8 @@
 #include "loggers/storage_logger.h"
 
-#include <memory>
-
 namespace noisepage::storage {
 #ifdef NOISEPAGE_USE_LOGGING
-std::shared_ptr<spdlog::logger> storage_logger = nullptr;  // NOLINT
+common::SanctionedSharedPtr<spdlog::logger>::Ptr storage_logger = nullptr;
 
 void InitStorageLogger() {
   if (storage_logger == nullptr) {

--- a/src/loggers/transaction_logger.cpp
+++ b/src/loggers/transaction_logger.cpp
@@ -1,10 +1,8 @@
 #include "loggers/transaction_logger.h"
 
-#include <memory>
-
 namespace noisepage::transaction {
 #ifdef NOISEPAGE_USE_LOGGING
-std::shared_ptr<spdlog::logger> transaction_logger = nullptr;  // NOLINT
+common::SanctionedSharedPtr<spdlog::logger>::Ptr transaction_logger = nullptr;
 
 void InitTransactionLogger() {
   if (transaction_logger == nullptr) {

--- a/src/optimizer/plan_generator.cpp
+++ b/src/optimizer/plan_generator.cpp
@@ -109,7 +109,6 @@ void PlanGenerator::CorrectOutputPlanWithProjection() {
     }
   }
 
-  // We don't actually want shared_ptr but pending another PR
   auto schema = std::make_unique<planner::OutputSchema>(std::move(columns));
   if (output_plan_) {
     plan_meta_data_->AddPlanNodeMetaData(output_plan_->GetPlanNodeId(), plan_node_meta_data_);

--- a/test/optimizer/logical_operator_test.cpp
+++ b/test/optimizer/logical_operator_test.cpp
@@ -1260,7 +1260,7 @@ TEST(OperatorTests, LogicalAggregateAndGroupByTest) {
   parser::AbstractExpression *expr_b_7 =
       new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
-  // columns: vector of shared_ptr of AbstractExpression
+  // columns: vector of ManagedPointer of AbstractExpression
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
   auto x_3 = common::ManagedPointer<parser::AbstractExpression>(expr_b_3);

--- a/test/optimizer/physical_operator_test.cpp
+++ b/test/optimizer/physical_operator_test.cpp
@@ -1298,7 +1298,7 @@ TEST(OperatorTests, HashGroupByTest) {
   parser::AbstractExpression *expr_b_7 =
       new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
-  // columns: vector of shared_ptr of AbstractExpression
+  // columns: vector of ManagedPointer of AbstractExpression
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
   auto x_3 = common::ManagedPointer<parser::AbstractExpression>(expr_b_3);
@@ -1403,7 +1403,7 @@ TEST(OperatorTests, SortGroupByTest) {
   parser::AbstractExpression *expr_b_7 =
       new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
-  // columns: vector of shared_ptr of AbstractExpression
+  // columns: vector of ManagedPointer of AbstractExpression
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
   auto x_3 = common::ManagedPointer<parser::AbstractExpression>(expr_b_3);


### PR DESCRIPTION
# Heading

Add SanctionedSharedPtr and refactor loggers to use it with documentation to justify the choice.

## Description

In team meeting today, we concluded that the compilation manager would want to use `shared_ptr` (possibly as a stopgap hack).

Rather than continue to NOLINT every declaration, this is a type-level way of declaring the following (taken from the class documentation of `SanctionedSharedPtr`):

```
 * SanctionedSharedPtr exists to declare at a code-level that
 *   1. I have thought deeply about ownership:
 *      - Who owns the pointee?
 *      - When is the pointee created?
 *      - When should the pointee be freed?
 *   2. I have thought deeply about memory management:
 *      - I am not creating a shared pointer to "fix a memory leak" by hiding the leak under the carpet.
 *      - I am creating a shared pointer because I genuinely believe that two or more objects need ownership of the
 *        memory at the same instance in time.
 *      - I certify that there are no cycles of shared pointers.
 *   3. I am convinced that there is literally no other possible way to achieve my task except with a shared pointer.
 *
 * If and only if you can sign your name to the above points, then feel free to use the SanctionedSharedPtr.
 * Please include the answers to the above questions where you include the SanctionedSharedPtr or in a README.
 * Otherwise, please open a discussion for your issue.
 *
 * If you are using a SanctionedSharedPtr as a temporary hack, please fill in the above questions as far as is
 * possible now and open a GitHub issue to keep track of it in the future.
 *
 * If you are reviewing code, please do not let anything merge using either shared_ptr or SanctionedSharedPtr
 * without pressing hard on the above points. This is to prevent NoisePage from going the way of Peloton.
```

This PR:
- Converts the existing `shared_ptr` usages (just the loggers) to be `SanctionedSharedPtr`;
- Documents why the logger pointers are OK;
- Nukes some dead comments.

This PR does **not** do anything beyond aliasing the `shared_ptr` type. Closer to a documentation refactor than a logic refactor. Ultimately we still rely on code review to prevent people from `// NOLINT`ing their problems away.