### PR TITLE
Added wal_async_commit_enable setting, defaulted to false

### DIFF
--- a/benchmark/benchmark_util/data_table_benchmark_util.cpp
+++ b/benchmark/benchmark_util/data_table_benchmark_util.cpp
@@ -79,7 +79,7 @@ LargeDataTableBenchmarkObject::LargeDataTableBenchmarkObject(const std::vector<u
       abort_count_(0),
       operation_ratio_(std::move(operation_ratio)),
       txn_manager_(common::ManagedPointer(&timestamp_manager_), DISABLED, common::ManagedPointer(buffer_pool), gc_on,
-                   common::ManagedPointer(log_manager)),
+                   false, common::ManagedPointer(log_manager)),
       txn_length_(txn_length),
       gc_on_(gc_on) {
   // Bootstrap the table to have the specified number of tuples

--- a/benchmark/integration/tpcc_benchmark.cpp
+++ b/benchmark/integration/tpcc_benchmark.cpp
@@ -85,9 +85,12 @@ BENCHMARK_DEFINE_F(TPCCBenchmark, ScaleFactor4WithoutLogging)(benchmark::State &
     // we need transactions, TPCC database, and GC
     transaction::TimestampManager timestamp_manager;
     transaction::DeferredActionManager deferred_action_manager{common::ManagedPointer(&timestamp_manager)};
-    transaction::TransactionManager txn_manager{
-        common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-        common::ManagedPointer(&buffer_pool_), true, common::ManagedPointer(log_manager_)};
+    transaction::TransactionManager txn_manager{common::ManagedPointer(&timestamp_manager),
+                                                common::ManagedPointer(&deferred_action_manager),
+                                                common::ManagedPointer(&buffer_pool_),
+                                                true,
+                                                false,
+                                                common::ManagedPointer(log_manager_)};
     gc_ = new storage::GarbageCollector(common::ManagedPointer(&timestamp_manager),
                                         common::ManagedPointer(&deferred_action_manager),
                                         common::ManagedPointer(&txn_manager), DISABLED);
@@ -177,9 +180,12 @@ BENCHMARK_DEFINE_F(TPCCBenchmark, ScaleFactor4WithLogging)(benchmark::State &sta
     log_manager_->Start();
     transaction::TimestampManager timestamp_manager;
     transaction::DeferredActionManager deferred_action_manager{common::ManagedPointer(&timestamp_manager)};
-    transaction::TransactionManager txn_manager{
-        common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-        common::ManagedPointer(&buffer_pool_), true, common::ManagedPointer(log_manager_)};
+    transaction::TransactionManager txn_manager{common::ManagedPointer(&timestamp_manager),
+                                                common::ManagedPointer(&deferred_action_manager),
+                                                common::ManagedPointer(&buffer_pool_),
+                                                true,
+                                                false,
+                                                common::ManagedPointer(log_manager_)};
     gc_ = new storage::GarbageCollector(common::ManagedPointer(&timestamp_manager),
                                         common::ManagedPointer(&deferred_action_manager),
                                         common::ManagedPointer(&txn_manager), DISABLED);
@@ -276,9 +282,12 @@ BENCHMARK_DEFINE_F(TPCCBenchmark, ScaleFactor4WithLoggingAndMetrics)(benchmark::
     log_manager_->Start();
     transaction::TimestampManager timestamp_manager;
     transaction::DeferredActionManager deferred_action_manager{common::ManagedPointer(&timestamp_manager)};
-    transaction::TransactionManager txn_manager{
-        common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-        common::ManagedPointer(&buffer_pool_), true, common::ManagedPointer(log_manager_)};
+    transaction::TransactionManager txn_manager{common::ManagedPointer(&timestamp_manager),
+                                                common::ManagedPointer(&deferred_action_manager),
+                                                common::ManagedPointer(&buffer_pool_),
+                                                true,
+                                                false,
+                                                common::ManagedPointer(log_manager_)};
     gc_ = new storage::GarbageCollector(common::ManagedPointer(&timestamp_manager),
                                         common::ManagedPointer(&deferred_action_manager),
                                         common::ManagedPointer(&txn_manager), DISABLED);
@@ -373,9 +382,12 @@ BENCHMARK_DEFINE_F(TPCCBenchmark, ScaleFactor4WithMetrics)(benchmark::State &sta
     // we need transactions, TPCC database, and GC
     transaction::TimestampManager timestamp_manager;
     transaction::DeferredActionManager deferred_action_manager{common::ManagedPointer(&timestamp_manager)};
-    transaction::TransactionManager txn_manager{
-        common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-        common::ManagedPointer(&buffer_pool_), true, common::ManagedPointer(log_manager_)};
+    transaction::TransactionManager txn_manager{common::ManagedPointer(&timestamp_manager),
+                                                common::ManagedPointer(&deferred_action_manager),
+                                                common::ManagedPointer(&buffer_pool_),
+                                                true,
+                                                false,
+                                                common::ManagedPointer(log_manager_)};
     gc_ = new storage::GarbageCollector(common::ManagedPointer(&timestamp_manager),
                                         common::ManagedPointer(&deferred_action_manager),
                                         common::ManagedPointer(&txn_manager), DISABLED);

--- a/benchmark/storage/block_compactor_benchmark.cpp
+++ b/benchmark/storage/block_compactor_benchmark.cpp
@@ -24,7 +24,10 @@ class BlockCompactorBenchmark : public benchmark::Fixture {
   transaction::DeferredActionManager deferred_action_manager_{common::ManagedPointer(&timestamp_manager_)};
   transaction::TransactionManager txn_manager_{common::ManagedPointer(&timestamp_manager_),
                                                common::ManagedPointer(&deferred_action_manager_),
-                                               common::ManagedPointer(&buffer_pool_), true, DISABLED};
+                                               common::ManagedPointer(&buffer_pool_),
+                                               true,
+                                               false,
+                                               DISABLED};
   storage::GarbageCollector gc_{common::ManagedPointer(&timestamp_manager_),
                                 common::ManagedPointer(&deferred_action_manager_),
                                 common::ManagedPointer(&txn_manager_), nullptr};

--- a/benchmark/storage/index_wrapper_benchmark.cpp
+++ b/benchmark/storage/index_wrapper_benchmark.cpp
@@ -73,7 +73,7 @@ class IndexBenchmark : public benchmark::Fixture {
     deferred_action_manager_ = new transaction::DeferredActionManager(common::ManagedPointer(timestamp_manager_));
     txn_manager_ = new transaction::TransactionManager(common::ManagedPointer(timestamp_manager_),
                                                        common::ManagedPointer(deferred_action_manager_),
-                                                       common::ManagedPointer(&buffer_pool_), true, DISABLED);
+                                                       common::ManagedPointer(&buffer_pool_), true, false, DISABLED);
     gc_ = new storage::GarbageCollector(common::ManagedPointer(timestamp_manager_),
                                         common::ManagedPointer(deferred_action_manager_),
                                         common::ManagedPointer(txn_manager_), DISABLED);

--- a/src/include/main/db_main.h
+++ b/src/include/main/db_main.h
@@ -74,6 +74,9 @@ class DBMain {
     /**
      * @param buffer_segment_pool non-null required component
      * @param gc_enabled argument to the TransactionManager
+     * @param wal_async_commit_enable true if commit callbacks should be invoked by TransactionManager at commit time
+     * rather than waiting until durable on disk and being invoked by the WAL worker. Doesn't make sense to set to true
+     * if WAL is not enabled.
      * @param log_manager argument to the TransactionManager
      */
     TransactionLayer(const common::ManagedPointer<storage::RecordBufferSegmentPool> buffer_segment_pool,

--- a/src/include/main/db_main.h
+++ b/src/include/main/db_main.h
@@ -540,6 +540,15 @@ class DBMain {
     }
 
     /**
+     * @param value TransactionManager argument
+     * @return self reference for chaining
+     */
+    Builder &SetWalAsyncCommit(const bool value) {
+      wal_async_commit_enable_ = value;
+      return *this;
+    }
+
+    /**
      * @param value LogManager argument
      * @return self reference for chaining
      */

--- a/src/include/settings/settings_defs.h
+++ b/src/include/settings/settings_defs.h
@@ -107,6 +107,15 @@ SETTING_string(
     noisepage::settings::Callbacks::NoOp
 )
 
+// Asynchronous commit txns when WAL is enabled
+SETTING_bool(
+    wal_async_commit_enable,
+    "When WAL is enabled, allow commit confirmation before results are durable in the WAL. (default: false)",
+    false,
+    false,
+    noisepage::settings::Callbacks::NoOp
+)
+
 // Number of buffers log manager can use to buffer logs
 SETTING_int64(
     wal_num_buffers,

--- a/src/include/settings/settings_defs.h
+++ b/src/include/settings/settings_defs.h
@@ -110,7 +110,7 @@ SETTING_string(
 // Asynchronous commit txns when WAL is enabled
 SETTING_bool(
     wal_async_commit_enable,
-    "When WAL is enabled, allow commit confirmation before results are durable in the WAL. (default: false)",
+    "Enable commit confirmation before results are durable in the WAL. (default: false)",
     false,
     false,
     noisepage::settings::Callbacks::NoOp

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -36,14 +36,17 @@ class TransactionManager {
    */
   TransactionManager(const common::ManagedPointer<TimestampManager> timestamp_manager,
                      const common::ManagedPointer<DeferredActionManager> deferred_action_manager,
-                     const common::ManagedPointer<storage::RecordBufferSegmentPool> buffer_pool, bool gc_enabled,
-                     const common::ManagedPointer<storage::LogManager> log_manager)
+                     const common::ManagedPointer<storage::RecordBufferSegmentPool> buffer_pool, const bool gc_enabled,
+                     const bool wal_async_commit_enable, const common::ManagedPointer<storage::LogManager> log_manager)
       : timestamp_manager_(timestamp_manager),
         deferred_action_manager_(deferred_action_manager),
         buffer_pool_(buffer_pool),
         gc_enabled_(gc_enabled),
+        wal_async_commit_enable_(wal_async_commit_enable),
         log_manager_(log_manager) {
     NOISEPAGE_ASSERT(timestamp_manager_ != DISABLED, "transaction manager cannot function without a timestamp manager");
+    NOISEPAGE_ASSERT(!wal_async_commit_enable_ || (wal_async_commit_enable_ && log_manager_ != DISABLED),
+                     "Doesn't make sense to enable async commit without enabling logging.");
   }
 
   /**
@@ -83,10 +86,11 @@ class TransactionManager {
   const common::ManagedPointer<TimestampManager> timestamp_manager_;
   const common::ManagedPointer<DeferredActionManager> deferred_action_manager_;
   const common::ManagedPointer<storage::RecordBufferSegmentPool> buffer_pool_;
+  const bool gc_enabled_ = false;
+  const bool wal_async_commit_enable_ = false;
 
   common::Gate txn_gate_;
 
-  bool gc_enabled_ = false;
   TransactionQueue completed_txns_;
   const common::ManagedPointer<storage::LogManager> log_manager_;
 

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -32,6 +32,9 @@ class TransactionManager {
    * @param deferred_action_manager deferred action manager to use for transactions
    * @param buffer_pool the buffer pool to use for transaction undo buffers
    * @param gc_enabled true if txns should be stored in a local queue to hand off to the GC, false otherwise
+   * @param wal_async_commit_enable true if commit callbacks should be invoked by TransactionManager at commit time
+   * rather than waiting until durable on disk and being invoked by the WAL worker. Doesn't make sense to set to true if
+   * WAL is not enabled.
    * @param log_manager the log manager in the system, or DISABLED(nulllptr) if logging is turned off.
    */
   TransactionManager(const common::ManagedPointer<TimestampManager> timestamp_manager,

--- a/test/network/network_test.cpp
+++ b/test/network/network_test.cpp
@@ -63,7 +63,7 @@ class NetworkTests : public TerrierTest {
     deferred_action_manager_ = new transaction::DeferredActionManager(common::ManagedPointer(timestamp_manager_));
     txn_manager_ = new transaction::TransactionManager(common::ManagedPointer(timestamp_manager_),
                                                        common::ManagedPointer(deferred_action_manager_),
-                                                       common::ManagedPointer(&buffer_pool_), true, DISABLED);
+                                                       common::ManagedPointer(&buffer_pool_), true, false, DISABLED);
     gc_ = new storage::GarbageCollector(common::ManagedPointer(timestamp_manager_),
                                         common::ManagedPointer(deferred_action_manager_),
                                         common::ManagedPointer(txn_manager_), DISABLED);

--- a/test/optimizer/logical_operator_test.cpp
+++ b/test/optimizer/logical_operator_test.cpp
@@ -28,7 +28,7 @@ TEST(OperatorTests, LogicalInsertTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -96,7 +96,7 @@ TEST(OperatorTests, LogicalInsertSelectTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -135,7 +135,7 @@ TEST(OperatorTests, LogicalLimitTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -183,7 +183,7 @@ TEST(OperatorTests, LogicalDeleteTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
   catalog::db_oid_t database_oid(123);
@@ -221,7 +221,7 @@ TEST(OperatorTests, LogicalUpdateTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -278,7 +278,7 @@ TEST(OperatorTests, LogicalExportExternalFileTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -330,7 +330,7 @@ TEST(OperatorTests, LogicalGetTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -427,7 +427,7 @@ TEST(OperatorTests, LogicalExternalFileGetTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -491,7 +491,7 @@ TEST(OperatorTests, LogicalQueryDerivedGetTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -568,7 +568,7 @@ TEST(OperatorTests, LogicalFilterTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -640,7 +640,7 @@ TEST(OperatorTests, LogicalProjectionTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -698,7 +698,7 @@ TEST(OperatorTests, LogicalDependentJoinTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -774,7 +774,7 @@ TEST(OperatorTests, LogicalMarkJoinTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -849,7 +849,7 @@ TEST(OperatorTests, LogicalSingleJoinTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -925,7 +925,7 @@ TEST(OperatorTests, LogicalInnerJoinTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1001,7 +1001,7 @@ TEST(OperatorTests, LogicalLeftJoinTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1062,7 +1062,7 @@ TEST(OperatorTests, LogicalRightJoinTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1124,7 +1124,7 @@ TEST(OperatorTests, LogicalOuterJoinTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1185,7 +1185,7 @@ TEST(OperatorTests, LogicalSemiJoinTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1246,7 +1246,7 @@ TEST(OperatorTests, LogicalAggregateAndGroupByTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1355,7 +1355,7 @@ TEST(OperatorTests, LogicalCreateDatabaseTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1390,7 +1390,7 @@ TEST(OperatorTests, LogicalCreateFunctionTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1512,7 +1512,7 @@ TEST(OperatorTests, LogicalCreateIndexTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1627,7 +1627,7 @@ TEST(OperatorTests, LogicalCreateTableTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1741,7 +1741,7 @@ TEST(OperatorTests, LogicalCreateNamespaceTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1776,7 +1776,7 @@ TEST(OperatorTests, LogicalCreateTriggerTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1905,7 +1905,7 @@ TEST(OperatorTests, LogicalCreateViewTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1963,7 +1963,7 @@ TEST(OperatorTests, LogicalDropDatabaseTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1998,7 +1998,7 @@ TEST(OperatorTests, LogicalDropTableTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -2032,7 +2032,7 @@ TEST(OperatorTests, LogicalDropIndexTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -2067,7 +2067,7 @@ TEST(OperatorTests, LogicalDropNamespaceTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -2102,7 +2102,7 @@ TEST(OperatorTests, LogicalDropTriggerTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -2152,7 +2152,7 @@ TEST(OperatorTests, LogicalDropViewTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 

--- a/test/optimizer/optimizer_context_test.cpp
+++ b/test/optimizer/optimizer_context_test.cpp
@@ -125,7 +125,7 @@ TEST_F(OptimizerContextTest, RecordOperatorNodeIntoGroupDuplicateSingleLayer) {
   auto *buffer_pool = new storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(deferred_action_manager),
-      common::ManagedPointer(buffer_pool), false, nullptr);
+      common::ManagedPointer(buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -191,7 +191,7 @@ TEST_F(OptimizerContextTest, RecordOperatorNodeIntoGroupDuplicateMultiLayer) {
   auto *buffer_pool = new storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(deferred_action_manager),
-      common::ManagedPointer(buffer_pool), false, nullptr);
+      common::ManagedPointer(buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -272,7 +272,7 @@ TEST_F(OptimizerContextTest, RecordOperatorNodeIntoGroupDuplicate) {
   auto *buffer_pool = new storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(deferred_action_manager),
-      common::ManagedPointer(buffer_pool), false, nullptr);
+      common::ManagedPointer(buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -310,7 +310,7 @@ TEST_F(OptimizerContextTest, SimpleBindingTest) {
   auto *buffer_pool = new storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(deferred_action_manager),
-      common::ManagedPointer(buffer_pool), false, nullptr);
+      common::ManagedPointer(buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -370,7 +370,7 @@ TEST_F(OptimizerContextTest, SingleWildcardTest) {
   auto *buffer_pool = new storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(deferred_action_manager),
-      common::ManagedPointer(buffer_pool), false, nullptr);
+      common::ManagedPointer(buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 

--- a/test/optimizer/physical_operator_test.cpp
+++ b/test/optimizer/physical_operator_test.cpp
@@ -34,7 +34,7 @@ TEST(OperatorTests, TableFreeScanTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -59,7 +59,7 @@ TEST(OperatorTests, SeqScanTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -156,7 +156,7 @@ TEST(OperatorTests, IndexScanTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -262,7 +262,7 @@ TEST(OperatorTests, ExternalFileScanTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -315,7 +315,7 @@ TEST(OperatorTests, QueryDerivedScanTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -388,7 +388,7 @@ TEST(OperatorTests, OrderByTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -413,7 +413,7 @@ TEST(OperatorTests, LimitTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -462,7 +462,7 @@ TEST(OperatorTests, InnerNLJoinTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -537,7 +537,7 @@ TEST(OperatorTests, LeftNLJoinTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -585,7 +585,7 @@ TEST(OperatorTests, RightNLJoinTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -633,7 +633,7 @@ TEST(OperatorTests, OuterNLJoin) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -681,7 +681,7 @@ TEST(OperatorTests, InnerHashJoinTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -768,7 +768,7 @@ TEST(OperatorTests, LeftSemiHashJoinTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
   parser::AbstractExpression *expr_b_1 =
@@ -855,7 +855,7 @@ TEST(OperatorTests, LeftHashJoinTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -942,7 +942,7 @@ TEST(OperatorTests, RightHashJoinTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -990,7 +990,7 @@ TEST(OperatorTests, OuterHashJoinTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1038,7 +1038,7 @@ TEST(OperatorTests, InsertTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1097,7 +1097,7 @@ TEST(OperatorTests, InsertSelectTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1137,7 +1137,7 @@ TEST(OperatorTests, DeleteTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1177,7 +1177,7 @@ TEST(OperatorTests, ExportExternalFileTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1225,7 +1225,7 @@ TEST(OperatorTests, UpdateTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1274,7 +1274,7 @@ TEST(OperatorTests, HashGroupByTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1379,7 +1379,7 @@ TEST(OperatorTests, SortGroupByTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1487,7 +1487,7 @@ TEST(OperatorTests, AggregateTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1512,7 +1512,7 @@ TEST(OperatorTests, CreateDatabaseTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1544,7 +1544,7 @@ TEST(OperatorTests, CreateFunctionTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1662,7 +1662,7 @@ TEST(OperatorTests, CreateIndexTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1761,7 +1761,7 @@ TEST(OperatorTests, CreateTableTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1872,7 +1872,7 @@ TEST(OperatorTests, CreateNamespaceTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -1904,7 +1904,7 @@ TEST(OperatorTests, CreateTriggerTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -2024,7 +2024,7 @@ TEST(OperatorTests, CreateViewTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -2079,7 +2079,7 @@ TEST(OperatorTests, DropDatabaseTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -2111,7 +2111,7 @@ TEST(OperatorTests, DropTableTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -2143,7 +2143,7 @@ TEST(OperatorTests, DropIndexTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -2175,7 +2175,7 @@ TEST(OperatorTests, DropNamespaceTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -2207,7 +2207,7 @@ TEST(OperatorTests, DropTriggerTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
@@ -2254,7 +2254,7 @@ TEST(OperatorTests, DropViewTest) {
   auto buffer_pool = storage::RecordBufferSegmentPool(100, 2);
   transaction::TransactionManager txn_manager = transaction::TransactionManager(
       common::ManagedPointer(&timestamp_manager), common::ManagedPointer(&deferred_action_manager),
-      common::ManagedPointer(&buffer_pool), false, nullptr);
+      common::ManagedPointer(&buffer_pool), false, false, nullptr);
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 

--- a/test/storage/block_compactor_test.cpp
+++ b/test/storage/block_compactor_test.cpp
@@ -91,7 +91,10 @@ TEST_F(BlockCompactorTest, CompactionTest) {
     transaction::DeferredActionManager deferred_action_manager{common::ManagedPointer(&timestamp_manager)};
     transaction::TransactionManager txn_manager{common::ManagedPointer(&timestamp_manager),
                                                 common::ManagedPointer(&deferred_action_manager),
-                                                common::ManagedPointer(&buffer_pool_), true, DISABLED};
+                                                common::ManagedPointer(&buffer_pool_),
+                                                true,
+                                                false,
+                                                DISABLED};
     storage::GarbageCollector gc{common::ManagedPointer(&timestamp_manager),
                                  common::ManagedPointer(&deferred_action_manager), common::ManagedPointer(&txn_manager),
                                  DISABLED};
@@ -175,7 +178,10 @@ TEST_F(BlockCompactorTest, GatherTest) {
     transaction::DeferredActionManager deferred_action_manager{common::ManagedPointer(&timestamp_manager)};
     transaction::TransactionManager txn_manager{common::ManagedPointer(&timestamp_manager),
                                                 common::ManagedPointer(&deferred_action_manager),
-                                                common::ManagedPointer(&buffer_pool_), true, DISABLED};
+                                                common::ManagedPointer(&buffer_pool_),
+                                                true,
+                                                false,
+                                                DISABLED};
     storage::GarbageCollector gc{common::ManagedPointer(&timestamp_manager),
                                  common::ManagedPointer(&deferred_action_manager), common::ManagedPointer(&txn_manager),
                                  DISABLED};
@@ -282,7 +288,10 @@ TEST_F(BlockCompactorTest, DictionaryCompressionTest) {
     transaction::DeferredActionManager deferred_action_manager{common::ManagedPointer(&timestamp_manager)};
     transaction::TransactionManager txn_manager{common::ManagedPointer(&timestamp_manager),
                                                 common::ManagedPointer(&deferred_action_manager),
-                                                common::ManagedPointer(&buffer_pool_), true, DISABLED};
+                                                common::ManagedPointer(&buffer_pool_),
+                                                true,
+                                                false,
+                                                DISABLED};
     storage::GarbageCollector gc{common::ManagedPointer(&timestamp_manager),
                                  common::ManagedPointer(&deferred_action_manager), common::ManagedPointer(&txn_manager),
                                  DISABLED};

--- a/test/storage/export_table_test.cpp
+++ b/test/storage/export_table_test.cpp
@@ -231,7 +231,10 @@ TEST_F(ExportTableTest, ExportDictionaryCompressedTableTest) {
   transaction::DeferredActionManager deferred_action_manager{common::ManagedPointer(&timestamp_manager)};
   transaction::TransactionManager txn_manager{common::ManagedPointer(&timestamp_manager),
                                               common::ManagedPointer(&deferred_action_manager),
-                                              common::ManagedPointer(&buffer_pool_), true, DISABLED};
+                                              common::ManagedPointer(&buffer_pool_),
+                                              true,
+                                              false,
+                                              DISABLED};
   storage::GarbageCollector gc{common::ManagedPointer(&timestamp_manager),
                                common::ManagedPointer(&deferred_action_manager), common::ManagedPointer(&txn_manager),
                                DISABLED};
@@ -309,7 +312,10 @@ TEST_F(ExportTableTest, ExportVarlenTableTest) {
   transaction::DeferredActionManager deferred_action_manager{common::ManagedPointer(&timestamp_manager)};
   transaction::TransactionManager txn_manager{common::ManagedPointer(&timestamp_manager),
                                               common::ManagedPointer(&deferred_action_manager),
-                                              common::ManagedPointer(&buffer_pool_), true, DISABLED};
+                                              common::ManagedPointer(&buffer_pool_),
+                                              true,
+                                              false,
+                                              DISABLED};
   storage::GarbageCollector gc{common::ManagedPointer(&timestamp_manager),
                                common::ManagedPointer(&deferred_action_manager), common::ManagedPointer(&txn_manager),
                                DISABLED};


### PR DESCRIPTION
### Summary
This PR implements something similar to Postgres' [asynchronous commit WAL setting](https://www.postgresql.org/docs/current/wal-async-commit.html), albeit not at a per-transaction granularity as Postgres allows.

### Background
Currently, if WAL is enabled then on transaction COMMIT the `TransactionManager` pushes a transaction's `CommitRecord` down to the `LogManager`, which in turn pushes it to the `DiskSerializerTask`. Once a transaction's records are serialized, it is removed from the running transactions table by the `DiskSerializerTask`, and then the callback is pushed to the `DiskLogConsumerTask`. Finally, once a transaction's records are persisted to disk (via `fdatasync`) its callback can be invoked and the client receives an acknowledgement of COMMIT. This coordination is expensive for short-lived queries, where the overhead of synchronizing data structures, threads scheduling, and the latency of the `fdatasync` system call can dominate transaction processing time. However, these steps are all necessary for full ACID guarantees (namely durability, though one could argue consistency because without synchronous commit, a client may see a result that is not reproducible after crash-and-recovery if its results were dependent on another COMMIT transaction that was not persisted to the WAL yet).

### Changes
There is a new command-line setting called `wal_async_commit_enable` that is defaulted to `false`, which maintains the current behavior of the system. If the setting is set to `true` (which only works if WAL is enabled) then on transaction COMMIT the `TransactionManager` still pushes a transaction's `CommitRecord` down to the `LogManager`, however the callback is swapped with the no-op `EmptyCallback` and the real callback is invoked immediately. This reduces the latency between when the system receives COMMIT and returns acknowledgement to the client.

### Caveats
Asynchronous commit in NoisePage comes with all of the caveats described in the Postgres documentation: if the system crashes after COMMIT but before the WAL worker syncs data to disk, there is the possibility of losing data.

### Performance

Some quick numbers from my NUC with an NVMe drive:

**oltpbench TPC-C, scale factor = 1, terminals = 1**
| WAL Configuration | Txns/sec |
|-|-|
| Disabled | 1655 |
| Enabled (wal_async_commit_enable=true) | 1623 |
| Enabled (wal_async_commit_enable=false) | 290 |

**oltpbench TPC-C, scale factor = 6, terminals = 6**
| WAL Configuration | Txns/sec |
|-|-|
| Disabled | 5755 |
| Enabled (wal_async_commit_enable=true) | 5312 |
| Enabled (wal_async_commit_enable=false) | 1048 |

**oltpbench YCSB-read only, scale factor = 1200, terminals = 1**
| WAL Configuration | Txns/sec |
|-|-|
| Disabled | 24328 |
| Enabled (wal_async_commit_enable=true) | 22999 |
| Enabled (wal_async_commit_enable=false) | 3934 |

**oltpbench YCSB-read only, scale factor = 1200, terminals = 6**
| WAL Configuration | Txns/sec |
|-|-|
| Disabled | 80595 |
| Enabled (wal_async_commit_enable=true) | 69375 |
| Enabled (wal_async_commit_enable=false) | 20972 |

### Discussion
- Is this useful for the full system or should I keep it for my experimental branches? My motivation for opening a PR is that Postgres exposes it as a setting, and SingleStore/MemSQL's default configuration is asynchronous durability.
- Should there be a configuration in CI for benchmarking this? My intuition is no, since WAL disabled and enabled both serve as the bounds for this configuration's performance.

### Remaining Tasks

- [ ] If we want to move forward then all of the tests and benchmarks will need a quick refactor to reflect the `TransactionManager`'s new signature.