### PR TITLE
Fix iterator invalidation in binding insert statements.

### DIFF
--- a/script/testing/junit/traces/insert.test
+++ b/script/testing/junit/traces/insert.test
@@ -236,26 +236,34 @@ statement ok
 CREATE TABLE insert13 (c1 integer, c2 double)
 
 statement ok
-INSERT INTO insert13 (c2, c1) VALUES (2.0, 1)
+INSERT INTO insert13 (c2, c1) VALUES (2.0, 1), (4.0, 2), (8.0, 3)
 
-query IR nosort
+query IR rowsort
 SELECT * FROM insert13
 ----
 1
 2.0
+2
+4.0
+3
+8.0
 
 statement ok
-INSERT INTO insert13 (c2) VALUES (4.0)
+INSERT INTO insert13 (c2) VALUES (16.0),(32.0),(64.0)
 
-query R nosort
+query R rowsort
 SELECT c2 FROM insert13 WHERE c1 IS NULL
 ----
-4.0
+16.0
+32.0
+64.0
 
-query R nosort
+query R rowsort
 SELECT c2 FROM insert13 WHERE c1 IS NOT NULL
 ----
 2.0
+4.0
+8.0
 
 statement ok
 DROP TABLE insert13

--- a/script/testing/junit/traces/insert.test
+++ b/script/testing/junit/traces/insert.test
@@ -231,3 +231,31 @@ SELECT * from insert12
 statement ok
 DROP TABLE insert12
 
+# Test inserts that are: out of order, missing values, multiple values, multiple types. Issue #1408
+statement ok
+CREATE TABLE insert13 (c1 integer, c2 double)
+
+statement ok
+INSERT INTO insert13 (c2, c1) VALUES (2.0, 1)
+
+query IR nosort
+SELECT * FROM insert13
+----
+1
+2.0
+
+statement ok
+INSERT INTO insert13 (c2) VALUES (4.0)
+
+query R nosort
+SELECT c2 FROM insert13 WHERE c1 IS NULL
+----
+4.0
+
+query R nosort
+SELECT c2 FROM insert13 WHERE c1 IS NOT NULL
+----
+2.0
+
+statement ok
+DROP TABLE insert13

--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -398,10 +398,8 @@ void BindNodeVisitor::Visit(common::ManagedPointer<parser::InsertStatement> node
           }
 
           // We overwrite the original insert columns and values with the schema-ordered versions generated above.
-          insert_columns->clear();
           values.clear();
           for (auto &pair : cols) {
-            insert_columns->emplace_back(pair.first.Name());
             values.emplace_back(pair.second);
           }
         }
@@ -442,6 +440,15 @@ void BindNodeVisitor::Visit(common::ManagedPointer<parser::InsertStatement> node
           ins_val->Accept(common::ManagedPointer(this).CastManagedPointerTo<SqlNodeVisitor>());
           values[i] = ins_val;
         }
+      }
+    }
+    // The final list of insert columns will always be the full list. Done here to avoid iterator invalidation problems.
+    {
+      const auto &cols = table_schema.GetColumns();
+      node->GetInsertColumns()->clear();
+      node->GetInsertColumns()->reserve(cols.size());
+      for (const auto &col : cols) {
+        node->GetInsertColumns()->emplace_back(col.Name());
       }
     }
   }


### PR DESCRIPTION
# Heading

Fix iterator invalidation in binding insert statements.

## Description

Fix #1408.

The list of column names to insert into was getting iterator-invalidated.