### PR TITLE
Add ant version pin and openjdk11 to Mac.

### DIFF
--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -29,8 +29,9 @@ OSX_BUILD_PACKAGES=(\
   "zeromq" \
 )
 OSX_TEST_PACKAGES=(\
-  "ant" \
+  "ant@1.9" \
   "lsof" \
+  "openjdk@11" \
   "postgresql" \
 )
 


### PR DESCRIPTION
# Heading

Add `ant` version pin and openjdk11 to Mac.

## Description

Latest version of `ant` has an `openjdk15` dependency.

This screws up compiling and running oltpbench.

If this works, I need to update the mac boxes `~/.profile`.