### PR TITLE
Hardcode LLVM_DIR to llvm@8 path on OSX.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
                     agent { label 'macos' }
                     environment {
                         LIBRARY_PATH="$LIBRARY_PATH:/usr/local/opt/libpqxx/lib/"
-                        LLVM_DIR=sh(script: "brew --prefix llvm@8", label: "Fetching LLVM path", returnStdout: true).trim()
+                        LLVM_DIR="/usr/local/opt/llvm@8"
                         CC="${LLVM_DIR}/bin/clang"
                         CXX="${LLVM_DIR}/bin/clang++"
                     }
@@ -121,7 +121,7 @@ pipeline {
                     environment {
                         ASAN_OPTIONS="detect_container_overflow=0"
                         LIBRARY_PATH="$LIBRARY_PATH:/usr/local/opt/libpqxx/lib/"
-                        LLVM_DIR=sh(script: "brew --prefix llvm@8", label: "Fetching LLVM path", returnStdout: true).trim()
+                        LLVM_DIR="/usr/local/opt/llvm@8"
                         CC="${LLVM_DIR}/bin/clang"
                         CXX="${LLVM_DIR}/bin/clang++"
                     }
@@ -287,7 +287,7 @@ pipeline {
                     environment {
                         ASAN_OPTIONS="detect_container_overflow=0"
                         LIBRARY_PATH="$LIBRARY_PATH:/usr/local/opt/libpqxx/lib/"
-                        LLVM_DIR=sh(script: "brew --prefix llvm@8", label: "Fetching LLVM path", returnStdout: true).trim()
+                        LLVM_DIR="/usr/local/opt/llvm@8"
                         CC="${LLVM_DIR}/bin/clang"
                         CXX="${LLVM_DIR}/bin/clang++"
                     }
@@ -404,7 +404,7 @@ pipeline {
                     agent { label 'macos' }
                     environment {
                         ASAN_OPTIONS="detect_container_overflow=0"
-                        LLVM_DIR=sh(script: "brew --prefix llvm@8", label: "Fetching LLVM path", returnStdout: true).trim()
+                        LLVM_DIR="/usr/local/opt/llvm@8"
                         CC="${LLVM_DIR}/bin/clang"
                         CXX="${LLVM_DIR}/bin/clang++"
                     }

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -23,6 +23,7 @@ OSX_BUILD_PACKAGES=(\
   "libevent" \
   "libpqxx" \
   "pkg-config" \
+  "python@3.8" \
   "ninja" \
   "tbb" \
   "zeromq" \

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -168,7 +168,7 @@ install_mac() {
   # Install Homebrew.
   if test ! $(which brew); then
     echo "Installing Homebrew (https://brew.sh/)"
-    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
   fi
   # Update Homebrew.
   brew update


### PR DESCRIPTION
# Heading

Hardcode LLVM_DIR to llvm@8 path on OSX.

## Description

brew is generally fragile as part of a build system, sometimes making
changes that require us to update the template VM images that we run on.
We will now move towards installing brew from scratch.
This is problematic in Jenkins because the setting of environment variables
happens before the packages.sh install step.
Since we don't update LLVM_DIR often, we might as well hardcode it.


go jenkins go