### PR TITLE
Skip recording the un-modeled LIMIT operating unit

### DIFF
--- a/script/model/data_class/grouped_op_unit_data.py
+++ b/script/model/data_class/grouped_op_unit_data.py
@@ -150,9 +150,6 @@ def _pipeline_get_grouped_op_unit_data(filename, warmup_period, ee_sample_interv
             features = line[features_vector_index].split(';')
             concurrency = 0
             for idx, feature in enumerate(features):
-                if feature == 'LIMIT':
-                    continue
-
                 opunit = OpUnit[feature]
                 x_loc = [v[idx] if type(v) == list else v for v in x_multiple]
                 if x_loc[data_info.instance.input_csv_index[ExecutionFeature.NUM_ROWS]] == 0:

--- a/src/include/self_driving/modeling/operating_unit_defs.h
+++ b/src/include/self_driving/modeling/operating_unit_defs.h
@@ -105,7 +105,7 @@ enum class ExecutionOperatingUnitType : uint32_t {
   /**
    * LIMIT
    * We don't model LIMIT for now since there's no LIMIT operator. But we keep this OpUnit type since there's a LIMIT
-   * translator. We skip this OpUnit in the OperatingUnitRecorder.
+   * translator (which requires an OpUnit type). We skip this OpUnit in the OperatingUnitRecorder.
    */
   LIMIT,
 

--- a/src/include/self_driving/modeling/operating_unit_defs.h
+++ b/src/include/self_driving/modeling/operating_unit_defs.h
@@ -104,8 +104,8 @@ enum class ExecutionOperatingUnitType : uint32_t {
   OUTPUT,
   /**
    * LIMIT
-   * num_rows:
-   * cardinality:
+   * We don't model LIMIT for now since there's no LIMIT operator. But we keep this OpUnit type since there's a LIMIT
+   * translator. We skip this OpUnit in the OperatingUnitRecorder.
    */
   LIMIT,
 

--- a/src/self_driving/modeling/operating_unit_recorder.cpp
+++ b/src/self_driving/modeling/operating_unit_recorder.cpp
@@ -611,13 +611,7 @@ void OperatingUnitRecorder::Visit(const planner::CSVScanPlanNode *plan) {
 }
 
 void OperatingUnitRecorder::Visit(const planner::LimitPlanNode *plan) {
-  VisitAbstractPlanNode(plan);
-  RecordArithmeticFeatures(plan, 1);
-
-  // Copy outwards
-  auto num_keys = plan->GetOutputSchema()->GetColumns().size();
-  auto key_size = ComputeKeySizeOutputSchema(plan, &num_keys);
-  AggregateFeatures(plan_feature_type_, key_size, num_keys, plan, 1, 1);
+  // Limit plan does not have its own operator and we don't model Limit with our operating units. So we skip.
 }
 
 void OperatingUnitRecorder::Visit(const planner::OrderByPlanNode *plan) {


### PR DESCRIPTION
We don't model the LIMIT operating unit since it does not have its own operator. But we still record this OpUnit in the `OperatingUnitRecorder`, which causes inference error unless we skip it manually. This PR skips recording the LIMIT OpUnit in `OperatingUnitRecorder`.