### PR TITLE
Add calls to lsof in Jenkins.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,6 +70,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh script: 'sudo lsof -i -P -n', label: 'Check ports.'
                         sh script: 'echo y | sudo ./script/installation/packages.sh build', label: 'Installing packages'
                         sh 'cd apidoc && doxygen -u Doxyfile.in && doxygen Doxyfile.in 2>warnings.txt && if [ -s warnings.txt ]; then cat warnings.txt; false; fi'
                         sh 'mkdir build'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
-                        sh script: 'sudo sh ./script/testing/lsof.sh', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
                         sh script: 'echo y | sudo ./script/installation/packages.sh build', label: 'Installing packages'
                         sh 'cd apidoc && doxygen -u Doxyfile.in && doxygen Doxyfile.in 2>warnings.txt && if [ -s warnings.txt ]; then cat warnings.txt; false; fi'
                         sh 'mkdir build'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,14 +110,14 @@ pipeline {
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
-                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
                         sh 'cd build && timeout 1h ninja jumbotests'
                         sh 'cd build && timeout 1h ninja check-tpl'
-                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple', label: 'UnitTest (Simple)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended', label: 'UnitTest (Extended)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended -a "pipeline_metrics_enable=True" -a "pipeline_metrics_interval=0" -a "counters_enable=True" -a "query_trace_metrics_enable=True"', label: 'UnitTest (Extended with pipeline metrics, counters, and query trace metrics)'
-                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
                     }
                     post {
                         always {
@@ -153,13 +153,13 @@ pipeline {
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
-                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
                         sh 'cd build && timeout 1h ninja unittest'
                         sh 'cd build && timeout 1h ninja check-tpl'
-                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple', label: 'UnitTest (Simple)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended', label: 'UnitTest (Extended)'
-                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
                         sh 'cd build && lcov --directory . --capture --output-file coverage.info'
                         sh 'cd build && lcov --remove coverage.info \'/usr/*\' --output-file coverage.info'
                         sh 'cd build && lcov --remove coverage.info \'*/build/*\' --output-file coverage.info'
@@ -208,13 +208,13 @@ pipeline {
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
-                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
                         sh 'cd build && timeout 1h ninja jumbotests'
                         sh 'cd build && timeout 1h ninja check-tpl'
-                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple', label: 'UnitTest (Simple)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended', label: 'UnitTest (Extended)'
-                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
                     }
                     post {
                         always {
@@ -247,13 +247,13 @@ pipeline {
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
-                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
                         sh 'cd build && timeout 1h ninja jumbotests'
                         sh 'cd build && timeout 1h ninja check-tpl'
-                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=simple', label: 'UnitTest (Simple)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=extended', label: 'UnitTest (Extended)'
-                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
                     }
                     post {
                         always {
@@ -290,13 +290,13 @@ pipeline {
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
-                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
                         sh 'cd build && timeout 1h ninja jumbotests'
                         sh 'cd build && timeout 1h ninja check-tpl'
-                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=simple', label: 'UnitTest (Simple)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=extended', label: 'UnitTest (Extended)'
-                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
                     }
                     post {
                         always {
@@ -330,7 +330,7 @@ pipeline {
                         cmake -GNinja -DNOISEPAGE_UNITY_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DNOISEPAGE_USE_ASAN=ON ..
                         ninja noisepage''', label: 'Compiling'
 
-                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
 
                         sh script: '''
                         cd build
@@ -368,7 +368,7 @@ pipeline {
                         timeout 30m python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/end_to_end_debug/tpcc_parallel_disabled.json --build-type=debug
                         ''', label: 'OLTPBench (No Parallel)'
 
-                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
                     }
                     post {
                         cleanup {
@@ -390,7 +390,7 @@ pipeline {
                 cmake -GNinja -DNOISEPAGE_UNITY_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DNOISEPAGE_USE_ASAN=OFF -DNOISEPAGE_USE_JEMALLOC=ON ..
                 ninja noisepage''', label: 'Compiling'
 
-                sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
 
                 sh script:'''
                 cd build
@@ -422,7 +422,7 @@ pipeline {
                 timeout 30m python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/end_to_end_performance/tpcc_wal_ramdisk.json --build-type=release
                 ''', label: 'OLTPBench (TPCC RamDisk WAL)'
 
-                sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
             }
              post {
                  cleanup {
@@ -458,7 +458,7 @@ pipeline {
                 ../benchmark/mini_runners --mini_runner_rows_limit=100 --rerun=0 --warm_num=1
                 ''', label: 'Mini-trainer input generation'
 
-                sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
 
                 sh script: '''
                 cd build
@@ -466,7 +466,7 @@ pipeline {
                 timeout 10m ninja self_driving_test
                 ''', label: 'Running self-driving test'
 
-                sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
             }
             post {
                 cleanup {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
-                        sh script: 'sudo ./script/testing/lsof.sh', label: 'Check ports.'
+                        sh script: 'sudo sh ./script/testing/lsof.sh', label: 'Check ports.'
                         sh script: 'echo y | sudo ./script/installation/packages.sh build', label: 'Installing packages'
                         sh 'cd apidoc && doxygen -u Doxyfile.in && doxygen Doxyfile.in 2>warnings.txt && if [ -s warnings.txt ]; then cat warnings.txt; false; fi'
                         sh 'mkdir build'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,14 +110,14 @@ pipeline {
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
-                        sh 'sudo lsof -i -P -n | grep LISTEN'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
                         sh 'cd build && timeout 1h ninja jumbotests'
                         sh 'cd build && timeout 1h ninja check-tpl'
-                        sh 'sudo lsof -i -P -n | grep LISTEN'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple', label: 'UnitTest (Simple)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended', label: 'UnitTest (Extended)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended -a "pipeline_metrics_enable=True" -a "pipeline_metrics_interval=0" -a "counters_enable=True" -a "query_trace_metrics_enable=True"', label: 'UnitTest (Extended with pipeline metrics, counters, and query trace metrics)'
-                        sh 'sudo lsof -i -P -n | grep LISTEN'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
                     }
                     post {
                         always {
@@ -153,13 +153,13 @@ pipeline {
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
-                        sh 'sudo lsof -i -P -n | grep LISTEN'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
                         sh 'cd build && timeout 1h ninja unittest'
                         sh 'cd build && timeout 1h ninja check-tpl'
-                        sh 'sudo lsof -i -P -n | grep LISTEN'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple', label: 'UnitTest (Simple)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended', label: 'UnitTest (Extended)'
-                        sh 'sudo lsof -i -P -n | grep LISTEN'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
                         sh 'cd build && lcov --directory . --capture --output-file coverage.info'
                         sh 'cd build && lcov --remove coverage.info \'/usr/*\' --output-file coverage.info'
                         sh 'cd build && lcov --remove coverage.info \'*/build/*\' --output-file coverage.info'
@@ -208,13 +208,13 @@ pipeline {
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
-                        sh 'sudo lsof -i -P -n | grep LISTEN'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
                         sh 'cd build && timeout 1h ninja jumbotests'
                         sh 'cd build && timeout 1h ninja check-tpl'
-                        sh 'sudo lsof -i -P -n | grep LISTEN'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple', label: 'UnitTest (Simple)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended', label: 'UnitTest (Extended)'
-                        sh 'sudo lsof -i -P -n | grep LISTEN'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
                     }
                     post {
                         always {
@@ -247,13 +247,13 @@ pipeline {
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
-                        sh 'sudo lsof -i -P -n | grep LISTEN'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
                         sh 'cd build && timeout 1h ninja jumbotests'
                         sh 'cd build && timeout 1h ninja check-tpl'
-                        sh 'sudo lsof -i -P -n | grep LISTEN'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=simple', label: 'UnitTest (Simple)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=extended', label: 'UnitTest (Extended)'
-                        sh 'sudo lsof -i -P -n | grep LISTEN'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
                     }
                     post {
                         always {
@@ -290,13 +290,13 @@ pipeline {
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
-                        sh 'sudo lsof -i -P -n | grep LISTEN'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
                         sh 'cd build && timeout 1h ninja jumbotests'
                         sh 'cd build && timeout 1h ninja check-tpl'
-                        sh 'sudo lsof -i -P -n | grep LISTEN'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=simple', label: 'UnitTest (Simple)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=extended', label: 'UnitTest (Extended)'
-                        sh 'sudo lsof -i -P -n | grep LISTEN'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
                     }
                     post {
                         always {
@@ -330,7 +330,7 @@ pipeline {
                         cmake -GNinja -DNOISEPAGE_UNITY_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DNOISEPAGE_USE_ASAN=ON ..
                         ninja noisepage''', label: 'Compiling'
 
-                        sh 'sudo lsof -i -P -n | grep LISTEN'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
 
                         sh script: '''
                         cd build
@@ -368,7 +368,7 @@ pipeline {
                         timeout 30m python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/end_to_end_debug/tpcc_parallel_disabled.json --build-type=debug
                         ''', label: 'OLTPBench (No Parallel)'
 
-                        sh 'sudo lsof -i -P -n | grep LISTEN'
+                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
                     }
                     post {
                         cleanup {
@@ -390,7 +390,7 @@ pipeline {
                 cmake -GNinja -DNOISEPAGE_UNITY_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DNOISEPAGE_USE_ASAN=OFF -DNOISEPAGE_USE_JEMALLOC=ON ..
                 ninja noisepage''', label: 'Compiling'
 
-                sh 'sudo lsof -i -P -n | grep LISTEN'
+                sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
 
                 sh script:'''
                 cd build
@@ -422,7 +422,7 @@ pipeline {
                 timeout 30m python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/end_to_end_performance/tpcc_wal_ramdisk.json --build-type=release
                 ''', label: 'OLTPBench (TPCC RamDisk WAL)'
 
-                sh 'sudo lsof -i -P -n | grep LISTEN'
+                sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
             }
              post {
                  cleanup {
@@ -458,7 +458,7 @@ pipeline {
                 ../benchmark/mini_runners --mini_runner_rows_limit=100 --rerun=0 --warm_num=1
                 ''', label: 'Mini-trainer input generation'
 
-                sh 'sudo lsof -i -P -n | grep LISTEN'
+                sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
 
                 sh script: '''
                 cd build
@@ -466,7 +466,7 @@ pipeline {
                 timeout 10m ninja self_driving_test
                 ''', label: 'Running self-driving test'
 
-                sh 'sudo lsof -i -P -n | grep LISTEN'
+                sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
             }
             post {
                 cleanup {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
-                        sh script: 'sudo lsof -i -P -n', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n || true', label: 'Check ports.'
                         sh script: 'echo y | sudo ./script/installation/packages.sh build', label: 'Installing packages'
                         sh 'cd apidoc && doxygen -u Doxyfile.in && doxygen Doxyfile.in 2>warnings.txt && if [ -s warnings.txt ]; then cat warnings.txt; false; fi'
                         sh 'mkdir build'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,6 +62,7 @@ pipeline {
                     agent {
                         docker {
                             image 'noisepage:focal'
+                            args '--cap-add sys_ptrace'
                         }
                     }
                     environment {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,6 +62,7 @@ pipeline {
                     agent {
                         docker {
                             image 'noisepage:focal'
+                            args '--cap-add=ALL'
                         }
                     }
                     environment {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,6 @@ pipeline {
                     agent {
                         docker {
                             image 'noisepage:focal'
-                            args '--cap-add=ALL'
                         }
                     }
                     environment {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,11 +110,14 @@ pipeline {
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
+                        sh 'sudo lsof -i -P -n | grep LISTEN'
                         sh 'cd build && timeout 1h ninja jumbotests'
                         sh 'cd build && timeout 1h ninja check-tpl'
+                        sh 'sudo lsof -i -P -n | grep LISTEN'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple', label: 'UnitTest (Simple)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended', label: 'UnitTest (Extended)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended -a "pipeline_metrics_enable=True" -a "pipeline_metrics_interval=0" -a "counters_enable=True" -a "query_trace_metrics_enable=True"', label: 'UnitTest (Extended with pipeline metrics, counters, and query trace metrics)'
+                        sh 'sudo lsof -i -P -n | grep LISTEN'
                     }
                     post {
                         always {
@@ -150,10 +153,13 @@ pipeline {
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
+                        sh 'sudo lsof -i -P -n | grep LISTEN'
                         sh 'cd build && timeout 1h ninja unittest'
                         sh 'cd build && timeout 1h ninja check-tpl'
+                        sh 'sudo lsof -i -P -n | grep LISTEN'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple', label: 'UnitTest (Simple)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended', label: 'UnitTest (Extended)'
+                        sh 'sudo lsof -i -P -n | grep LISTEN'
                         sh 'cd build && lcov --directory . --capture --output-file coverage.info'
                         sh 'cd build && lcov --remove coverage.info \'/usr/*\' --output-file coverage.info'
                         sh 'cd build && lcov --remove coverage.info \'*/build/*\' --output-file coverage.info'
@@ -202,10 +208,13 @@ pipeline {
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
+                        sh 'sudo lsof -i -P -n | grep LISTEN'
                         sh 'cd build && timeout 1h ninja jumbotests'
                         sh 'cd build && timeout 1h ninja check-tpl'
+                        sh 'sudo lsof -i -P -n | grep LISTEN'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple', label: 'UnitTest (Simple)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended', label: 'UnitTest (Extended)'
+                        sh 'sudo lsof -i -P -n | grep LISTEN'
                     }
                     post {
                         always {
@@ -238,10 +247,13 @@ pipeline {
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
+                        sh 'sudo lsof -i -P -n | grep LISTEN'
                         sh 'cd build && timeout 1h ninja jumbotests'
                         sh 'cd build && timeout 1h ninja check-tpl'
+                        sh 'sudo lsof -i -P -n | grep LISTEN'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=simple', label: 'UnitTest (Simple)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=extended', label: 'UnitTest (Extended)'
+                        sh 'sudo lsof -i -P -n | grep LISTEN'
                     }
                     post {
                         always {
@@ -278,10 +290,13 @@ pipeline {
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
+                        sh 'sudo lsof -i -P -n | grep LISTEN'
                         sh 'cd build && timeout 1h ninja jumbotests'
                         sh 'cd build && timeout 1h ninja check-tpl'
+                        sh 'sudo lsof -i -P -n | grep LISTEN'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=simple', label: 'UnitTest (Simple)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=extended', label: 'UnitTest (Extended)'
+                        sh 'sudo lsof -i -P -n | grep LISTEN'
                     }
                     post {
                         always {
@@ -314,6 +329,8 @@ pipeline {
                         cd build
                         cmake -GNinja -DNOISEPAGE_UNITY_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DNOISEPAGE_USE_ASAN=ON ..
                         ninja noisepage''', label: 'Compiling'
+
+                        sh 'sudo lsof -i -P -n | grep LISTEN'
 
                         sh script: '''
                         cd build
@@ -350,6 +367,8 @@ pipeline {
                         cd build
                         timeout 30m python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/end_to_end_debug/tpcc_parallel_disabled.json --build-type=debug
                         ''', label: 'OLTPBench (No Parallel)'
+
+                        sh 'sudo lsof -i -P -n | grep LISTEN'
                     }
                     post {
                         cleanup {
@@ -370,6 +389,8 @@ pipeline {
                 cd build
                 cmake -GNinja -DNOISEPAGE_UNITY_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DNOISEPAGE_USE_ASAN=OFF -DNOISEPAGE_USE_JEMALLOC=ON ..
                 ninja noisepage''', label: 'Compiling'
+
+                sh 'sudo lsof -i -P -n | grep LISTEN'
 
                 sh script:'''
                 cd build
@@ -400,6 +421,8 @@ pipeline {
                 cd build
                 timeout 30m python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/end_to_end_performance/tpcc_wal_ramdisk.json --build-type=release
                 ''', label: 'OLTPBench (TPCC RamDisk WAL)'
+
+                sh 'sudo lsof -i -P -n | grep LISTEN'
             }
              post {
                  cleanup {
@@ -435,11 +458,15 @@ pipeline {
                 ../benchmark/mini_runners --mini_runner_rows_limit=100 --rerun=0 --warm_num=1
                 ''', label: 'Mini-trainer input generation'
 
+                sh 'sudo lsof -i -P -n | grep LISTEN'
+
                 sh script: '''
                 cd build
                 export BUILD_ABS_PATH=`pwd`
                 timeout 10m ninja self_driving_test
                 ''', label: 'Running self-driving test'
+
+                sh 'sudo lsof -i -P -n | grep LISTEN'
             }
             post {
                 cleanup {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,6 @@ pipeline {
                     agent {
                         docker {
                             image 'noisepage:focal'
-                            args '--cap-add sys_ptrace'
                         }
                     }
                     environment {
@@ -71,7 +70,6 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
-                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
                         sh script: 'echo y | sudo ./script/installation/packages.sh build', label: 'Installing packages'
                         sh 'cd apidoc && doxygen -u Doxyfile.in && doxygen Doxyfile.in 2>warnings.txt && if [ -s warnings.txt ]; then cat warnings.txt; false; fi'
                         sh 'mkdir build'
@@ -112,14 +110,14 @@ pipeline {
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
-                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
                         sh 'cd build && timeout 1h ninja jumbotests'
                         sh 'cd build && timeout 1h ninja check-tpl'
-                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple', label: 'UnitTest (Simple)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended', label: 'UnitTest (Extended)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended -a "pipeline_metrics_enable=True" -a "pipeline_metrics_interval=0" -a "counters_enable=True" -a "query_trace_metrics_enable=True"', label: 'UnitTest (Extended with pipeline metrics, counters, and query trace metrics)'
-                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
                     }
                     post {
                         always {
@@ -155,13 +153,13 @@ pipeline {
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
-                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
                         sh 'cd build && timeout 1h ninja unittest'
                         sh 'cd build && timeout 1h ninja check-tpl'
-                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple', label: 'UnitTest (Simple)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended', label: 'UnitTest (Extended)'
-                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
                         sh 'cd build && lcov --directory . --capture --output-file coverage.info'
                         sh 'cd build && lcov --remove coverage.info \'/usr/*\' --output-file coverage.info'
                         sh 'cd build && lcov --remove coverage.info \'*/build/*\' --output-file coverage.info'
@@ -210,13 +208,13 @@ pipeline {
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
-                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
                         sh 'cd build && timeout 1h ninja jumbotests'
                         sh 'cd build && timeout 1h ninja check-tpl'
-                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple', label: 'UnitTest (Simple)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended', label: 'UnitTest (Extended)'
-                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
                     }
                     post {
                         always {
@@ -249,13 +247,13 @@ pipeline {
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
-                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
                         sh 'cd build && timeout 1h ninja jumbotests'
                         sh 'cd build && timeout 1h ninja check-tpl'
-                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=simple', label: 'UnitTest (Simple)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=extended', label: 'UnitTest (Extended)'
-                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
                     }
                     post {
                         always {
@@ -292,13 +290,13 @@ pipeline {
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15721', label: 'Kill PID(15721)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15722', label: 'Kill PID(15722)'
                         sh script: 'cd build && timeout 10s sudo python3 -B ../script/testing/kill_server.py 15723', label: 'Kill PID(15723)'
-                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
                         sh 'cd build && timeout 1h ninja jumbotests'
                         sh 'cd build && timeout 1h ninja check-tpl'
-                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=simple', label: 'UnitTest (Simple)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=extended', label: 'UnitTest (Extended)'
-                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
                     }
                     post {
                         always {
@@ -332,7 +330,7 @@ pipeline {
                         cmake -GNinja -DNOISEPAGE_UNITY_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DNOISEPAGE_USE_ASAN=ON ..
                         ninja noisepage''', label: 'Compiling'
 
-                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
 
                         sh script: '''
                         cd build
@@ -370,7 +368,7 @@ pipeline {
                         timeout 30m python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/end_to_end_debug/tpcc_parallel_disabled.json --build-type=debug
                         ''', label: 'OLTPBench (No Parallel)'
 
-                        sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                        sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
                     }
                     post {
                         cleanup {
@@ -392,7 +390,7 @@ pipeline {
                 cmake -GNinja -DNOISEPAGE_UNITY_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DNOISEPAGE_USE_ASAN=OFF -DNOISEPAGE_USE_JEMALLOC=ON ..
                 ninja noisepage''', label: 'Compiling'
 
-                sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
 
                 sh script:'''
                 cd build
@@ -424,7 +422,7 @@ pipeline {
                 timeout 30m python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/end_to_end_performance/tpcc_wal_ramdisk.json --build-type=release
                 ''', label: 'OLTPBench (TPCC RamDisk WAL)'
 
-                sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
             }
              post {
                  cleanup {
@@ -460,7 +458,7 @@ pipeline {
                 ../benchmark/mini_runners --mini_runner_rows_limit=100 --rerun=0 --warm_num=1
                 ''', label: 'Mini-trainer input generation'
 
-                sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
 
                 sh script: '''
                 cd build
@@ -468,7 +466,7 @@ pipeline {
                 timeout 10m ninja self_driving_test
                 ''', label: 'Running self-driving test'
 
-                sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
             }
             post {
                 cleanup {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
-                        sh script: 'sudo lsof -i -P -n || true', label: 'Check ports.'
+                        sh script: 'sudo ./script/testing/lsof.sh', label: 'Check ports.'
                         sh script: 'echo y | sudo ./script/installation/packages.sh build', label: 'Installing packages'
                         sh 'cd apidoc && doxygen -u Doxyfile.in && doxygen Doxyfile.in 2>warnings.txt && if [ -s warnings.txt ]; then cat warnings.txt; false; fi'
                         sh 'mkdir build'

--- a/Jenkinsfile-nightly
+++ b/Jenkinsfile-nightly
@@ -57,7 +57,7 @@ pipeline {
                 cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DNOISEPAGE_USE_ASAN=OFF -DNOISEPAGE_USE_JEMALLOC=ON -DNOISEPAGE_BUILD_TESTS=OFF ..
                 ninja noisepage''', label: 'Compiling'
 
-                sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
 
                 catchError(stageResult: 'Failure'){
                     sh script:'''
@@ -78,7 +78,7 @@ pipeline {
                     ''', label: 'OLTPBench (No WAL)'
                 }
 
-                sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
 
                 archiveArtifacts(artifacts: 'build/oltp_result/**/*.*', excludes: 'build/oltp_result/**/*.csv', fingerprint: true)
             }
@@ -101,7 +101,7 @@ pipeline {
                 cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DNOISEPAGE_USE_ASAN=OFF -DNOISEPAGE_USE_JEMALLOC=ON -DNOISEPAGE_BUILD_TESTS=OFF ..
                 ninja''', label: 'Compiling'
 
-                sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
 
                 script { // TODO: This script block is temporary to get some initial data into microbenchmarks
                     def iterations = 4
@@ -123,7 +123,7 @@ pipeline {
 
                 }
 
-                sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
+                sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
 
             }
             post {

--- a/Jenkinsfile-nightly
+++ b/Jenkinsfile-nightly
@@ -57,6 +57,8 @@ pipeline {
                 cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DNOISEPAGE_USE_ASAN=OFF -DNOISEPAGE_USE_JEMALLOC=ON -DNOISEPAGE_BUILD_TESTS=OFF ..
                 ninja noisepage''', label: 'Compiling'
 
+                sh 'sudo lsof -i -P -n | grep LISTEN'
+
                 catchError(stageResult: 'Failure'){
                     sh script:'''
                     cd build
@@ -75,6 +77,8 @@ pipeline {
                     timeout 3h python3 ../script/testing/oltpbench/run_oltpbench.py --config-file=../script/testing/oltpbench/configs/nightly/nightly_wal_disabled.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
                     ''', label: 'OLTPBench (No WAL)'
                 }
+
+                sh 'sudo lsof -i -P -n | grep LISTEN'
 
                 archiveArtifacts(artifacts: 'build/oltp_result/**/*.*', excludes: 'build/oltp_result/**/*.csv', fingerprint: true)
             }
@@ -97,6 +101,8 @@ pipeline {
                 cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DNOISEPAGE_USE_ASAN=OFF -DNOISEPAGE_USE_JEMALLOC=ON -DNOISEPAGE_BUILD_TESTS=OFF ..
                 ninja''', label: 'Compiling'
 
+                sh 'sudo lsof -i -P -n | grep LISTEN'
+
                 script { // TODO: This script block is temporary to get some initial data into microbenchmarks
                     def iterations = 4
                     for(int i = 0;i < iterations; i++){
@@ -116,6 +122,8 @@ pipeline {
                     }
 
                 }
+
+                sh 'sudo lsof -i -P -n | grep LISTEN'
 
             }
             post {

--- a/Jenkinsfile-nightly
+++ b/Jenkinsfile-nightly
@@ -57,7 +57,7 @@ pipeline {
                 cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DNOISEPAGE_USE_ASAN=OFF -DNOISEPAGE_USE_JEMALLOC=ON -DNOISEPAGE_BUILD_TESTS=OFF ..
                 ninja noisepage''', label: 'Compiling'
 
-                sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
 
                 catchError(stageResult: 'Failure'){
                     sh script:'''
@@ -78,7 +78,7 @@ pipeline {
                     ''', label: 'OLTPBench (No WAL)'
                 }
 
-                sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
 
                 archiveArtifacts(artifacts: 'build/oltp_result/**/*.*', excludes: 'build/oltp_result/**/*.csv', fingerprint: true)
             }
@@ -101,7 +101,7 @@ pipeline {
                 cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DNOISEPAGE_USE_ASAN=OFF -DNOISEPAGE_USE_JEMALLOC=ON -DNOISEPAGE_BUILD_TESTS=OFF ..
                 ninja''', label: 'Compiling'
 
-                sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
 
                 script { // TODO: This script block is temporary to get some initial data into microbenchmarks
                     def iterations = 4
@@ -123,7 +123,7 @@ pipeline {
 
                 }
 
-                sh script: 'sudo lsof -i -P -n | grep -q LISTEN', label: 'Check ports.'
+                sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
 
             }
             post {

--- a/Jenkinsfile-nightly
+++ b/Jenkinsfile-nightly
@@ -57,7 +57,7 @@ pipeline {
                 cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DNOISEPAGE_USE_ASAN=OFF -DNOISEPAGE_USE_JEMALLOC=ON -DNOISEPAGE_BUILD_TESTS=OFF ..
                 ninja noisepage''', label: 'Compiling'
 
-                sh 'sudo lsof -i -P -n | grep LISTEN'
+                sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
 
                 catchError(stageResult: 'Failure'){
                     sh script:'''
@@ -78,7 +78,7 @@ pipeline {
                     ''', label: 'OLTPBench (No WAL)'
                 }
 
-                sh 'sudo lsof -i -P -n | grep LISTEN'
+                sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
 
                 archiveArtifacts(artifacts: 'build/oltp_result/**/*.*', excludes: 'build/oltp_result/**/*.csv', fingerprint: true)
             }
@@ -101,7 +101,7 @@ pipeline {
                 cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DNOISEPAGE_USE_ASAN=OFF -DNOISEPAGE_USE_JEMALLOC=ON -DNOISEPAGE_BUILD_TESTS=OFF ..
                 ninja''', label: 'Compiling'
 
-                sh 'sudo lsof -i -P -n | grep LISTEN'
+                sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
 
                 script { // TODO: This script block is temporary to get some initial data into microbenchmarks
                     def iterations = 4
@@ -123,7 +123,7 @@ pipeline {
 
                 }
 
-                sh 'sudo lsof -i -P -n | grep LISTEN'
+                sh script: 'sudo lsof -i -P -n | grep LISTEN', label: 'Check ports.'
 
             }
             post {

--- a/script/testing/lsof.sh
+++ b/script/testing/lsof.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-sudo lsof -i -P -n | grep LISTEN

--- a/script/testing/lsof.sh
+++ b/script/testing/lsof.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo lsof -i -P -n | grep LISTEN


### PR DESCRIPTION
# Heading

Add calls to lsof in Jenkins.

## Description

Before and after everything that might spawn a NoisePage instance.

This is to catch any stray processes leftover from before our run, or lingering after our run.