### PR TITLE
 Fix correlated subquery optimizer rules

### DIFF
--- a/script/testing/junit/traces/nested-query.test
+++ b/script/testing/junit/traces/nested-query.test
@@ -175,6 +175,11 @@ SELECT item_name FROM shipment WHERE qty <= (SELECT SUM(amount) FROM part WHERE 
 14 values hashing to eeafa4e65b8e56d2198e1a4703307d57
 
 query T nosort
+SELECT item_name FROM shipment WHERE qty <= (SELECT SUM(amount) FROM part WHERE shipment.pno = part.pno) order by item_name;
+----
+14 values hashing to eeafa4e65b8e56d2198e1a4703307d57
+
+query T nosort
 SELECT item_name FROM shipment WHERE qty < (SELECT SUM(amount) FROM part INNER JOIN shipment s on part.pno = s.pno) order by item_name;
 ----
 14 values hashing to eeafa4e65b8e56d2198e1a4703307d57

--- a/src/include/optimizer/rules/unnesting_rules.h
+++ b/src/include/optimizer/rules/unnesting_rules.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <tuple>
+#include <unordered_set>
 #include <vector>
 
 #include "optimizer/rule.h"
@@ -119,5 +122,21 @@ class DependentSingleJoinToInnerJoin : public Rule {
                  std::vector<std::unique_ptr<AbstractOptimizerNode>> *transformed,
                  OptimizationContext *context) const override;
 };
+
+/**
+ * Given predicates associated with some aggregate, this function will extract the predicates that are correlated with
+ * an outer query, as well as the columns from those predicates that aren't correlated.
+ * @param predicates vector of predicates associated with an aggregate
+ * @param child_group_aliases_set the table alias set of the predicate's child node
+ * @return
+ *      correlated_predicates - predicates which are correlated to an outer query
+ *      normal_predicates - predicates which are not correlated to an outer query
+ *      new_group_cols - columns from correlated predicates which are not correlated to an outer query. These will be
+ * used as group by columns in the nested aggregate
+ */
+std::tuple<std::vector<AnnotatedExpression>, std::vector<AnnotatedExpression>,
+           std::vector<common::ManagedPointer<parser::AbstractExpression>>>
+ExtractCorrelatedPredicatesWithAggregate(const std::vector<AnnotatedExpression> &predicates,
+                                         const std::unordered_set<std::string> &child_group_aliases_set);
 
 };  // namespace noisepage::optimizer

--- a/src/include/optimizer/rules/unnesting_rules.h
+++ b/src/include/optimizer/rules/unnesting_rules.h
@@ -128,15 +128,14 @@ class DependentSingleJoinToInnerJoin : public Rule {
  * an outer query, as well as the columns from those predicates that aren't correlated.
  * @param predicates vector of predicates associated with an aggregate
  * @param child_group_aliases_set the table alias set of the predicate's child node
- * @return
- *      correlated_predicates - predicates which are correlated to an outer query
- *      normal_predicates - predicates which are not correlated to an outer query
- *      new_group_cols - columns from correlated predicates which are not correlated to an outer query. These will be
- * used as group by columns in the nested aggregate
+ * @param[out] correlated_predicates predicates which are correlated to an outer query
+ * @param[out] normal_predicates predicates which are not correlated to an outer query
+ * @param[out] new_group_cols columns from correlated predicates which are not correlated to an outer query. These
+ * will be used as group by columns in the nested aggregate
  */
-std::tuple<std::vector<AnnotatedExpression>, std::vector<AnnotatedExpression>,
-           std::vector<common::ManagedPointer<parser::AbstractExpression>>>
-ExtractCorrelatedPredicatesWithAggregate(const std::vector<AnnotatedExpression> &predicates,
-                                         const std::unordered_set<std::string> &child_group_aliases_set);
+void ExtractCorrelatedPredicatesWithAggregate(
+    const std::vector<AnnotatedExpression> &predicates, const std::unordered_set<std::string> &child_group_aliases_set,
+    std::vector<AnnotatedExpression> *correlated_predicates, std::vector<AnnotatedExpression> *normal_predicates,
+    std::vector<common::ManagedPointer<parser::AbstractExpression>> *new_groupby_cols);
 
 };  // namespace noisepage::optimizer

--- a/src/optimizer/rules/rewrite_rules.cpp
+++ b/src/optimizer/rules/rewrite_rules.cpp
@@ -501,10 +501,11 @@ void RewritePullFilterThroughAggregation::Transform(common::ManagedPointer<Abstr
       // (outer_relation.a = (expr))
       correlated_predicates.emplace_back(predicate);
       auto root_expr = predicate.GetExpr();
-      if (root_expr->GetChild(0)->GetDepth() < root_expr->GetDepth()) {
-        new_groupby_cols.emplace_back(root_expr->GetChild(1).Get());
-      } else {
+      // See https://github.com/cmu-db/noisepage/issues/1404
+      if (root_expr->GetChild(0)->GetDepth() > root_expr->GetDepth()) {
         new_groupby_cols.emplace_back(root_expr->GetChild(0).Get());
+      } else {
+        new_groupby_cols.emplace_back(root_expr->GetChild(1).Get());
       }
     }
   }

--- a/src/optimizer/rules/rewrite_rules.cpp
+++ b/src/optimizer/rules/rewrite_rules.cpp
@@ -503,13 +503,13 @@ void RewritePullFilterThroughAggregation::Transform(common::ManagedPointer<Abstr
       // See https://github.com/cmu-db/noisepage/issues/1404
       // The higher the depth of an expression the deeper/more nested it is.
       // If the sub-query depth level of the left side of the predicate is greater than the current expression then the
-      // left side references the outer query.
+      // left side doesn't references the outer query (i.e. the right side references the outer query).
       // The left side shall be evaluated as a part of the new aggregation before the new filter
       if (root_expr->GetChild(0)->GetDepth() > root_expr->GetDepth()) {
         new_groupby_cols.emplace_back(root_expr->GetChild(0).Get());
       } else {
-        // Otherwise, the right side of the predicate references the outer query
-        // The right side shall be evaluated as a part of the new aggregation before the new filter
+        // Otherwise, the right side of the predicate doesn't references the outer query (i.e. the left side references
+        // the outer query). The right side shall be evaluated as a part of the new aggregation before the new filter
         new_groupby_cols.emplace_back(root_expr->GetChild(1).Get());
       }
     }

--- a/src/optimizer/rules/rewrite_rules.cpp
+++ b/src/optimizer/rules/rewrite_rules.cpp
@@ -502,9 +502,14 @@ void RewritePullFilterThroughAggregation::Transform(common::ManagedPointer<Abstr
       correlated_predicates.emplace_back(predicate);
       auto root_expr = predicate.GetExpr();
       // See https://github.com/cmu-db/noisepage/issues/1404
+      // If the sub-query depth level of the first child is greater than the current expression
+      // the first child is a (expr) and the second child is outer_relation.a
+      // The first child expression shall be evaluated as a part of the new aggregation before the new filter
       if (root_expr->GetChild(0)->GetDepth() > root_expr->GetDepth()) {
         new_groupby_cols.emplace_back(root_expr->GetChild(0).Get());
       } else {
+        // Otherwise, the first child is outer_relation.a and the second child is a (expr)
+        // The second child expression shall be evaluated as a part of the new aggregation before the new filter
         new_groupby_cols.emplace_back(root_expr->GetChild(1).Get());
       }
     }

--- a/src/optimizer/rules/unnesting_rules.cpp
+++ b/src/optimizer/rules/unnesting_rules.cpp
@@ -150,29 +150,29 @@ void DependentSingleJoinToInnerJoin::Transform(common::ManagedPointer<AbstractOp
   const auto &agg_group_aliases_set = memo.GetGroupByID(agg_group_id)->GetTableAliases();
   auto &filter_predicates = filter_expr->Contents()->GetContentsAs<LogicalFilter>()->GetPredicates();
 
-  std::vector<AnnotatedExpression> ancestor_predicates;
-  std::vector<AnnotatedExpression> descendant_predicates;
+  std::vector<AnnotatedExpression> correlated_predicates;
+  std::vector<AnnotatedExpression> normal_predicates;
   std::vector<common::ManagedPointer<parser::AbstractExpression>> new_groupby_cols;
 
   // loop over all predicates check each of them if they refer table not contained in agg
   // from RewritePullFilterThroughAggregation
   for (auto &predicate : filter_predicates) {
     if (OptimizerUtil::IsSubset(agg_group_aliases_set, predicate.GetTableAliasSet())) {
-      descendant_predicates.emplace_back(predicate);
+      normal_predicates.emplace_back(predicate);
     } else {
-      // Correlated predicate, already in the form of
-      // (outer_relation.a = (expr))
-      ancestor_predicates.emplace_back(predicate);
+      // Correlated predicate, predicate in nested query references column in outer query
+      correlated_predicates.emplace_back(predicate);
       auto root_expr = predicate.GetExpr();
       // See https://github.com/cmu-db/noisepage/issues/1404
-      // If the sub-query depth level of the first child is greater than the current expression
-      // the first child is a (expr) and the second child is outer_relation.a
-      // The first child expression shall be evaluated as a part of the new aggregation before the new filter
+      // The higher the depth of an expression the deeper/more nested it is.
+      // If the sub-query depth level of the left side of the predicate is greater than the current expression then the
+      // left side references the outer query.
+      // The left side shall be evaluated as a part of the new aggregation before the new filter
       if (root_expr->GetChild(0)->GetDepth() > root_expr->GetDepth()) {
         new_groupby_cols.emplace_back(root_expr->GetChild(0).Get());
       } else {
-        // Otherwise, the first child is outer_relation.a and the second child is a (expr)
-        // The second child expression shall be evaluated as a part of the new aggregation before the new filter
+        // Otherwise, the right side of the predicate references the outer query
+        // The right side shall be evaluated as a part of the new aggregation before the new filter
         new_groupby_cols.emplace_back(root_expr->GetChild(1).Get());
       }
     }
@@ -194,10 +194,10 @@ void DependentSingleJoinToInnerJoin::Transform(common::ManagedPointer<AbstractOp
   // Create a new inner join node from single join
   std::vector<std::unique_ptr<AbstractOptimizerNode>> inner_node;
   inner_node.emplace_back(input->GetChildren()[0]->Copy());
-  if (!descendant_predicates.empty()) {
+  if (!normal_predicates.empty()) {
     std::vector<std::unique_ptr<AbstractOptimizerNode>> child_node;
     child_node.emplace_back(std::move(new_aggr));
-    auto filter = std::make_unique<OperatorNode>(LogicalFilter::Make(std::move(descendant_predicates))
+    auto filter = std::make_unique<OperatorNode>(LogicalFilter::Make(std::move(normal_predicates))
                                                      .RegisterWithTxnContext(context->GetOptimizerContext()->GetTxn()),
                                                  std::move(child_node), context->GetOptimizerContext()->GetTxn());
     inner_node.emplace_back(std::move(filter));
@@ -211,10 +211,10 @@ void DependentSingleJoinToInnerJoin::Transform(common::ManagedPointer<AbstractOp
   std::unique_ptr<OperatorNode> output;
   // Create new filter nodes
   // Construct a top filter if any
-  if (!ancestor_predicates.empty()) {
+  if (!correlated_predicates.empty()) {
     std::vector<std::unique_ptr<AbstractOptimizerNode>> root_node;
     root_node.emplace_back(std::move(new_inner));
-    output = std::make_unique<OperatorNode>(LogicalFilter::Make(std::move(ancestor_predicates))
+    output = std::make_unique<OperatorNode>(LogicalFilter::Make(std::move(correlated_predicates))
                                                 .RegisterWithTxnContext(context->GetOptimizerContext()->GetTxn()),
                                             std::move(root_node), context->GetOptimizerContext()->GetTxn());
 

--- a/src/optimizer/rules/unnesting_rules.cpp
+++ b/src/optimizer/rules/unnesting_rules.cpp
@@ -150,8 +150,11 @@ void DependentSingleJoinToInnerJoin::Transform(common::ManagedPointer<AbstractOp
   const auto &agg_group_aliases_set = memo.GetGroupByID(agg_group_id)->GetTableAliases();
   auto &filter_predicates = filter_expr->Contents()->GetContentsAs<LogicalFilter>()->GetPredicates();
 
-  auto [correlated_predicates, normal_predicates, new_groupby_cols] =
-      ExtractCorrelatedPredicatesWithAggregate(filter_predicates, agg_group_aliases_set);
+  std::vector<AnnotatedExpression> correlated_predicates;
+  std::vector<AnnotatedExpression> normal_predicates;
+  std::vector<common::ManagedPointer<parser::AbstractExpression>> new_groupby_cols;
+  ExtractCorrelatedPredicatesWithAggregate(filter_predicates, agg_group_aliases_set, &correlated_predicates,
+                                           &normal_predicates, &new_groupby_cols);
 
   // Create a new agg node
   auto aggregation = agg_expr->Contents()->GetContentsAs<LogicalAggregateAndGroupBy>();
@@ -199,19 +202,16 @@ void DependentSingleJoinToInnerJoin::Transform(common::ManagedPointer<AbstractOp
   transformed->emplace_back(std::move(output));
 }
 
-std::tuple<std::vector<AnnotatedExpression>, std::vector<AnnotatedExpression>,
-           std::vector<common::ManagedPointer<parser::AbstractExpression>>>
-ExtractCorrelatedPredicatesWithAggregate(const std::vector<AnnotatedExpression> &predicates,
-                                         const std::unordered_set<std::string> &child_group_aliases_set) {
-  std::vector<AnnotatedExpression> correlated_predicates;
-  std::vector<AnnotatedExpression> normal_predicates;
-  std::vector<common::ManagedPointer<parser::AbstractExpression>> new_groupby_cols;
+void ExtractCorrelatedPredicatesWithAggregate(
+    const std::vector<AnnotatedExpression> &predicates, const std::unordered_set<std::string> &child_group_aliases_set,
+    std::vector<AnnotatedExpression> *correlated_predicates, std::vector<AnnotatedExpression> *normal_predicates,
+    std::vector<common::ManagedPointer<parser::AbstractExpression>> *new_groupby_cols) {
   for (auto &predicate : predicates) {
     if (OptimizerUtil::IsSubset(child_group_aliases_set, predicate.GetTableAliasSet())) {
-      normal_predicates.emplace_back(predicate);
+      normal_predicates->emplace_back(predicate);
     } else {
       // Correlated predicate, predicate in nested query references column in outer query
-      correlated_predicates.emplace_back(predicate);
+      correlated_predicates->emplace_back(predicate);
       auto root_expr = predicate.GetExpr();
       // See https://github.com/cmu-db/noisepage/issues/1404
       // The higher the depth of an expression the deeper/more nested it is.
@@ -219,16 +219,14 @@ ExtractCorrelatedPredicatesWithAggregate(const std::vector<AnnotatedExpression> 
       // left side doesn't references the outer query (i.e. the right side references the outer query).
       // The left side shall be evaluated as a part of the new aggregation before the new filter
       if (root_expr->GetChild(0)->GetDepth() > root_expr->GetDepth()) {
-        new_groupby_cols.emplace_back(root_expr->GetChild(0).Get());
+        new_groupby_cols->emplace_back(root_expr->GetChild(0).Get());
       } else {
         // Otherwise, the right side of the predicate doesn't references the outer query (i.e. the left side references
         // the outer query). The right side shall be evaluated as a part of the new aggregation before the new filter
-        new_groupby_cols.emplace_back(root_expr->GetChild(1).Get());
+        new_groupby_cols->emplace_back(root_expr->GetChild(1).Get());
       }
     }
   }
-
-  return {correlated_predicates, normal_predicates, new_groupby_cols};
 }
 
 }  // namespace noisepage::optimizer

--- a/src/optimizer/rules/unnesting_rules.cpp
+++ b/src/optimizer/rules/unnesting_rules.cpp
@@ -141,11 +141,42 @@ void DependentSingleJoinToInnerJoin::Transform(common::ManagedPointer<AbstractOp
                                                UNUSED_ATTRIBUTE OptimizationContext *context) const {
   UNUSED_ATTRIBUTE auto single_join = input->Contents()->GetContentsAs<LogicalSingleJoin>();
   NOISEPAGE_ASSERT(single_join->GetJoinPredicates().empty(), "SingleJoin should have no predicates");
+  // From LOGICALSINGLEJOIN -> LOGICALFILTER -> LOGICALAGGREGATEANDGROUPBY
+  //  to LOGICALFILTER -> LOGICALINNERJOIN -> LOGICALFILTER -> LOGICALAGGREGATEANDGROUPBY
+  auto &memo = context->GetOptimizerContext()->GetMemo();
   auto filter_expr = input->GetChildren()[1];
   auto agg_expr = filter_expr->GetChildren()[0];
+  auto agg_group_id = agg_expr->GetChildren()[0]->Contents()->GetContentsAs<LeafOperator>()->GetOriginGroup();
+  const auto &agg_group_aliases_set = memo.GetGroupByID(agg_group_id)->GetTableAliases();
   auto &filter_predicates = filter_expr->Contents()->GetContentsAs<LogicalFilter>()->GetPredicates();
 
+  std::vector<AnnotatedExpression> correlated_predicates;
+  std::vector<AnnotatedExpression> normal_predicates;
   std::vector<common::ManagedPointer<parser::AbstractExpression>> new_groupby_cols;
+
+  // loop over all predicates check each of them if they refer table not contained in agg
+  // from RewritePullFilterThroughAggregation
+  for (auto &predicate : filter_predicates) {
+    if (OptimizerUtil::IsSubset(agg_group_aliases_set, predicate.GetTableAliasSet())) {
+      normal_predicates.emplace_back(predicate);
+    } else {
+      // Correlated predicate, predicate in nested query references column in outer query
+      correlated_predicates.emplace_back(predicate);
+      auto root_expr = predicate.GetExpr();
+      // See https://github.com/cmu-db/noisepage/issues/1404
+      // The higher the depth of an expression the deeper/more nested it is.
+      // If the sub-query depth level of the left side of the predicate is greater than the current expression then the
+      // left side doesn't references the outer query (i.e. the right side references the outer query).
+      // The left side shall be evaluated as a part of the new aggregation before the new filter
+      if (root_expr->GetChild(0)->GetDepth() > root_expr->GetDepth()) {
+        new_groupby_cols.emplace_back(root_expr->GetChild(0).Get());
+      } else {
+        // Otherwise, the right side of the predicate doesn't references the outer query (i.e. the left side references
+        // the outer query). The right side shall be evaluated as a part of the new aggregation before the new filter
+        new_groupby_cols.emplace_back(root_expr->GetChild(1).Get());
+      }
+    }
+  }
 
   // Create a new agg node
   auto aggregation = agg_expr->Contents()->GetContentsAs<LogicalAggregateAndGroupBy>();
@@ -163,25 +194,33 @@ void DependentSingleJoinToInnerJoin::Transform(common::ManagedPointer<AbstractOp
   // Create a new inner join node from single join
   std::vector<std::unique_ptr<AbstractOptimizerNode>> inner_node;
   inner_node.emplace_back(input->GetChildren()[0]->Copy());
-
-  inner_node.emplace_back(std::move(new_aggr));
+  if (!normal_predicates.empty()) {
+    std::vector<std::unique_ptr<AbstractOptimizerNode>> child_node;
+    child_node.emplace_back(std::move(new_aggr));
+    auto filter = std::make_unique<OperatorNode>(LogicalFilter::Make(std::move(normal_predicates))
+                                                     .RegisterWithTxnContext(context->GetOptimizerContext()->GetTxn()),
+                                                 std::move(child_node), context->GetOptimizerContext()->GetTxn());
+    inner_node.emplace_back(std::move(filter));
+  } else {
+    inner_node.emplace_back(std::move(new_aggr));
+  }
   auto new_inner = std::make_unique<OperatorNode>(
       LogicalInnerJoin::Make().RegisterWithTxnContext(context->GetOptimizerContext()->GetTxn()), std::move(inner_node),
       context->GetOptimizerContext()->GetTxn());
 
   std::unique_ptr<OperatorNode> output;
-  // Construct a top filter
-  std::vector<AnnotatedExpression> new_filter_predicates;
-  new_filter_predicates.reserve(filter_predicates.size());
-  for (auto &predicate : filter_predicates) {
-    new_filter_predicates.emplace_back(predicate);
-  }
-  std::vector<std::unique_ptr<AbstractOptimizerNode>> root_node;
-  root_node.emplace_back(std::move(new_inner));
-  output = std::make_unique<OperatorNode>(LogicalFilter::Make(std::move(new_filter_predicates))
-                                              .RegisterWithTxnContext(context->GetOptimizerContext()->GetTxn()),
-                                          std::move(root_node), context->GetOptimizerContext()->GetTxn());
+  // Create new filter nodes
+  // Construct a top filter if any
+  if (!correlated_predicates.empty()) {
+    std::vector<std::unique_ptr<AbstractOptimizerNode>> root_node;
+    root_node.emplace_back(std::move(new_inner));
+    output = std::make_unique<OperatorNode>(LogicalFilter::Make(std::move(correlated_predicates))
+                                                .RegisterWithTxnContext(context->GetOptimizerContext()->GetTxn()),
+                                            std::move(root_node), context->GetOptimizerContext()->GetTxn());
 
+  } else {
+    output = std::move(new_inner);
+  }
   transformed->emplace_back(std::move(output));
 }
 

--- a/src/optimizer/rules/unnesting_rules.cpp
+++ b/src/optimizer/rules/unnesting_rules.cpp
@@ -166,13 +166,13 @@ void DependentSingleJoinToInnerJoin::Transform(common::ManagedPointer<AbstractOp
       // See https://github.com/cmu-db/noisepage/issues/1404
       // The higher the depth of an expression the deeper/more nested it is.
       // If the sub-query depth level of the left side of the predicate is greater than the current expression then the
-      // left side references the outer query.
+      // left side doesn't references the outer query (i.e. the right side references the outer query).
       // The left side shall be evaluated as a part of the new aggregation before the new filter
       if (root_expr->GetChild(0)->GetDepth() > root_expr->GetDepth()) {
         new_groupby_cols.emplace_back(root_expr->GetChild(0).Get());
       } else {
-        // Otherwise, the right side of the predicate references the outer query
-        // The right side shall be evaluated as a part of the new aggregation before the new filter
+        // Otherwise, the right side of the predicate doesn't references the outer query (i.e. the left side references
+        // the outer query). The right side shall be evaluated as a part of the new aggregation before the new filter
         new_groupby_cols.emplace_back(root_expr->GetChild(1).Get());
       }
     }


### PR DESCRIPTION
## Description
Part of RewritePullFilterThroughAggregation and DependentSingleJoinToInnerJoin rules rule adds a group by column to the aggregation from one of the sides of the predicate. When selecting a column we need to make sure that the column is at the same depth as the aggregation or deeper. If the group by column is part of the outer query and the aggregation part of the inner query, then the aggregation has no way of accessing the column. A higher value for depth means deeper in the querer and a lower value for depth means more shallow in the query. The current code was always setting the column from the left side of the predicate as the group by column. This was sometimes causing the group by column to be more shallow than the aggregation itself which caused the query to error out.

Fixes #1404

### Remaining Tasks
N/A

## Performance
N/A

## Further Work
Check if this fixed any other nested query open issues