### PR TITLE
Fix default values of mismatched types

### DIFF
--- a/script/testing/junit/traces/insert.test
+++ b/script/testing/junit/traces/insert.test
@@ -267,3 +267,28 @@ SELECT c2 FROM insert13 WHERE c1 IS NOT NULL
 
 statement ok
 DROP TABLE insert13
+
+# Support default value expressions of compatible types
+statement ok
+CREATE TABLE insert14 (id integer default '1')
+
+statement ok
+INSERT INTO insert14 VALUES (DEFAULT)
+
+query I nosort
+SELECT * from insert14
+----
+1
+
+statement ok
+DROP TABLE insert14
+
+# Support default value expressions of incompatible types up until insert (postgres behavior)
+statement ok
+CREATE TABLE insert15 (id smallint default 239040928093)
+
+statement error
+INSERT INTO insert15 VALUES (DEFAULT)
+
+statement ok
+DROP TABLE insert15

--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -421,6 +421,7 @@ void BindNodeVisitor::Visit(common::ManagedPointer<parser::InsertStatement> node
           if (is_default_expression) {
             auto stored_expr = ins_col.StoredExpression()->Copy();
             ins_val = common::ManagedPointer(stored_expr);
+            sherpa_->SetDesiredType(common::ManagedPointer(ins_val), ins_col.Type());
             sherpa_->GetParseResult()->AddExpression(std::move(stored_expr));
           }
 

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -207,13 +207,13 @@ class Schema {
 
     void Validate() const {
       NOISEPAGE_ASSERT(type_ != type::TypeId::INVALID, "Attribute type cannot be INVALID.");
-      NOISEPAGE_ASSERT(default_value_ == nullptr || type_ == default_value_->GetReturnValueType() ||
+      NOISEPAGE_ASSERT(default_value_ == nullptr || default_value_->GetReturnValueType() != type::TypeId::INVALID ||
                            (default_value_->GetReturnValueType() == type::TypeId::INVALID &&
                             common::ManagedPointer(default_value_)
                                 .CastManagedPointerTo<parser::ConstantValueExpression>()
                                 ->IsNull()),
-                       "Default value does not have same time as the column.");
-      // TODO(Matt): I don't love that last part that NULL default values come out of the parser woth TypeId::INVALID.
+                       "Default value either: 1) shouldn't exist 2) shouldn't have INVALID type 3) UNLESS it's NULL.");
+      // TODO(Matt): I don't love that last part that NULL default values come out of the parser with TypeId::INVALID.
 
       if (type_ == type::TypeId::VARCHAR || type_ == type::TypeId::VARBINARY) {
         NOISEPAGE_ASSERT(attr_length_ == storage::VARLEN_COLUMN, "Invalid attribute length.");


### PR DESCRIPTION
### Overview
Postgres lets you do this:
```sql
matt=# create table foo (id int default '1');
CREATE TABLE
Time: 9.845 ms
matt=# insert into foo values (default);
INSERT 0 1
Time: 1.021 ms
matt=# select * from foo;
 id 
----
  1
(1 row)

Time: 0.248 ms
```
Basically you can have a default value that is not the same type as the schema column. It gets cast at insert time, which can be verified by setting a default that doesn't actually work. Postgres also lets you do this:
```sql
matt=# create table foo (id smallint default 3429089082);
CREATE TABLE
Time: 1.317 ms
matt=# insert into foo values (default);
ERROR:  22003: smallint out of range
LOCATION:  int82, int8.c:1313
Time: 1.315 ms
```
We now match this behavior. This was found while trying to run Wikipedia via oltpbench using the Postgres DDL.
### Changes
- Relax assertion in `Schema::Column` that default value's type matches column type, because Postgres doesn't require this.
- Set desired type in `BinderSherpa` for default values before visiting them in order to handle casting.
- Add tracefile test.