### PR TITLE
Fix missing includes in model_server_manager header.

### DIFF
--- a/src/include/self_driving/model_server/model_server_manager.h
+++ b/src/include/self_driving/model_server/model_server_manager.h
@@ -12,14 +12,19 @@
 
 #pragma once
 
+#include <atomic>
+#include <condition_variable>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
 #include "common/json.h"
 #include "common/managed_pointer.h"
+#include "messenger/messenger_defs.h"
 
 namespace noisepage::messenger {
+class ConnectionRouter;
 class Messenger;
 }  // namespace noisepage::messenger
 

--- a/src/include/self_driving/model_server/model_server_manager.h
+++ b/src/include/self_driving/model_server/model_server_manager.h
@@ -13,9 +13,9 @@
 #pragma once
 
 #include <atomic>
-#include <condition_variable>
+#include <condition_variable>  // NOLINT
 #include <string>
-#include <thread>
+#include <thread>  // NOLINT
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
# Heading

Fix missing includes in model_server_manager header.

## Description

Fix #1406.

The underlying cause is that the model server manager header is missing some includes which the previous `#include` items were providing.

---

Apparently github has video support for pull requests now.