### PR TITLE
Increase the fake sleep in AdaptiveCheckTest.

### DIFF
--- a/test/execution/sql_filter_manager_test.cpp
+++ b/test/execution/sql_filter_manager_test.cpp
@@ -145,14 +145,14 @@ TEST_F(FilterManagerTest, AdaptiveCheckTest) {
   filter.InsertClauseTerms(
       {[](auto exec_ctx, auto vp, auto tids, auto ctx) {
          auto *r = reinterpret_cast<uint32_t *>(ctx);
-         if (*r < 1000) std::this_thread::sleep_for(250us);  // Fake a sleep.
+         if (*r < 1000) std::this_thread::sleep_for(500us);  // Fake a sleep.
          const auto val = GenericValue::CreateInteger(500);
          VectorFilterExecutor::SelectLessThanVal(
              reinterpret_cast<exec::ExecutionContext *>(exec_ctx)->GetExecutionSettings(), vp, Col::A, val, tids);
        },
        [](auto exec_ctx, auto vp, auto tids, auto ctx) {
          auto *r = reinterpret_cast<uint32_t *>(ctx);
-         if (*r >= 1000) std::this_thread::sleep_for(250us);  // Fake a sleep.
+         if (*r >= 1000) std::this_thread::sleep_for(500us);  // Fake a sleep.
          const auto val = GenericValue::CreateInteger(7);
          VectorFilterExecutor::SelectLessThanVal(
              reinterpret_cast<exec::ExecutionContext *>(exec_ctx)->GetExecutionSettings(), vp, Col::B, val, tids);


### PR DESCRIPTION
# Heading

Increase the fake sleep in AdaptiveCheckTest.

## Description

Fix #1378.

I don't know why `FilterManager.AdaptiveCheckTest` has become more flaky nowadays.
This just builds on @gonzalezjo's previous fix in #1085 by upping the fake sleep time from 250us to 500us, so hopefully that test becomes more reliable.

I don't particularly see a point in running this through CI.