### PR TITLE
Implement a hacky version of SHOW for transaction_isolation.

### DIFF
--- a/src/include/binder/sql_node_visitor.h
+++ b/src/include/binder/sql_node_visitor.h
@@ -21,6 +21,7 @@ class UpdateStatement;
 class CopyStatement;
 class AnalyzeStatement;
 class VariableSetStatement;
+class VariableShowStatement;
 class JoinDefinition;
 class TableRef;
 
@@ -140,6 +141,12 @@ class SqlNodeVisitor {
    * @param node node to be visited
    */
   virtual void Visit(common::ManagedPointer<parser::VariableSetStatement> node) {}
+
+  /**
+   * Visitor pattern for VariableShowStatement
+   * @param node node to be visited
+   */
+  virtual void Visit(common::ManagedPointer<parser::VariableShowStatement> node) {}
 
   /**
    * Visitor pattern for AggregateExpression

--- a/src/include/network/network_defs.h
+++ b/src/include/network/network_defs.h
@@ -117,6 +117,7 @@ enum class QueryType : uint8_t {
   QUERY_DROP_VIEW,
   // Misc (non-transactional)
   QUERY_SET,
+  QUERY_SHOW,
   // end of what we support in the traffic cop right now
   QUERY_RENAME,
   QUERY_ALTER,
@@ -127,7 +128,6 @@ enum class QueryType : uint8_t {
   // Misc
   QUERY_COPY,
   QUERY_ANALYZE,
-  QUERY_SHOW,
   QUERY_OTHER,
   QUERY_EXPLAIN,
   QUERY_INVALID

--- a/src/include/network/network_util.h
+++ b/src/include/network/network_util.h
@@ -14,8 +14,18 @@ class NetworkUtil {
   /**
    * @param type query type from the parser
    * @return true if a BEGIN, COMMIT, or ABORT. Order of QueryType enum matters here.
+   *
+   * @warning This logic relies on ordering of values in the enum's definition and is documented there as well.
    */
   static bool TransactionalQueryType(const QueryType type) { return type <= QueryType::QUERY_ROLLBACK; }
+
+  /**
+   * @param type query type from the parser
+   * @return true if the statement should NOT be bound nor optimized.
+   */
+  static bool SkipBindQueryType(const QueryType type) {
+    return type == QueryType::QUERY_SET || type == QueryType::QUERY_SHOW;
+  }
 
   /**
    * @param type query type from the parser
@@ -53,13 +63,15 @@ class NetworkUtil {
    * @param type query type from the parser
    * @return true for statement types that aren't run in a txn, currently SET but other internal queries might be added
    */
-  static bool NonTransactionalQueryType(const QueryType type) { return type == QueryType::QUERY_SET; }
+  static bool NonTransactionalQueryType(const QueryType type) {
+    return type == QueryType::QUERY_SET || type == QueryType::QUERY_SHOW;
+  }
 
   /**
    * @param type query type from the parser
    * @return true if a query that is current not implemented in the system. Order of QueryType enum matters here.
    */
-  static bool UnsupportedQueryType(const QueryType type) { return type > QueryType::QUERY_SET; }
+  static bool UnsupportedQueryType(const QueryType type) { return type > QueryType::QUERY_SHOW; }
 };
 
 }  // namespace noisepage::network

--- a/src/include/parser/parser_defs.h
+++ b/src/include/parser/parser_defs.h
@@ -25,7 +25,8 @@ enum class StatementType {
   ANALYZE = 15,
   VARIABLE_SET = 16,
   CREATE_FUNC = 17,
-  EXPLAIN = 18
+  EXPLAIN = 18,
+  VARIABLE_SHOW = 19,
 };
 
 enum class FKConstrMatchType { SIMPLE = 0, PARTIAL = 1, FULL = 2 };

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -200,6 +200,9 @@ class PostgresParser {
 
   // VARIABLE SET statements
   static std::unique_ptr<VariableSetStatement> VariableSetTransform(ParseResult *parse_result, VariableSetStmt *root);
+  // VARIABLE SHOW statements
+  static std::unique_ptr<VariableShowStatement> VariableShowTransform(ParseResult *parse_result,
+                                                                      VariableShowStmt *stmt);
 
   /**
    * Converts the target of an update clause, i.e. one or more column = expression

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -202,7 +202,7 @@ class PostgresParser {
   static std::unique_ptr<VariableSetStatement> VariableSetTransform(ParseResult *parse_result, VariableSetStmt *root);
   // VARIABLE SHOW statements
   static std::unique_ptr<VariableShowStatement> VariableShowTransform(ParseResult *parse_result,
-                                                                      VariableShowStmt *stmt);
+                                                                      VariableShowStmt *root);
 
   /**
    * Converts the target of an update clause, i.e. one or more column = expression

--- a/src/include/parser/statements.h
+++ b/src/include/parser/statements.h
@@ -16,3 +16,4 @@
 #include "parser/transaction_statement.h"
 #include "parser/update_statement.h"
 #include "parser/variable_set_statement.h"
+#include "parser/variable_show_statement.h"

--- a/src/include/parser/variable_show_statement.h
+++ b/src/include/parser/variable_show_statement.h
@@ -14,6 +14,9 @@ namespace parser {
  */
 class VariableShowStatement : public SQLStatement {
  public:
+  /**
+   * @param name The name of the parameter to show.
+   */
   VariableShowStatement(std::string name) : SQLStatement(StatementType::VARIABLE_SHOW), name_(name) {}
 
   ~VariableShowStatement() override = default;

--- a/src/include/parser/variable_show_statement.h
+++ b/src/include/parser/variable_show_statement.h
@@ -25,7 +25,7 @@ class VariableShowStatement : public SQLStatement {
   void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override { v->Visit(common::ManagedPointer(this)); }
 
   /** @return The name of the variable to show. */
-  std::string GetName() { return name_; }
+  const std::string &GetName() { return name_; }
 
  private:
   const std::string name_;

--- a/src/include/parser/variable_show_statement.h
+++ b/src/include/parser/variable_show_statement.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "binder/sql_node_visitor.h"
+#include "parser/sql_statement.h"
+
+namespace noisepage {
+namespace parser {
+/**
+ * VariableShowStatement represents SQL statements of the form "SHOW ...".
+ */
+class VariableShowStatement : public SQLStatement {
+ public:
+  VariableShowStatement(std::string name) : SQLStatement(StatementType::VARIABLE_SHOW), name_(name) {}
+
+  ~VariableShowStatement() override = default;
+
+  void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override { v->Visit(common::ManagedPointer(this)); }
+
+  /** @return The name of the variable to show. */
+  std::string GetName() { return name_; }
+
+ private:
+  const std::string name_;
+};
+}  // namespace parser
+}  // namespace noisepage

--- a/src/include/parser/variable_show_statement.h
+++ b/src/include/parser/variable_show_statement.h
@@ -17,7 +17,8 @@ class VariableShowStatement : public SQLStatement {
   /**
    * @param name The name of the parameter to show.
    */
-  VariableShowStatement(std::string name) : SQLStatement(StatementType::VARIABLE_SHOW), name_(name) {}
+  explicit VariableShowStatement(std::string name)
+      : SQLStatement(StatementType::VARIABLE_SHOW), name_(std::move(name)) {}
 
   ~VariableShowStatement() override = default;
 

--- a/src/include/traffic_cop/traffic_cop.h
+++ b/src/include/traffic_cop/traffic_cop.h
@@ -179,6 +179,17 @@ class TrafficCop {
                                        common::ManagedPointer<network::Statement> statement) const;
 
   /**
+   * Contains the logic to handle SHOW statements.
+   * @param connection_ctx The context to be used to access the internal txn.
+   * @param statement The show statement to be executed.
+   * @param out Packet writer for writing results.
+   * @return The result of the operation.
+   */
+  TrafficCopResult ExecuteShowStatement(common::ManagedPointer<network::ConnectionContext> connection_ctx,
+                                        common::ManagedPointer<network::Statement> statement,
+                                        common::ManagedPointer<network::PostgresPacketWriter> out) const;
+
+  /**
    * Contains the logic to reason about CREATE execution.
    * @param connection_ctx context to be used to access the internal txn
    * @param physical_plan to be executed

--- a/src/include/traffic_cop/traffic_cop.h
+++ b/src/include/traffic_cop/traffic_cop.h
@@ -179,7 +179,7 @@ class TrafficCop {
                                        common::ManagedPointer<network::Statement> statement) const;
 
   /**
-   * Contains the logic to handle SHOW statements.
+   * Contains the logic to handle SHOW statements. Currently a hack to only support SHOW TRANSACTION ISOLATION LEVEL
    * @param connection_ctx The context to be used to access the internal txn.
    * @param statement The show statement to be executed.
    * @param out Packet writer for writing results.

--- a/src/network/postgres/postgres_packet_writer.cpp
+++ b/src/network/postgres/postgres_packet_writer.cpp
@@ -161,6 +161,9 @@ void PostgresPacketWriter::WriteCommandComplete(const QueryType query_type, cons
     case QueryType::QUERY_SET:
       WriteCommandComplete("SET");
       break;
+    case QueryType::QUERY_SHOW:
+      WriteCommandComplete("SHOW");
+      break;
     default:
       WriteCommandComplete("This QueryType needs a completion message!");
       break;

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -155,6 +155,10 @@ std::unique_ptr<SQLStatement> PostgresParser::NodeTransform(ParseResult *parse_r
       result = VariableSetTransform(parse_result, reinterpret_cast<VariableSetStmt *>(node));
       break;
     }
+    case T_VariableShowStmt: {
+      result = VariableShowTransform(parse_result, reinterpret_cast<VariableShowStmt *>(node));
+      break;
+    }
     case T_ViewStmt: {
       result = CreateViewTransform(parse_result, reinterpret_cast<ViewStmt *>(node));
       break;
@@ -2054,6 +2058,14 @@ std::unique_ptr<VariableSetStatement> PostgresParser::VariableSetTransform(Parse
   }
   bool is_set_default = root->kind_ == VariableSetKind::VAR_SET_DEFAULT;
   auto result = std::make_unique<VariableSetStatement>(name, std::move(values), is_set_default);
+  return result;
+}
+
+// Postgres.VariableShowStmt -> noisepage.VariableShowStatement
+std::unique_ptr<VariableShowStatement> PostgresParser::VariableShowTransform(ParseResult *parse_result,
+                                                                             VariableShowStmt *root) {
+  std::string name = root->name_;
+  auto result = std::make_unique<VariableShowStatement>(name);
   return result;
 }
 

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -180,18 +180,16 @@ TrafficCopResult TrafficCop::ExecuteShowStatement(
 
   const auto &show_stmt = statement->RootStatement().CastManagedPointerTo<parser::VariableShowStatement>();
 
-  std::cout << show_stmt->GetName() << std::endl;
   NOISEPAGE_ASSERT(show_stmt->GetName() == "transaction_isolation", "Nothing else is supported right now.");
 
   auto expr = std::make_unique<parser::ConstantValueExpression>(type::TypeId::VARCHAR);
   expr->SetAlias("transaction_isolation");
   std::vector<noisepage::planner::OutputSchema::Column> cols;
   cols.emplace_back("transaction_isolation", type::TypeId::VARCHAR, std::move(expr));
-  std::vector<network::FieldFormat> format = {network::FieldFormat::text};
   execution::sql::StringVal dummy_result("snapshot isolation");
 
-  out->WriteRowDescription(cols, format);
-  out->WriteDataRow(reinterpret_cast<const byte *>(&dummy_result), cols, format);
+  out->WriteRowDescription(cols, {network::FieldFormat::text});
+  out->WriteDataRow(reinterpret_cast<const byte *>(&dummy_result), cols, {network::FieldFormat::text});
   return {ResultType::COMPLETE, 0u};
 }
 

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -178,7 +178,8 @@ TrafficCopResult TrafficCop::ExecuteShowStatement(
   NOISEPAGE_ASSERT(statement->GetQueryType() == network::QueryType::QUERY_SHOW,
                    "ExecuteSetStatement called with invalid QueryType.");
 
-  const auto &show_stmt = statement->RootStatement().CastManagedPointerTo<parser::VariableShowStatement>();
+  const auto &show_stmt UNUSED_ATTRIBUTE =
+      statement->RootStatement().CastManagedPointerTo<parser::VariableShowStatement>();
 
   NOISEPAGE_ASSERT(show_stmt->GetName() == "transaction_isolation", "Nothing else is supported right now.");
 

--- a/src/traffic_cop/traffic_cop_util.cpp
+++ b/src/traffic_cop/traffic_cop_util.cpp
@@ -135,6 +135,8 @@ network::QueryType TrafficCopUtil::QueryTypeForStatement(const common::ManagedPo
     }
     case parser::StatementType::VARIABLE_SET:
       return network::QueryType::QUERY_SET;
+    case parser::StatementType::VARIABLE_SHOW:
+      return network::QueryType::QUERY_SHOW;
     case parser::StatementType::PREPARE:
       return network::QueryType::QUERY_PREPARE;
     case parser::StatementType::EXECUTE:


### PR DESCRIPTION
# Implement a hacky version of SHOW for transaction_isolation.

## Description

This adds "support" for SHOW TRANSACTION ISOLATION LEVEL, which postgres translates as SHOW transaction_isolation.

This does **NOT** implement a general-purpose SHOW, which should talk to the settings manager.
Nor does it reconcile the fact that some SET and SHOW should be transactional (as found by @Poojita-Raj).

This is purely to unblock @AlanDZQ for his oltpbench stuff.
The rest of the work is left for #1188.

## Remaining tasks

If it gets through CI, then ready for review.