### PR TITLE
Change metrics sample interval to a sample rate [0,100]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,7 +117,7 @@ pipeline {
                         sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple', label: 'UnitTest (Simple)'
                         sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended', label: 'UnitTest (Extended)'
-                        sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended -a "pipeline_metrics_enable=True" -a "pipeline_metrics_interval=0" -a "counters_enable=True" -a "query_trace_metrics_enable=True"', label: 'UnitTest (Extended with pipeline metrics, counters, and query trace metrics)'
+                        sh script: 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended -a "pipeline_metrics_enable=True" -a "pipeline_metrics_sample_rate=100" -a "counters_enable=True" -a "query_trace_metrics_enable=True"', label: 'UnitTest (Extended with pipeline metrics, counters, and query trace metrics)'
                         sh script: 'sudo lsof -i -P -n | grep LISTEN || true', label: 'Check ports.'
                     }
                     post {

--- a/benchmark/integration/tpcc_benchmark.cpp
+++ b/benchmark/integration/tpcc_benchmark.cpp
@@ -271,7 +271,7 @@ BENCHMARK_DEFINE_F(TPCCBenchmark, ScaleFactor4WithLoggingAndMetrics)(benchmark::
     for (const auto &file : metrics::LoggingMetricRawData::FILES) unlink(std::string(file).c_str());
     auto *const metrics_manager = new metrics::MetricsManager;
     auto *const metrics_thread = new metrics::MetricsThread(common::ManagedPointer(metrics_manager), metrics_period_);
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::LOGGING, 0);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::LOGGING, 100);
     metrics_manager->EnableMetric(metrics::MetricsComponent::LOGGING);
     thread_registry_ = new common::DedicatedThreadRegistry{common::ManagedPointer(metrics_manager)};
     // we need transactions, TPCC database, and GC
@@ -377,7 +377,7 @@ BENCHMARK_DEFINE_F(TPCCBenchmark, ScaleFactor4WithMetrics)(benchmark::State &sta
     for (const auto &file : metrics::TransactionMetricRawData::FILES) unlink(std::string(file).c_str());
     auto *const metrics_manager = new metrics::MetricsManager;
     auto *const metrics_thread = new metrics::MetricsThread(common::ManagedPointer(metrics_manager), metrics_period_);
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::TRANSACTION, 0);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::TRANSACTION, 100);
     metrics_manager->EnableMetric(metrics::MetricsComponent::TRANSACTION);
     // we need transactions, TPCC database, and GC
     transaction::TimestampManager timestamp_manager;

--- a/benchmark/metrics/garbage_collection_metrics_benchmark.cpp
+++ b/benchmark/metrics/garbage_collection_metrics_benchmark.cpp
@@ -35,7 +35,7 @@ BENCHMARK_DEFINE_F(GarbageCollectionMetricsBenchmark, TPCCish)(benchmark::State 
     for (const auto &file : metrics::GarbageCollectionMetricRawData::FILES) unlink(std::string(file).c_str());
     auto *const metrics_manager = new metrics::MetricsManager();
     auto *const metrics_thread = new metrics::MetricsThread(common::ManagedPointer(metrics_manager), metrics_period_);
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::GARBAGECOLLECTION, 0);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::GARBAGECOLLECTION, 100);
     metrics_manager->EnableMetric(metrics::MetricsComponent::GARBAGECOLLECTION);
 
     LargeDataTableBenchmarkObject tested(attr_sizes_, initial_table_size_, txn_length, insert_update_select_ratio,
@@ -66,7 +66,7 @@ BENCHMARK_DEFINE_F(GarbageCollectionMetricsBenchmark, HighAbortRate)(benchmark::
     for (const auto &file : metrics::GarbageCollectionMetricRawData::FILES) unlink(std::string(file).c_str());
     auto *const metrics_manager = new metrics::MetricsManager();
     auto *const metrics_thread = new metrics::MetricsThread(common::ManagedPointer(metrics_manager), metrics_period_);
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::GARBAGECOLLECTION, 0);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::GARBAGECOLLECTION, 100);
     metrics_manager->EnableMetric(metrics::MetricsComponent::GARBAGECOLLECTION);
 
     LargeDataTableBenchmarkObject tested(attr_sizes_, 1000, txn_length, insert_update_select_ratio, &block_store_,
@@ -97,7 +97,7 @@ BENCHMARK_DEFINE_F(GarbageCollectionMetricsBenchmark, SingleStatementInsert)(ben
     for (const auto &file : metrics::GarbageCollectionMetricRawData::FILES) unlink(std::string(file).c_str());
     auto *const metrics_manager = new metrics::MetricsManager();
     auto *const metrics_thread = new metrics::MetricsThread(common::ManagedPointer(metrics_manager), metrics_period_);
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::GARBAGECOLLECTION, 0);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::GARBAGECOLLECTION, 100);
     metrics_manager->EnableMetric(metrics::MetricsComponent::GARBAGECOLLECTION);
 
     LargeDataTableBenchmarkObject tested(attr_sizes_, 0, txn_length, insert_update_select_ratio, &block_store_,
@@ -128,7 +128,7 @@ BENCHMARK_DEFINE_F(GarbageCollectionMetricsBenchmark, SingleStatementUpdate)(ben
     for (const auto &file : metrics::GarbageCollectionMetricRawData::FILES) unlink(std::string(file).c_str());
     auto *const metrics_manager = new metrics::MetricsManager();
     auto *const metrics_thread = new metrics::MetricsThread(common::ManagedPointer(metrics_manager), metrics_period_);
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::GARBAGECOLLECTION, 0);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::GARBAGECOLLECTION, 100);
     metrics_manager->EnableMetric(metrics::MetricsComponent::GARBAGECOLLECTION);
 
     LargeDataTableBenchmarkObject tested(attr_sizes_, initial_table_size_, txn_length, insert_update_select_ratio,
@@ -159,7 +159,7 @@ BENCHMARK_DEFINE_F(GarbageCollectionMetricsBenchmark, SingleStatementSelect)(ben
     for (const auto &file : metrics::GarbageCollectionMetricRawData::FILES) unlink(std::string(file).c_str());
     auto *const metrics_manager = new metrics::MetricsManager();
     auto *const metrics_thread = new metrics::MetricsThread(common::ManagedPointer(metrics_manager), metrics_period_);
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::GARBAGECOLLECTION, 0);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::GARBAGECOLLECTION, 100);
     metrics_manager->EnableMetric(metrics::MetricsComponent::GARBAGECOLLECTION);
 
     LargeDataTableBenchmarkObject tested(attr_sizes_, initial_table_size_, txn_length, insert_update_select_ratio,

--- a/benchmark/metrics/large_transaction_metrics_benchmark.cpp
+++ b/benchmark/metrics/large_transaction_metrics_benchmark.cpp
@@ -36,7 +36,7 @@ BENCHMARK_DEFINE_F(LargeTransactionMetricsBenchmark, TPCCish)(benchmark::State &
     for (const auto &file : metrics::TransactionMetricRawData::FILES) unlink(std::string(file).c_str());
     auto *const metrics_manager = new metrics::MetricsManager();
     auto *const metrics_thread = new metrics::MetricsThread(common::ManagedPointer(metrics_manager), metrics_period_);
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::TRANSACTION, 100);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::TRANSACTION, 1);
     metrics_manager->EnableMetric(metrics::MetricsComponent::TRANSACTION);
 
     LargeDataTableBenchmarkObject tested(attr_sizes_, initial_table_size_, txn_length, insert_update_select_ratio,
@@ -68,7 +68,7 @@ BENCHMARK_DEFINE_F(LargeTransactionMetricsBenchmark, HighAbortRate)(benchmark::S
     for (const auto &file : metrics::TransactionMetricRawData::FILES) unlink(std::string(file).c_str());
     auto *const metrics_manager = new metrics::MetricsManager();
     auto *const metrics_thread = new metrics::MetricsThread(common::ManagedPointer(metrics_manager), metrics_period_);
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::TRANSACTION, 100);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::TRANSACTION, 1);
     metrics_manager->EnableMetric(metrics::MetricsComponent::TRANSACTION);
 
     // use a smaller table to make aborts more likely
@@ -101,7 +101,7 @@ BENCHMARK_DEFINE_F(LargeTransactionMetricsBenchmark, SingleStatementInsert)(benc
     for (const auto &file : metrics::TransactionMetricRawData::FILES) unlink(std::string(file).c_str());
     auto *const metrics_manager = new metrics::MetricsManager();
     auto *const metrics_thread = new metrics::MetricsThread(common::ManagedPointer(metrics_manager), metrics_period_);
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::TRANSACTION, 100);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::TRANSACTION, 1);
     metrics_manager->EnableMetric(metrics::MetricsComponent::TRANSACTION);
 
     // don't need any initial tuples
@@ -134,7 +134,7 @@ BENCHMARK_DEFINE_F(LargeTransactionMetricsBenchmark, SingleStatementUpdate)(benc
     for (const auto &file : metrics::TransactionMetricRawData::FILES) unlink(std::string(file).c_str());
     auto *const metrics_manager = new metrics::MetricsManager();
     auto *const metrics_thread = new metrics::MetricsThread(common::ManagedPointer(metrics_manager), metrics_period_);
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::TRANSACTION, 100);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::TRANSACTION, 1);
     metrics_manager->EnableMetric(metrics::MetricsComponent::TRANSACTION);
 
     LargeDataTableBenchmarkObject tested(attr_sizes_, initial_table_size_, txn_length, insert_update_select_ratio,
@@ -166,7 +166,7 @@ BENCHMARK_DEFINE_F(LargeTransactionMetricsBenchmark, SingleStatementSelect)(benc
     for (const auto &file : metrics::TransactionMetricRawData::FILES) unlink(std::string(file).c_str());
     auto *const metrics_manager = new metrics::MetricsManager();
     auto *const metrics_thread = new metrics::MetricsThread(common::ManagedPointer(metrics_manager), metrics_period_);
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::TRANSACTION, 100);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::TRANSACTION, 1);
     metrics_manager->EnableMetric(metrics::MetricsComponent::TRANSACTION);
 
     LargeDataTableBenchmarkObject tested(attr_sizes_, initial_table_size_, txn_length, insert_update_select_ratio,

--- a/benchmark/metrics/logging_metrics_benchmark.cpp
+++ b/benchmark/metrics/logging_metrics_benchmark.cpp
@@ -51,7 +51,7 @@ BENCHMARK_DEFINE_F(LoggingMetricsBenchmark, TPCCish)(benchmark::State &state) {
     for (const auto &file : metrics::LoggingMetricRawData::FILES) unlink(std::string(file).c_str());
     auto *const metrics_manager = new metrics::MetricsManager();
     auto *const metrics_thread = new metrics::MetricsThread(common::ManagedPointer(metrics_manager), metrics_period_);
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::LOGGING, 0);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::LOGGING, 100);
     metrics_manager->EnableMetric(metrics::MetricsComponent::LOGGING);
     thread_registry_ = new common::DedicatedThreadRegistry(common::ManagedPointer(metrics_manager));
 
@@ -102,7 +102,7 @@ BENCHMARK_DEFINE_F(LoggingMetricsBenchmark, HighAbortRate)(benchmark::State &sta
     for (const auto &file : metrics::LoggingMetricRawData::FILES) unlink(std::string(file).c_str());
     auto *const metrics_manager = new metrics::MetricsManager();
     auto *const metrics_thread = new metrics::MetricsThread(common::ManagedPointer(metrics_manager), metrics_period_);
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::LOGGING, 0);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::LOGGING, 100);
     metrics_manager->EnableMetric(metrics::MetricsComponent::LOGGING);
     thread_registry_ = new common::DedicatedThreadRegistry(common::ManagedPointer(metrics_manager));
 
@@ -153,7 +153,7 @@ BENCHMARK_DEFINE_F(LoggingMetricsBenchmark, SingleStatementInsert)(benchmark::St
     for (const auto &file : metrics::LoggingMetricRawData::FILES) unlink(std::string(file).c_str());
     auto *const metrics_manager = new metrics::MetricsManager();
     auto *const metrics_thread = new metrics::MetricsThread(common::ManagedPointer(metrics_manager), metrics_period_);
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::LOGGING, 0);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::LOGGING, 100);
     metrics_manager->EnableMetric(metrics::MetricsComponent::LOGGING);
     thread_registry_ = new common::DedicatedThreadRegistry(common::ManagedPointer(metrics_manager));
 
@@ -204,7 +204,7 @@ BENCHMARK_DEFINE_F(LoggingMetricsBenchmark, SingleStatementUpdate)(benchmark::St
     for (const auto &file : metrics::LoggingMetricRawData::FILES) unlink(std::string(file).c_str());
     auto *const metrics_manager = new metrics::MetricsManager();
     auto *const metrics_thread = new metrics::MetricsThread(common::ManagedPointer(metrics_manager), metrics_period_);
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::LOGGING, 0);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::LOGGING, 100);
     metrics_manager->EnableMetric(metrics::MetricsComponent::LOGGING);
     thread_registry_ = new common::DedicatedThreadRegistry(common::ManagedPointer(metrics_manager));
 
@@ -255,7 +255,7 @@ BENCHMARK_DEFINE_F(LoggingMetricsBenchmark, SingleStatementSelect)(benchmark::St
     for (const auto &file : metrics::LoggingMetricRawData::FILES) unlink(std::string(file).c_str());
     auto *const metrics_manager = new metrics::MetricsManager();
     auto *const metrics_thread = new metrics::MetricsThread(common::ManagedPointer(metrics_manager), metrics_period_);
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::LOGGING, 0);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::LOGGING, 100);
     metrics_manager->EnableMetric(metrics::MetricsComponent::LOGGING);
     thread_registry_ = new common::DedicatedThreadRegistry(common::ManagedPointer(metrics_manager));
 

--- a/benchmark/runner/mini_runners.cpp
+++ b/benchmark/runner/mini_runners.cpp
@@ -2018,7 +2018,7 @@ void InitializeRunnersState() {
   auto catalog = db_main->GetCatalogLayer()->GetCatalog();
   auto txn_manager = db_main->GetTransactionLayer()->GetTransactionManager();
   DbMainSetParam<settings::Param::pipeline_metrics_enable, bool>(true);
-  DbMainSetParam<settings::Param::pipeline_metrics_interval, int>(0);
+  DbMainSetParam<settings::Param::pipeline_metrics_sample_rate, int>(100);
 
   // Create the database
   auto txn = txn_manager->BeginTransaction();

--- a/benchmark/runner/tpcc_runner.cpp
+++ b/benchmark/runner/tpcc_runner.cpp
@@ -45,11 +45,11 @@ class TPCCRunner : public benchmark::Fixture {
     db_main_ = db_main_builder.Build();
 
     auto metrics_manager = db_main_->GetMetricsManager();
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::EXECUTION, 0);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::EXECUTION, 100);
     metrics_manager->EnableMetric(metrics::MetricsComponent::EXECUTION);
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::GARBAGECOLLECTION, 0);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::GARBAGECOLLECTION, 100);
     metrics_manager->EnableMetric(metrics::MetricsComponent::GARBAGECOLLECTION);
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::LOGGING, 0);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::LOGGING, 100);
     metrics_manager->EnableMetric(metrics::MetricsComponent::LOGGING);
   }
 

--- a/benchmark/runner/tpch_runner.cpp
+++ b/benchmark/runner/tpch_runner.cpp
@@ -40,7 +40,7 @@ class TPCHRunner : public benchmark::Fixture {
     db_main_ = db_main_builder.Build();
 
     auto metrics_manager = db_main_->GetMetricsManager();
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::EXECUTION_PIPELINE, 0);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::EXECUTION_PIPELINE, 100);
     metrics_manager->EnableMetric(metrics::MetricsComponent::EXECUTION_PIPELINE);
   }
 

--- a/benchmark/runner/transaction_logging_gc_runner.cpp
+++ b/benchmark/runner/transaction_logging_gc_runner.cpp
@@ -68,7 +68,7 @@ BENCHMARK_DEFINE_F(TransactionLoggingGCRunner, TransactionRunner)(benchmark::Sta
     // log all of the Inserts from table creation
     log_manager_->ForceFlush();
 
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::TRANSACTION, 49);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::TRANSACTION, 2);
     metrics_manager->EnableMetric(metrics::MetricsComponent::TRANSACTION);
 
     gc_ = new storage::GarbageCollector(common::ManagedPointer(tested.GetTimestampManager()), DISABLED,
@@ -129,9 +129,9 @@ BENCHMARK_DEFINE_F(TransactionLoggingGCRunner, LoggingGCRunner)(benchmark::State
     // log all of the Inserts from table creation
     log_manager_->ForceFlush();
 
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::LOGGING, 0);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::LOGGING, 100);
     metrics_manager->EnableMetric(metrics::MetricsComponent::LOGGING);
-    metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::GARBAGECOLLECTION, 0);
+    metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::GARBAGECOLLECTION, 100);
     metrics_manager->EnableMetric(metrics::MetricsComponent::GARBAGECOLLECTION);
 
     gc_ = new storage::GarbageCollector(common::ManagedPointer(tested.GetTimestampManager()), DISABLED,

--- a/src/include/main/db_main.h
+++ b/src/include/main/db_main.h
@@ -786,7 +786,7 @@ class DBMain {
     bool use_metrics_thread_ = false;
     bool query_trace_metrics_ = false;
     bool pipeline_metrics_ = false;
-    uint32_t pipeline_metrics_interval_ = 9;
+    uint8_t pipeline_metrics_sample_rate_ = 10;
     bool transaction_metrics_ = false;
     bool logging_metrics_ = false;
     bool gc_metrics_ = false;
@@ -887,7 +887,7 @@ class DBMain {
 
       query_trace_metrics_ = settings_manager->GetBool(settings::Param::query_trace_metrics_enable);
       pipeline_metrics_ = settings_manager->GetBool(settings::Param::pipeline_metrics_enable);
-      pipeline_metrics_interval_ = settings_manager->GetInt(settings::Param::pipeline_metrics_interval);
+      pipeline_metrics_sample_rate_ = settings_manager->GetInt(settings::Param::pipeline_metrics_sample_rate);
       transaction_metrics_ = settings_manager->GetBool(settings::Param::transaction_metrics_enable);
       logging_metrics_ = settings_manager->GetBool(settings::Param::logging_metrics_enable);
       gc_metrics_ = settings_manager->GetBool(settings::Param::gc_metrics_enable);
@@ -907,8 +907,8 @@ class DBMain {
      */
     std::unique_ptr<metrics::MetricsManager> BootstrapMetricsManager() {
       std::unique_ptr<metrics::MetricsManager> metrics_manager = std::make_unique<metrics::MetricsManager>();
-      metrics_manager->SetMetricSampleInterval(metrics::MetricsComponent::EXECUTION_PIPELINE,
-                                               pipeline_metrics_interval_);
+      metrics_manager->SetMetricSampleRate(metrics::MetricsComponent::EXECUTION_PIPELINE,
+                                           pipeline_metrics_sample_rate_);
 
       if (query_trace_metrics_) metrics_manager->EnableMetric(metrics::MetricsComponent::QUERY_TRACE);
       if (pipeline_metrics_) metrics_manager->EnableMetric(metrics::MetricsComponent::EXECUTION_PIPELINE);

--- a/src/include/metrics/metrics_manager.h
+++ b/src/include/metrics/metrics_manager.h
@@ -23,6 +23,8 @@ namespace noisepage::metrics {
  */
 class MetricsManager {
  public:
+  MetricsManager();
+
   /**
    * Aggregate metrics from all threads which have collected stats, combine with what was previously collected
    *
@@ -75,12 +77,9 @@ class MetricsManager {
 
   /**
    * @param component to update
-   * @param sample_interval the interval between recording two metrics for the component. 0 means recording every metric
+   * @param sample_rate sampling rate of 0 to 100, expressed as a percentage of data points. 100 means all data, 0 none
    */
-  void SetMetricSampleInterval(const MetricsComponent component, uint32_t sample_interval) {
-    common::SpinLatch::ScopedSpinLatch guard(&latch_);
-    sample_interval_[static_cast<uint8_t>(component)] = sample_interval;
-  }
+  void SetMetricSampleRate(MetricsComponent component, uint8_t sample_rate);
 
   /**
    * @param component to be disabled
@@ -102,7 +101,7 @@ class MetricsManager {
 
   std::bitset<NUM_COMPONENTS> enabled_metrics_ = 0x0;
 
-  std::array<uint32_t, NUM_COMPONENTS> sample_interval_{0x0};
+  std::array<std::bitset<100>, NUM_COMPONENTS> samples_;
 };
 
 }  // namespace noisepage::metrics

--- a/src/include/metrics/metrics_manager.h
+++ b/src/include/metrics/metrics_manager.h
@@ -101,7 +101,7 @@ class MetricsManager {
 
   std::bitset<NUM_COMPONENTS> enabled_metrics_ = 0x0;
 
-  std::array<std::bitset<100>, NUM_COMPONENTS> samples_;
+  std::array<std::vector<bool>, NUM_COMPONENTS> samples_mask_;  // std::vector<bool> may use a bitset for efficiency
 };
 
 }  // namespace noisepage::metrics

--- a/src/include/metrics/metrics_store.h
+++ b/src/include/metrics/metrics_store.h
@@ -222,7 +222,7 @@ class MetricsStore {
    * interval, false otherwise
    */
   bool ComponentToRecord(const MetricsComponent component) {
-    auto component_index = static_cast<uint8_t>(component);
+    const auto component_index = static_cast<uint8_t>(component);
     if (!enabled_metrics_.test(component_index)) return false;
 
     // increment the sample count to use as our index into the bitset
@@ -230,7 +230,7 @@ class MetricsStore {
 
     const auto sample_count = sample_count_[component_index];
 
-    return samples_[component_index].test(sample_count);
+    return samples_mask_[component_index][sample_count];
   }
 
   /**
@@ -245,7 +245,7 @@ class MetricsStore {
 
   explicit MetricsStore(common::ManagedPointer<metrics::MetricsManager> metrics_manager,
                         const std::bitset<NUM_COMPONENTS> &enabled_metrics,
-                        const std::array<std::bitset<100>, NUM_COMPONENTS> &sample_rate);
+                        const std::array<std::vector<bool>, NUM_COMPONENTS> &samples_mask_);
 
   std::array<std::unique_ptr<AbstractRawData>, NUM_COMPONENTS> GetDataToAggregate();
 
@@ -259,7 +259,7 @@ class MetricsStore {
   std::unique_ptr<ExecuteCommandMetric> execute_command_metric_;
 
   const std::bitset<NUM_COMPONENTS> &enabled_metrics_;
-  const std::array<std::bitset<100>, NUM_COMPONENTS> &samples_;
+  const std::array<std::vector<bool>, NUM_COMPONENTS> &samples_mask_;
   std::array<uint8_t, NUM_COMPONENTS> sample_count_{0};
 };
 

--- a/src/include/settings/settings_callbacks.h
+++ b/src/include/settings/settings_callbacks.h
@@ -145,8 +145,8 @@ class Callbacks {
    * @param db_main pointer to db_main
    * @param action_context pointer to the action context for this settings change
    */
-  static void MetricsPipelineSamplingInterval(void *old_value, void *new_value, DBMain *db_main,
-                                              common::ManagedPointer<common::ActionContext> action_context);
+  static void MetricsPipelineSampleRate(void *old_value, void *new_value, DBMain *db_main,
+                                        common::ManagedPointer<common::ActionContext> action_context);
 
   /**
    * Enable or disable metrics collection for bind command

--- a/src/include/settings/settings_defs.h
+++ b/src/include/settings/settings_defs.h
@@ -286,14 +286,13 @@ SETTING_bool(
 )
 
 SETTING_int(
-    pipeline_metrics_interval,
-    "Sampling rate of metrics collection for the ExecutionEngine pipelines with 0 = 100%, 1 = 50%, "
-    "9 = 10%, X = 1/(X+1)% (default: 9 for 10%).",
-    9,
-    0,
+    pipeline_metrics_sample_rate,
+    "Sampling rate of metrics collection for the ExecutionEngine pipelines.",
     10,
+    0,
+    100,
     true,
-    noisepage::settings::Callbacks::MetricsPipelineSamplingInterval
+    noisepage::settings::Callbacks::MetricsPipelineSampleRate
 )
 
 SETTING_bool(

--- a/src/metrics/metrics_manager.cpp
+++ b/src/metrics/metrics_manager.cpp
@@ -2,8 +2,10 @@
 
 #include <sys/stat.h>
 
+#include <algorithm>
 #include <fstream>
 #include <memory>
+#include <random>
 #include <string>
 #include <utility>
 #include <vector>
@@ -36,13 +38,9 @@ void OpenFiles(std::vector<std::ofstream> *outfiles) {
 
 MetricsManager::MetricsManager() {
   // construct a bitset of all true (sampling rate 100) by default
-  std::bitset<100> samples;
-  for (uint8_t i = 0; i < 100; i++) {
-    samples.set(i);
-  }
-  NOISEPAGE_ASSERT(samples.all(), "All samples should be set to true.");
+  std::vector<bool> samples_mask(100, true);
   for (uint8_t i = 0; i < NUM_COMPONENTS; i++) {
-    samples_[i] = samples;
+    samples_mask_[i] = samples_mask;
   }
 }
 
@@ -64,12 +62,20 @@ void MetricsManager::Aggregate() {
 
 void MetricsManager::SetMetricSampleRate(const MetricsComponent component, const uint8_t sample_rate) {
   NOISEPAGE_ASSERT(sample_rate >= 0 && sample_rate <= 100, "Invalid sampling rate.");
-  std::bitset<100> samples;
+  // create a bitset with the correct number of trues based on sample rate
+  std::vector<bool> samples_mask(100, false);
   for (uint8_t i = 0; i < sample_rate; i++) {
-    samples.set(i);
+    samples_mask[i] = true;
   }
+  // shuffle the bitset to distribute the samples
+  auto rd = std::random_device{};
+  auto rng = std::default_random_engine{rd()};
+  std::shuffle(samples_mask.begin(), samples_mask.end(), rng);
+  // replace the existing samples mask for this component in the global data structure
+  NOISEPAGE_ASSERT(std::count(samples_mask.begin(), samples_mask.end(), true) == sample_rate,
+                   "Vector should count number of trues equal to sample rate.");
   common::SpinLatch::ScopedSpinLatch guard(&latch_);
-  samples_[static_cast<uint8_t>(component)] = samples;
+  samples_mask_[static_cast<uint8_t>(component)] = samples_mask;
 }
 
 void MetricsManager::ResetMetric(const MetricsComponent component) const {
@@ -124,7 +130,7 @@ void MetricsManager::RegisterThread() {
   const auto thread_id = std::this_thread::get_id();
   NOISEPAGE_ASSERT(stores_map_.count(thread_id) == 0, "This thread was already registered.");
   auto result =
-      stores_map_.emplace(thread_id, new MetricsStore(common::ManagedPointer(this), enabled_metrics_, samples_));
+      stores_map_.emplace(thread_id, new MetricsStore(common::ManagedPointer(this), enabled_metrics_, samples_mask_));
   NOISEPAGE_ASSERT(result.second, "Insertion to concurrent map failed.");
   common::thread_context.metrics_store_ = result.first->second;
 }

--- a/src/metrics/metrics_store.cpp
+++ b/src/metrics/metrics_store.cpp
@@ -11,8 +11,8 @@ namespace noisepage::metrics {
 
 MetricsStore::MetricsStore(const common::ManagedPointer<metrics::MetricsManager> metrics_manager,
                            const std::bitset<NUM_COMPONENTS> &enabled_metrics,
-                           const std::array<uint32_t, NUM_COMPONENTS> &sampling_masks)
-    : metrics_manager_(metrics_manager), enabled_metrics_{enabled_metrics}, sample_interval_(sampling_masks) {
+                           const std::array<std::bitset<100>, NUM_COMPONENTS> &samples)
+    : metrics_manager_(metrics_manager), enabled_metrics_{enabled_metrics}, samples_(samples) {
   logging_metric_ = std::make_unique<LoggingMetric>();
   txn_metric_ = std::make_unique<TransactionMetric>();
   gc_metric_ = std::make_unique<GarbageCollectionMetric>();

--- a/src/metrics/metrics_store.cpp
+++ b/src/metrics/metrics_store.cpp
@@ -11,8 +11,8 @@ namespace noisepage::metrics {
 
 MetricsStore::MetricsStore(const common::ManagedPointer<metrics::MetricsManager> metrics_manager,
                            const std::bitset<NUM_COMPONENTS> &enabled_metrics,
-                           const std::array<std::bitset<100>, NUM_COMPONENTS> &samples)
-    : metrics_manager_(metrics_manager), enabled_metrics_{enabled_metrics}, samples_(samples) {
+                           const std::array<std::vector<bool>, NUM_COMPONENTS> &samples_mask)
+    : metrics_manager_(metrics_manager), enabled_metrics_{enabled_metrics}, samples_mask_(samples_mask) {
   logging_metric_ = std::make_unique<LoggingMetric>();
   txn_metric_ = std::make_unique<TransactionMetric>();
   gc_metric_ = std::make_unique<GarbageCollectionMetric>();

--- a/src/self_driving/pilot/pilot.cpp
+++ b/src/self_driving/pilot/pilot.cpp
@@ -44,24 +44,24 @@ void Pilot::PerformPlanning() {
 
 void Pilot::ExecuteForecast() {
   NOISEPAGE_ASSERT(forecast_ != nullptr, "Need forecast_ initialized.");
-  bool oldval = settings_manager_->GetBool(settings::Param::pipeline_metrics_enable);
-  bool oldcounter = settings_manager_->GetBool(settings::Param::counters_enable);
-  uint64_t oldintv = settings_manager_->GetInt64(settings::Param::pipeline_metrics_interval);
+  const bool old_metrics_enable = settings_manager_->GetBool(settings::Param::pipeline_metrics_enable);
+  const bool old_counters_enable = settings_manager_->GetBool(settings::Param::counters_enable);
+  const auto old_sample_rate = settings_manager_->GetInt64(settings::Param::pipeline_metrics_sample_rate);
 
   auto action_context = std::make_unique<common::ActionContext>(common::action_id_t(1));
-  if (!oldval) {
+  if (!old_metrics_enable) {
     settings_manager_->SetBool(settings::Param::pipeline_metrics_enable, true, common::ManagedPointer(action_context),
                                EmptySetterCallback);
   }
 
   action_context = std::make_unique<common::ActionContext>(common::action_id_t(2));
-  if (!oldcounter) {
+  if (!old_counters_enable) {
     settings_manager_->SetBool(settings::Param::counters_enable, true, common::ManagedPointer(action_context),
                                EmptySetterCallback);
   }
 
   action_context = std::make_unique<common::ActionContext>(common::action_id_t(3));
-  settings_manager_->SetInt(settings::Param::pipeline_metrics_interval, 0, common::ManagedPointer(action_context),
+  settings_manager_->SetInt(settings::Param::pipeline_metrics_sample_rate, 100, common::ManagedPointer(action_context),
                             EmptySetterCallback);
 
   auto pipeline_data = PilotUtil::CollectPipelineFeatures(common::ManagedPointer<selfdriving::Pilot>(this),
@@ -71,20 +71,20 @@ void Pilot::ExecuteForecast() {
   PilotUtil::InferenceWithFeatures(model_save_path_, model_server_manager_, pipeline_data, &pipeline_to_prediction);
 
   action_context = std::make_unique<common::ActionContext>(common::action_id_t(4));
-  if (!oldval) {
+  if (!old_metrics_enable) {
     settings_manager_->SetBool(settings::Param::pipeline_metrics_enable, false, common::ManagedPointer(action_context),
                                EmptySetterCallback);
   }
 
   action_context = std::make_unique<common::ActionContext>(common::action_id_t(5));
-  if (!oldcounter) {
+  if (!old_counters_enable) {
     settings_manager_->SetBool(settings::Param::counters_enable, false, common::ManagedPointer(action_context),
                                EmptySetterCallback);
   }
 
   action_context = std::make_unique<common::ActionContext>(common::action_id_t(6));
-  settings_manager_->SetInt(settings::Param::pipeline_metrics_interval, oldintv, common::ManagedPointer(action_context),
-                            EmptySetterCallback);
+  settings_manager_->SetInt(settings::Param::pipeline_metrics_sample_rate, old_sample_rate,
+                            common::ManagedPointer(action_context), EmptySetterCallback);
 }
 
 }  // namespace noisepage::selfdriving

--- a/src/settings/settings_callbacks.cpp
+++ b/src/settings/settings_callbacks.cpp
@@ -123,11 +123,12 @@ void Callbacks::MetricsPipeline(void *const old_value, void *const new_value, DB
   action_context->SetState(common::ActionState::SUCCESS);
 }
 
-void Callbacks::MetricsPipelineSamplingInterval(void *old_value, void *new_value, DBMain *db_main,
-                                                common::ManagedPointer<common::ActionContext> action_context) {
+void Callbacks::MetricsPipelineSampleRate(void *old_value, void *new_value, DBMain *db_main,
+                                          common::ManagedPointer<common::ActionContext> action_context) {
   action_context->SetState(common::ActionState::IN_PROGRESS);
   int interval = *static_cast<int *>(new_value);
-  db_main->GetMetricsManager()->SetMetricSampleInterval(metrics::MetricsComponent::EXECUTION_PIPELINE, interval);
+  db_main->GetMetricsManager()->SetMetricSampleRate(metrics::MetricsComponent::EXECUTION_PIPELINE,
+                                                    static_cast<uint8_t>(interval));
   action_context->SetState(common::ActionState::SUCCESS);
 }
 

--- a/test/integration/tpcc_test.cpp
+++ b/test/integration/tpcc_test.cpp
@@ -59,8 +59,8 @@ class TPCCTests : public TerrierTest {
     if (metrics_enabled) {
       db_main->GetMetricsManager()->EnableMetric(metrics::MetricsComponent::LOGGING);
       db_main->GetMetricsManager()->EnableMetric(metrics::MetricsComponent::TRANSACTION);
-      db_main->GetMetricsManager()->SetMetricSampleInterval(metrics::MetricsComponent::LOGGING, 0);
-      db_main->GetMetricsManager()->SetMetricSampleInterval(metrics::MetricsComponent::TRANSACTION, 100);
+      db_main->GetMetricsManager()->SetMetricSampleRate(metrics::MetricsComponent::LOGGING, 100);
+      db_main->GetMetricsManager()->SetMetricSampleRate(metrics::MetricsComponent::TRANSACTION, 1);
     }
 
     auto block_store = db_main->GetStorageLayer()->GetBlockStore();

--- a/test/metrics/metrics_test.cpp
+++ b/test/metrics/metrics_test.cpp
@@ -255,7 +255,7 @@ TEST_F(MetricsTests, PipelineCSVTest) {
     if (update_interval) {
       // Set the sampling interval correctly
       auto action_context = std::make_unique<common::ActionContext>(common::action_id_t(2));
-      settings_manager_->SetInt(settings::Param::pipeline_metrics_interval, interval,
+      settings_manager_->SetInt(settings::Param::pipeline_metrics_sample_rate, interval,
                                 common::ManagedPointer(action_context), setter_callback);
     }
 
@@ -291,16 +291,16 @@ TEST_F(MetricsTests, PipelineCSVTest) {
   insert_txn(port_, true, 0);
 
   // Enable, interval = 0, 5 inserts means 5 recorded data points
-  verify_scenario(true, true, 0, 5, 5);
+  verify_scenario(true, true, 100, 5, 5);
 
   // Disable, interval = 1, 5 inserts means 0 recorded data points
-  verify_scenario(false, true, 1, 5, 0);
+  verify_scenario(false, true, 50, 5, 0);
 
-  // Enable, keep interval, 5 inserts means 2 recorded data points
-  verify_scenario(true, false, 0, 5, 2);
+  // Enable, keep interval, 100 inserts means 2 recorded data points
+  verify_scenario(true, false, 100, 100, 50);
 
   // Enable, interval = 3, 5 inserts means 1 recorded data points
-  verify_scenario(true, true, 3, 5, 1);
+  verify_scenario(true, true, 25, 100, 25);
 }
 
 /**

--- a/test/metrics/metrics_test.cpp
+++ b/test/metrics/metrics_test.cpp
@@ -290,16 +290,16 @@ TEST_F(MetricsTests, PipelineCSVTest) {
   // Create table
   insert_txn(port_, true, 0);
 
-  // Enable, interval = 0, 5 inserts means 5 recorded data points
+  // Enable, rate = 100, 5 inserts means 5 recorded data points
   verify_scenario(true, true, 100, 5, 5);
 
-  // Disable, interval = 1, 5 inserts means 0 recorded data points
+  // Disable, rate = 50, 5 inserts means 0 recorded data points
   verify_scenario(false, true, 50, 5, 0);
 
-  // Enable, keep interval, 100 inserts means 2 recorded data points
+  // Enable, keep rate, 100 inserts means 50 recorded data points
   verify_scenario(true, false, 100, 100, 50);
 
-  // Enable, interval = 3, 5 inserts means 1 recorded data points
+  // Enable, rate = 25, 100 inserts means 25 recorded data points
   verify_scenario(true, true, 25, 100, 25);
 }
 


### PR DESCRIPTION
### Overview
Change metrics sampling interval to a sampling rate based on %.

### Motivation
I need to change pipeline metrics sampling at a finer granularity than currently offered with the interval implementation.

### Changes
There's a new setting to replace the interval. Default value is 10% just like the current sample interval of 9. Refactored tests and pilot. There's a side effect that it takes 100 queries to see this sample rate, rather than the old interval method. For example, if you set a sample rate of 10%, and run 10 queries, you may not see any samples generated. This is because the samples are distributed randomly in a bitset of 100 values, so it can take 100 samples to get the 10 you expect for 10% sampling.