### PR TITLE
Fix passing false arguments to testing scripts. Add dry-run functionality.

### DIFF
--- a/script/testing/oltpbench/test_oltpbench.py
+++ b/script/testing/oltpbench/test_oltpbench.py
@@ -20,7 +20,8 @@ class TestOLTPBench(TestServer):
         TestServer.__init__(self, args)
 
     def run_pre_suite(self):
-        self.install_oltp()
+        if not self.is_dry_run:
+            self.install_oltp()
 
     def install_oltp(self):
         self.clean_oltp()

--- a/script/testing/oltpbench/utils.py
+++ b/script/testing/oltpbench/utils.py
@@ -34,6 +34,9 @@ def parse_command_line_args():
     aparser.add_argument("--disable-mem-info",
                          action='store_true',
                          help="Disable collecting the memory info")
+    aparser.add_argument("--dry-run",
+                         action='store_true',
+                         help="Start and stop DB server without running the OLTPBench tests")
 
     args = vars(aparser.parse_args())
 

--- a/script/testing/util/common.py
+++ b/script/testing/util/common.py
@@ -19,10 +19,13 @@ def run_command(command,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=None,
-                printable=True):
+                printable=True,
+                silent_start=False):
     """
     General purpose wrapper for running a subprocess
     """
+    if not silent_start:
+        LOG.info(f'Running subproccess: {command}')
     p = subprocess.Popen(shlex.split(command),
                          stdout=stdout,
                          stderr=stderr,
@@ -39,7 +42,7 @@ def run_command(command,
     return rc, p.stdout, p.stderr
 
 
-def run_as_root(command, printable=True):
+def run_as_root(command, printable=True, silent_start=False):
     """
     General purpose wrapper for running a subprocess as root user
     """
@@ -49,7 +52,8 @@ def run_as_root(command, printable=True):
                        stdout=subprocess.PIPE,
                        stderr=subprocess.PIPE,
                        cwd=None,
-                       printable=printable)
+                       printable=printable,
+                       silent_start=silent_start)
 
 
 def print_file(filename):
@@ -165,7 +169,7 @@ def run_check_pids(pid):
 
     cmd = "python3 {SCRIPT} {PID}".format(SCRIPT=constants.FILE_CHECK_PIDS,
                                           PID=pid)
-    rc, stdout, _ = run_as_root(cmd, printable=False)
+    rc, stdout, _ = run_as_root(cmd, printable=False, silent_start=True)
 
     if rc != constants.ErrorCode.SUCCESS:
         LOG.error(
@@ -200,7 +204,7 @@ def run_collect_mem_info(pid):
     cmd = "python3 {SCRIPT} {PID}".format(
         SCRIPT=constants.FILE_COLLECT_MEM_INFO, PID=pid)
 
-    rc, stdout, _ = run_as_root(cmd, printable=False)
+    rc, stdout, _ = run_as_root(cmd, printable=False, silent_start=True)
 
     if rc != constants.ErrorCode.SUCCESS:
         LOG.error(

--- a/script/testing/util/db_server.py
+++ b/script/testing/util/db_server.py
@@ -45,7 +45,7 @@ class NoisePageServer:
             db_run_command = f'{self.build_path} {server_args_str}'
             self.db_process = subprocess.Popen(shlex.split(db_run_command), stdout=subprocess.PIPE,
                                                stderr=subprocess.PIPE)
-            LOG.info(f'Server start: {self.build_path} [PID={self.db_process.pid}]')
+            LOG.info(f'Server start: {db_run_command} [PID={self.db_process.pid}]')
 
             if not run_check_pids(self.db_process.pid):
                 LOG.info(f'{self.db_process.pid} does not exist. Trying again.')
@@ -133,8 +133,9 @@ def generate_server_args_str(server_args):
     """ Create a server args string to pass to the DBMS """
     server_args_arr = []
     for attribute, value in server_args.items():
-        value = f'={value}' if value else ''
-        arg = f'--{attribute}{value}'
+        value = str(value).lower() if isinstance(value, bool) else value
+        value = f'={value}' if value != None else ''
+        arg = f'-{attribute}{value}'
         server_args_arr.append(arg)
 
     return ' '.join(server_args_arr)

--- a/script/testing/util/db_server.py
+++ b/script/testing/util/db_server.py
@@ -36,13 +36,13 @@ class NoisePageServer:
         # Allow ourselves to try to restart the DBMS multiple times
         attempt_to_start_time = time.perf_counter()
         server_args_str = generate_server_args_str(self.server_args)
+        db_run_command = f'{self.build_path} {server_args_str}'
         for attempt in range(DB_START_ATTEMPTS):
             # Kill any other noisepage processes that our listening on our target port
             # early terminate the run_db if kill_server.py encounter any exceptions
             run_kill_server(self.db_port)
 
             # use memory buffer to hold db logs
-            db_run_command = f'{self.build_path} {server_args_str}'
             self.db_process = subprocess.Popen(shlex.split(db_run_command), stdout=subprocess.PIPE,
                                                stderr=subprocess.PIPE)
             LOG.info(f'Server start: {db_run_command} [PID={self.db_process.pid}]')

--- a/script/testing/util/test_server.py
+++ b/script/testing/util/test_server.py
@@ -26,6 +26,7 @@ class TestServer:
         db_port = args.get("db_port", constants.DEFAULT_DB_PORT)
         build_type = args.get("build_type", "")
         server_args = args.get("server_args", {})
+        self.is_dry_run = args.get("dry_run",False)
 
         self.db_instance = NoisePageServer(db_host, db_port, build_type, server_args, db_output_file)
 
@@ -92,8 +93,7 @@ class TestServer:
             self.run_pre_suite()
 
             test_suite_ret_vals = self.run_test_suite(test_suite)
-            test_suite_result = self.determine_test_suite_result(
-                test_suite_ret_vals)
+            test_suite_result = self.determine_test_suite_result(test_suite_ret_vals)
         except:
             traceback.print_exc(file=sys.stdout)
             test_suite_result = constants.ErrorCode.ERROR
@@ -119,17 +119,18 @@ class TestServer:
                 # early termination in case of db is unable to start/stop/restart
                 break
 
-            try:
-                test_case_ret_val = self.run_test(test_case)
-                print_file(test_case.test_output_file)
-                test_suite_ret_vals[test_case] = test_case_ret_val
-            except:
-                print_file(test_case.test_output_file)
-                if not self.continue_on_error:
-                    raise
-                else:
-                    traceback.print_exc(file=sys.stdout)
-                    test_suite_ret_vals[test_case] = constants.ErrorCode.ERROR
+            if not self.is_dry_run:
+                try:
+                    test_case_ret_val = self.run_test(test_case)
+                    print_file(test_case.test_output_file)
+                    test_suite_ret_vals[test_case] = test_case_ret_val
+                except:
+                    print_file(test_case.test_output_file)
+                    if not self.continue_on_error:
+                        raise
+                    else:
+                        traceback.print_exc(file=sys.stdout)
+                        test_suite_ret_vals[test_case] = constants.ErrorCode.ERROR
         return test_suite_ret_vals
 
     def determine_test_suite_result(self, test_suite_ret_vals):

--- a/script/testing/util/test_server.py
+++ b/script/testing/util/test_server.py
@@ -110,9 +110,9 @@ class TestServer:
                 # catch the exception from run_db(), stop_db(), and restart_db()
                 # in case the db is unable to start/stop/restart
                 if test_case.db_restart:
-                    self.db_instance.restart_db()
+                    self.db_instance.restart_db(self.is_dry_run)
                 elif not self.db_instance.db_process:
-                    self.db_instance.run_db()
+                    self.db_instance.run_db(self.is_dry_run)
             except:
                 traceback.print_exc(file=sys.stdout)
                 test_suite_ret_vals[test_case] = constants.ErrorCode.ERROR


### PR DESCRIPTION
# HotFix: Wal Disabled OLTPBench Tests

## Description
This fixes #1384. The server args string was not getting created correctly. This fixes the issue with boolean server args. Also, when the DB instance starts it prints the full start command along with the arguments. 

I also took a quick pass at adding `dry-run`, it ended up being much simpler than I thought. I implemented it so that the DB server starts and prints its starting command and then stops, without doing anything. Here is the output.
```
root@2adc8c73e54d:/repo/build# python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly_wal_disabled.json --build-type=release --dry-run
12-09-2020 17:33:08,998 [common.py:36] INFO : ****** start killing processes on port 15721 ******
12-09-2020 17:33:08,998 [common.py:36] INFO : ****** finish killing processes on port 15721 ******
12-09-2020 17:33:09,009 [db_server.py:48] INFO : Server start: /repo/build/bin/noisepage -wal_file_path=wal.log -wal_enable=false -connection_thread_count=32 -record_buffer_segment_size=1000000 [PID=4703]
12-09-2020 17:33:09,091 [db_server.py:61] INFO : DB process is verified as running in 0.68 sec
12-09-2020 17:33:09,091 [db_server.py:86] INFO : Stopped DB successfully
12-09-2020 17:33:09,649 [common.py:36] INFO : ****** start killing processes on port 15721 ******
12-09-2020 17:33:09,649 [common.py:36] INFO : ****** finish killing processes on port 15721 ******
12-09-2020 17:33:09,662 [db_server.py:48] INFO : Server start: /repo/build/bin/noisepage -wal_file_path=wal.log -wal_enable=false -connection_thread_count=32 -record_buffer_segment_size=1000000 [PID=4743]
12-09-2020 17:33:09,751 [db_server.py:61] INFO : DB process is verified as running in 0.69 sec
12-09-2020 17:33:09,751 [db_server.py:86] INFO : Stopped DB successfully
```
If you prefer it to just print the command and not even start/stop that would only be a little additional work. Let me know.

## Further work
There is some further work to improve the documentation around the testing infrastructure. We are currently working on this. 