### PR TITLE
Microbenchmark fix %change mistake

### DIFF
--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -73,6 +73,7 @@ PYTHON_PACKAGES=(\
   "lightgbm" \
   "numpy" \
   "pandas" \
+  "prettytable" \
   "psutil" \
   "psycopg2" \
   "pyarrow" \

--- a/script/testing/microbench/README.md
+++ b/script/testing/microbench/README.md
@@ -14,7 +14,7 @@ in TimescaleDB. The results will be visualized at [stats.noise.page](https://sta
 ## Requirements
 
 This script assumes that you have numactl package installed. If you are running the script locally you do not need to
- install `numctl` but you will need to comment out a line in `MicrobenchmarksRunner._build_benchmark_cmd()`. 
+ install `numctl` but you will need to specify `--local`. 
 
 ```
 sudo apt install numactl
@@ -28,14 +28,14 @@ in the Jenkins repository. It assumes that the microbenchmark binaries can be fo
 benchmark path.
 
 ```
-$ ./run_micro_bench.py --run
+$ ./run_micro_bench.py
 ```
 
 If you only want to run a subset microbenchmark, you can pass in the **name** of the microbenchmark 
 binary (e.g., `data_table_benchmark`) and not the suite name (e.g., `DataTableBenchmark`):
 
 ```
-$ ./run_micro_bench.py --run data_table_benchmark recovery_benchmark
+$ ./run_micro_bench.py data_table_benchmark recovery_benchmark
 ```
 
 ## Local Execution
@@ -47,7 +47,7 @@ flag. That will write the results to a directory in the same path as the script.
 compute the average results for the microbenchmarks for all the local runs:
 
 ```
-$ ./run_micro_bench.py --run --local
+$ ./run_micro_bench.py --local
 ```
 
 This will write the results of each invocation to a directory called "local". See note in the requirements section about `numactl`.
@@ -59,7 +59,7 @@ This makes it easier to do profiling from the script without needing to track do
 variables.
 
 ```
-$ ./run_micro_bench.py --run --perf data_table_benchmark
+$ ./run_micro_bench.py --perf data_table_benchmark
 ```
 
 The script will configure perf to write its trace file to `data_table_benchmark.perf`.

--- a/script/testing/microbench/README.md
+++ b/script/testing/microbench/README.md
@@ -14,7 +14,7 @@ in TimescaleDB. The results will be visualized at [stats.noise.page](https://sta
 ## Requirements
 
 This script assumes that you have numactl package installed. If you are running the script locally you do not need to
- install `numctl` but you will need to specify `--local`. 
+ install `numactl` but you will need to specify `--local`. 
 
 ```
 sudo apt install numactl

--- a/script/testing/microbench/artifact_processor.py
+++ b/script/testing/microbench/artifact_processor.py
@@ -11,7 +11,7 @@ from util.constants import LOG
 
 class ArtifactProcessor(object):
     """ Loads historical Google benchmark test results. Provide access by 
-        (suite_name, test_name)
+    (suite_name, test_name)
     """
 
     def __init__(self, required_num_results=None):
@@ -22,9 +22,17 @@ class ArtifactProcessor(object):
         return
 
     def load_local_artifacts(self, latest_local_build_dir):
-        """ load artifacts when run_micro_bench.py is run in local mode.
+        """ Load artifacts when run in local mode.
+
         It reads the results from the local directory structure and stores
-        them in the artifact processor. """
+        them in the artifact processor.
+        
+        Parameters
+        ----------
+        latest_local_build_dir : str
+            The path to the latest local build dir. The directories increment 
+            001, 002, 003, etc. This is the highest one.
+        """
         LOG.debug("Processing local data repository {}".format(LOCAL_REPO_DIR))
         local_build_dirs = reversed(sorted(next(os.walk(LOCAL_REPO_DIR))[1]))
         for build_dir in local_build_dirs:
@@ -40,8 +48,14 @@ class ArtifactProcessor(object):
                     return
 
     def load_jenkins_artifacts(self, ref_data_source):
-        """ Load the Jenkins artifacts into the artifact processor based on the
-        information provided in the ref_data_source dict """
+        """ Load the Jenkins artifacts into the artifact processor.
+        
+        Parameters
+        ----------
+        ref_data_source : dict
+            An object that contains information about where to get the Jenkins
+            data. It could be a project or a branch within that project.
+        """
         jenkins = Jenkins(JENKINS_URL)
         folders = ref_data_source.get("folders", [])
         project = ref_data_source.get("project")
@@ -56,8 +70,13 @@ class ArtifactProcessor(object):
                 return
 
     def has_min_history(self):
-        """ check whether all the collected artifacts have at least the minimum
-            number of results.
+        """ Check whether all the collected artifacts have at least the minimum
+        number of results.
+
+        Returns
+        -------
+        bool
+            Whether there were enough historical results.
         """
         if not self.required_num_results:
             LOG.debug("required_num_results is not set???")
@@ -77,7 +96,13 @@ class ArtifactProcessor(object):
 
     def add_artifact(self, gbench_run_result):
         """ Add an artifact file to the list of files to be used
-        for computing summary statistics
+        for computing summary statistics.
+
+        Paramters
+        ---------
+        gbench_run_result : GBenchRunResult
+            The Google Benchmark results from a single run. This will be added
+            to the list of artifacts.
         """
         # iterate over the GBBenchResult objects
         for key, bench_result in gbench_run_result.benchmarks.items():
@@ -90,10 +115,28 @@ class ArtifactProcessor(object):
         return
 
     def get_comparison_for_publish_result(self, bench_name, gbench_result, lax_tolerance=None):
-        """ create and return a dict comparing the historical benchmark results
-        to the benchmark result passed in. This will format the results in a
-        way that the performance storage service will understand. The main 
-        difference between this method and get_comparison is stdev_throughput.
+        """ Create and return a dict comparing the historical benchmark results
+        to the benchmark result passed in.
+        
+        This will format the results in a way that the performance storage
+        service will understand. The main difference between this method and
+        get_comparison is stdev_throughput.
+
+        Parameters
+        ----------
+        bench_name : str
+            The name of the microbenchmark.
+        gbench_result : GBenchRunResult
+            The benchmark result to be compared against.
+        lax_tolerance : int, optional
+            The allowed level of tolerance for performance. This is only used
+            if there are not enough historical results. (The default is None).
+
+        Returns
+        -------
+        publishable_comparison : dict
+            An object with information about the microbenchmark results and how
+            it compares to the historical results.
         """
         initial_comparison = self.get_comparison(bench_name, gbench_result, lax_tolerance)
         fields = ['suite', 'test', 'throughput', 'tolerance',
@@ -110,8 +153,27 @@ class ArtifactProcessor(object):
         return publishable_comparison
 
     def get_comparison(self, bench_name, gbench_result, lax_tolerance=None):
-        """ create and return a dict comparing the historical benchmark results
-            to the benchmark result passed in
+        """ Compare the historical benchmark results to the benchmark result
+        passed in.
+
+        This will determine what type of comparison ref_type it should be based
+        on the number of historical results.
+
+        Parameters
+        ----------
+        bench_name : str
+            The name of the microbenchmark.
+        gbench_result : GBenchRunResult
+            The result to compare against.
+        lax_tolerance : int, optional
+            The allowed level of tolerance for performance. This is only used
+            if there are not enough historical results. (The default is None).
+
+        Returns
+        -------
+        dict
+            An object with information about the microbenchmark results and how
+            it compares to the historical results.
         """
         key = (gbench_result.suite_name, gbench_result.test_name)
         historical_results = self.artifacts.get(key, None)
@@ -124,9 +186,32 @@ class ArtifactProcessor(object):
         return self._create_comparison_dict(bench_name, gbench_result, ref_type, lax_tolerance)
 
     def _create_comparison_dict(self, bench_name, gbench_result, ref_type='none', lax_tolerance=None):
-        """ creates the comparison dict based on the ref type. It takes a
-        GBenchTestResult and compares it against the results for the same 
-        benchmark stored in the artifact processor. """
+        """ Creates the comparison dict based on the ref type.
+        
+        It takes a GBenchTestResult and compares it against the results for the
+        same benchmark stored in the artifact processor.
+        
+        Parameters
+        ----------
+        bench_name : str
+            The name of the microbenchmark.
+        gbench_result : GBenchRunResult
+            The result to compare against.
+        ref_type : str, optional
+            The type of comparison to do against the historical reference data.
+            The options are 'none', 'lax', 'historic'. 'none' does no
+            comparison, 'lax' uses a relaxed threshold, and 'historic' uses
+            normal thresholds. (The default is 'none').
+        lax_tolerance : int, optional
+            The allowed level of tolerance for performance. This is only used
+            if there are not enough historical results. (The default is None).
+
+        Returns
+        -------
+        dict
+            An object with information about the microbenchmark results and how
+            it compares to the historical results.
+        """
         key = (gbench_result.suite_name, gbench_result.test_name)
         LOG.debug("Loading {REF_TYPE} history data for {SUITE_NAME}.{TEST_NAME} [{BENCH_NAME}]".format(
             REF_TYPE=ref_type, SUITE_NAME=gbench_result.suite_name, TEST_NAME=gbench_result.test_name, BENCH_NAME=bench_name
@@ -152,7 +237,7 @@ class ArtifactProcessor(object):
             comparison['ref_throughput'] = historical_results.get_mean_throughput()
             comparison['coef_var'] = 100 * historical_results.get_stdev_throughput() / comparison.get('ref_throughput')
             comparison['change'] = 100 * (gbench_result.items_per_second -
-                                          comparison.get('ref_throughput')) / comparison.get('throughput')
+                                          comparison.get('ref_throughput')) / comparison.get('ref_throughput')
             comparison['status'] = 'PASS' if is_comparison_pass(comparison.get('ref_throughput'),
                                                                 comparison.get('throughput'),
                                                                 comparison.get('tolerance')) else 'FAIL'
@@ -160,7 +245,32 @@ class ArtifactProcessor(object):
 
 
 def is_comparison_pass(avg_historical_throughput, test_throughput, tolerance, ref_type='none'):
-    """ Determine whether or not to consider the benchmark test as passed """
+    """ Determine whether or not to consider the benchmark test as passed.
+    
+    This is based on whether the throughput of the microbenchmark has decreased
+    more than the allowed tolerance %.
+    
+    Parameters
+    ----------
+    avg_historical_throughput : int
+        The average of the historical results' throughput.
+    test_throughput : int
+        The throughput of the microbenchmark test result.
+    tolerance : int
+        The percentage decrease allowed in throughput.
+    ref_type : str, optional
+        The type of comparison to do against the historical reference data.
+        The options are 'none', 'lax', 'historic'. 'none' does no
+        comparison. Otherwise, a normal comparison is done. (The default is
+        'none').
+
+    Returns
+    -------
+    bool
+        True if the test_throughput is within the allowed limits or if no
+        comparison should be done (ref_type = 'none'). False if the throughput
+        has degraded beyond the allowed threashold.
+    """
     if ref_type == 'none':
         return True
     min_allowed_throughput = avg_historical_throughput - float(avg_historical_throughput) * (float(tolerance) / 100)


### PR DESCRIPTION
# Microbenchmark %change fix + improved documentation

## Description
Matt found a mistake in the % change calculation on the dashboards so I audited all the percentage change calculations. I found I made the same mistake with the microbenchmark script. The impact is minimal as this is only really used when the results are printed out in the terminal. While I was fixing the mistake I figured I would improve the documentation for the files that I touched. Now they follow the numpydocs formatting. If anyone wants to double check that % change is calculated correctly here is a snippet of the output. 
![Screen Shot 2021-01-31 at 12 26 11 PM](https://user-images.githubusercontent.com/15481251/106392395-97b42100-63bf-11eb-942e-cfdf2696b6bb.png)


## Performance
No impact

## Further Work
None