### PR TITLE
Add guide comments to network folder's README.

### DIFF
--- a/src/network/postgres/postgres_network_commands.cpp
+++ b/src/network/postgres/postgres_network_commands.cpp
@@ -101,7 +101,7 @@ Transition SimpleQueryCommand::Exec(const common::ManagedPointer<ProtocolInterpr
   const auto statement = std::make_unique<network::Statement>(
       std::move(query_text), std::move(std::get<std::unique_ptr<parser::ParseResult>>(parse_result)));
 
-  // TODO(Matt:) Clients may send multiple statements in a single SimpleQuery packet/string. Handling that would
+  // TODO(Matt): Clients may send multiple statements in a single SimpleQuery packet/string. Handling that would
   // probably exist here, looping over all of the elements in the ParseResult. It's not clear to me how the binder would
   // handle that though since you pass the ParseResult in for binding. Maybe bind ParseResult once?
 


### PR DESCRIPTION
# Heading

Add guide comments to network folder's README.

## Description

I was poking around in the `network` folder earlier and thought that something like this would have been helpful:

- for people who've poked around before, a refresher of how things work
- for new people, a guide to where to look

Just documentation, no point going through CI.