### PR TITLE
DiskLogConsumerTask avoids calling Persist() if no data written

### DIFF
--- a/src/include/storage/write_ahead_log/log_io.h
+++ b/src/include/storage/write_ahead_log/log_io.h
@@ -124,6 +124,7 @@ class BufferedLogWriter {
    * don't care about all of the file's metadata being persisted, just the contents.
    */
   void Persist() {
+    if (buffer_size_ == 0) return;  // persist with no bytes written should be a no-op
 #if __APPLE__
     // macOS provides fcntl(out_, F_FULLFSYNC) to guarantee that on-disk buffers are flushed. AFAIK there is no portable
     // way to do this on Linux so we'll just keep fsync for now.

--- a/src/include/storage/write_ahead_log/log_io.h
+++ b/src/include/storage/write_ahead_log/log_io.h
@@ -124,7 +124,6 @@ class BufferedLogWriter {
    * don't care about all of the file's metadata being persisted, just the contents.
    */
   void Persist() {
-    if (buffer_size_ == 0) return;  // persist with no bytes written should be a no-op
 #if __APPLE__
     // macOS provides fcntl(out_, F_FULLFSYNC) to guarantee that on-disk buffers are flushed. AFAIK there is no portable
     // way to do this on Linux so we'll just keep fsync for now.

--- a/src/storage/write_ahead_log/disk_log_consumer_task.cpp
+++ b/src/storage/write_ahead_log/disk_log_consumer_task.cpp
@@ -42,8 +42,7 @@ void DiskLogConsumerTask::WriteBuffersToLogFile() {
 }
 
 uint64_t DiskLogConsumerTask::PersistLogFile() {
-  // buffers_ may be empty but we have callbacks to invoke due to read-only txns
-  if (!buffers_->empty()) {
+  if (current_data_written_ > 0) {
     // Force the buffers to be written to disk. Because all buffers log to the same file, it suffices to call persist on
     // any buffer.
     buffers_->front().Persist();


### PR DESCRIPTION
### Summary
This PR adds an optimization in `DiskLogConsumerTask` to avoid calling `BufferedLogWriter::Persist()` if no bytes have actually been written.

### Background
Currently, if WAL is enabled then the `DiskLogConsumerTask` hammers the `fdatasync` system call (via `BufferedLogWriter::Persist()`) based on a timeout. There's no reason to perform this system call if no bytes have been written, and this ends up on the critical path to read-only transaction COMMITs.

I first noticed this a few months ago when spinning up the system and noticing that the disk activity light on my NUC was going crazy even when the DBMS is idle and not writing any data, but punted until recently exploring read-only transaction bottlenecks.

### Changes
One-line change in`DiskLogConsumerTask` to add a check if the number of bytes the number of bytes written is 0, and if so skip the call to `Persist()`.

### Caveats
None that I can think of.

### Performance

Some quick numbers from my NUC with an NVMe drive:

**oltpbench TPC-C, scale factor = 1, terminals = 1**
| WAL Configuration | Txns/sec |
|-|-|
| Disabled | 1655 |
| Enabled (this PR) | 292 |
| Enabled (master) | 290 |

**oltpbench TPC-C, scale factor = 6, terminals = 6**
| WAL Configuration | Txns/sec |
|-|-|
| Disabled | 5755 |
| Enabled (this PR) | 1048 |
| Enabled (master) | 1048 |

**oltpbench YCSB-read only, scale factor = 1200, terminals = 1**
| WAL Configuration | Txns/sec |
|-|-|
| Disabled | 24328 |
| Enabled (this PR) | 4865 |
| Enabled (master) | 3934 |

**oltpbench YCSB-read only, scale factor = 1200, terminals = 6**
| WAL Configuration | Txns/sec |
|-|-|
| Disabled | 80595 |
| Enabled (this PR) | 25381 |
| Enabled (master) | 20972 |

### Discussion
- Should exponential backoff behavior change based on no data being written (i.e., maybe don't reset the backoff value)?

### Remaining Tasks
- None.