### PR TITLE
Fix missing artifact stats import.

### DIFF
--- a/script/testing/artifact_stats/base_artifact_stats_collector.py
+++ b/script/testing/artifact_stats/base_artifact_stats_collector.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod
+from abc import ABC, ABCMeta, abstractmethod
 
 
 class BaseArtifactStatsCollector(ABC):


### PR DESCRIPTION
In a PR comment, changed inheritance from `object` to `ABC` but forgot to import it.