### PR TITLE
Proposal: Improve Commit Hash in Testing Reporting 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -373,6 +373,7 @@ pipeline {
                         //Do not change.
                         //Performance Storage Service(Django) authentication information. The credentials can only be changed on Jenkins webpage
                         PSS_CREATOR = credentials('pss-creator')
+                        GITHUB_TOKEN = credentials('github-token-read-only')
                     }
                     steps {
                         sh 'echo $NODE_NAME'
@@ -386,32 +387,32 @@ pipeline {
 
                         sh script:'''
                         cd build
-                        PYTHONPATH=.. timeout 10m python3 -m script.testing.oltpbench --config-file=../script/testing/oltpbench/configs/end_to_end_performance/tatp.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
+                        PYTHONPATH=.. timeout 10m python3 -m script.testing.oltpbench --config-file=../script/testing/oltpbench/configs/end_to_end_performance/tatp.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW} --github-token=${GITHUB_TOKEN}
                         ''', label: 'OLTPBench (TATP)'
 
                         sh script:'''
                         cd build
-                        PYTHONPATH=.. timeout 10m python3 -m script.testing.oltpbench --config-file=../script/testing/oltpbench/configs/end_to_end_performance/tatp_wal_disabled.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
+                        PYTHONPATH=.. timeout 10m python3 -m script.testing.oltpbench --config-file=../script/testing/oltpbench/configs/end_to_end_performance/tatp_wal_disabled.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW} --github-token=${GITHUB_TOKEN}
                         ''', label: 'OLTPBench (TATP No WAL)'
 
                         sh script:'''
                         cd build
-                        PYTHONPATH=.. timeout 10m python3 -m script.testing.oltpbench --config-file=../script/testing/oltpbench/configs/end_to_end_performance/tatp_wal_ramdisk.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
+                        PYTHONPATH=.. timeout 10m python3 -m script.testing.oltpbench --config-file=../script/testing/oltpbench/configs/end_to_end_performance/tatp_wal_ramdisk.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW} --github-token=${GITHUB_TOKEN}
                         ''', label: 'OLTPBench (TATP RamDisk WAL)'
 
                         sh script:'''
                         cd build
-                        PYTHONPATH=.. timeout 30m python3 -m script.testing.oltpbench --config-file=../script/testing/oltpbench/configs/end_to_end_performance/tpcc.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
+                        PYTHONPATH=.. timeout 30m python3 -m script.testing.oltpbench --config-file=../script/testing/oltpbench/configs/end_to_end_performance/tpcc.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW} --github-token=${GITHUB_TOKEN}
                         ''', label: 'OLTPBench (TPCC HDD WAL)'
 
                         sh script:'''
                         cd build
-                        PYTHONPATH=.. timeout 30m python3 -m script.testing.oltpbench --config-file=../script/testing/oltpbench/configs/end_to_end_performance/tpcc_wal_disabled.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
+                        PYTHONPATH=.. timeout 30m python3 -m script.testing.oltpbench --config-file=../script/testing/oltpbench/configs/end_to_end_performance/tpcc_wal_disabled.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW} --github-token=${GITHUB_TOKEN}
                         ''', label: 'OLTPBench (TPCC No WAL)'
 
                         sh script:'''
                         cd build
-                        PYTHONPATH=.. timeout 30m python3 -m script.testing.oltpbench --config-file=../script/testing/oltpbench/configs/end_to_end_performance/tpcc_wal_ramdisk.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
+                        PYTHONPATH=.. timeout 30m python3 -m script.testing.oltpbench --config-file=../script/testing/oltpbench/configs/end_to_end_performance/tpcc_wal_ramdisk.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW} --github-token=${GITHUB_TOKEN}
                         ''', label: 'OLTPBench (TPCC RamDisk WAL)'
                     }
                     post {

--- a/Jenkinsfile-nightly
+++ b/Jenkinsfile-nightly
@@ -9,6 +9,7 @@ pipeline {
         // Performance Storage Service(Django) authentication information.
         // The credentials can only be changed on the Jenkins webpage.
         PSS_CREATOR = credentials('pss-creator')
+        GITHUB_TOKEN = credentials('github-token-read-only')
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '30'))
@@ -38,7 +39,7 @@ pipeline {
 
                 sh script: '''
                 cd build
-                PYTHONPATH=.. python3 -m script.testing.artifact_stats --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
+                PYTHONPATH=.. python3 -m script.testing.artifact_stats --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW} --github-token=${GITHUB_TOKEN}
                 ''', label: 'Artifact Stats'
             }
             post {
@@ -62,19 +63,19 @@ pipeline {
                 catchError(stageResult: 'Failure'){
                     sh script:'''
                     cd build
-                    PYTHONPATH=.. timeout 3h python3 -m script.testing.oltpbench --config-file=../script/testing/oltpbench/configs/nightly/nightly.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
+                    PYTHONPATH=.. timeout 3h python3 -m script.testing.oltpbench --config-file=../script/testing/oltpbench/configs/nightly/nightly.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW} --github-token=${GITHUB_TOKEN}
                     ''', label: 'OLTPBench (HDD WAL)'
                 }
                 catchError(stageResult: 'Failure'){
                     sh script:'''
                     cd build
-                    PYTHONPATH=.. timeout 3h python3 -m script.testing.oltpbench --config-file=../script/testing/oltpbench/configs/nightly/nightly_ramdisk.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
+                    PYTHONPATH=.. timeout 3h python3 -m script.testing.oltpbench --config-file=../script/testing/oltpbench/configs/nightly/nightly_ramdisk.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW} --github-token=${GITHUB_TOKEN}
                     ''', label: 'OLTPBench (RamDisk WAL)'
                 }
                 catchError(stageResult: 'Failure'){
                     sh script:'''
                     cd build
-                    PYTHONPATH=.. timeout 3h python3 -m script.testing.oltpbench --config-file=../script/testing/oltpbench/configs/nightly/nightly_wal_disabled.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
+                    PYTHONPATH=.. timeout 3h python3 -m script.testing.oltpbench --config-file=../script/testing/oltpbench/configs/nightly/nightly_wal_disabled.json --build-type=release --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW} --github-token=${GITHUB_TOKEN}
                     ''', label: 'OLTPBench (No WAL)'
                 }
 
@@ -106,7 +107,7 @@ pipeline {
                 //  WAL Path: Ramdisk
                 sh script:'''
                 cd script/testing
-                PYTHONPATH=.. python3 -m script.testing.microbench --num-threads=4 --benchmark-path $(pwd)/../../build/benchmark --logfile-path=/mnt/ramdisk/benchmark.log --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
+                PYTHONPATH=.. python3 -m script.testing.microbench --num-threads=4 --benchmark-path $(pwd)/../../build/benchmark --logfile-path=/mnt/ramdisk/benchmark.log --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW} --github-token=${GITHUB_TOKEN}
                 ''', label:'Microbenchmark'
 
                 archiveArtifacts 'script/testing/*.json'

--- a/script/testing/artifact_stats/__main__.py
+++ b/script/testing/artifact_stats/__main__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import logging
+import os
 import sys
 
 from ..reporting.report_result import report_artifact_stats_result
@@ -75,10 +76,16 @@ if __name__ == "__main__":
                         type=str,
                         help="Performance Storage Service password")
 
+    parser.add_argument("--github-token", 
+                        help="GitHub token for calling REST API")
+
     args = parser.parse_args()
 
     if args.debug:
         LOG.setLevel(logging.DEBUG)
+
+    if args.github_token:
+        os.environ['GITHUB_TOKEN'] = args.github_token
 
     # Get the BaseBinaryMetricsCollector subclasses imported from binary_metrics.binary_metrics_collectors
     # Effectively this adds each binary metric collector class into an array to be instantiated later.

--- a/script/testing/microbench/__main__.py
+++ b/script/testing/microbench/__main__.py
@@ -95,6 +95,9 @@ if __name__ == "__main__":
                         type=str,
                         help="Performance Storage Service password")
 
+    parser.add_argument("--github-token", 
+                        help="GitHub token for calling REST API")
+
     args = parser.parse_args()
 
     # -------------------------------------------------------
@@ -104,6 +107,9 @@ if __name__ == "__main__":
     if args.debug:
         LOG.setLevel(logging.DEBUG)
     LOG.debug("args: {}".format(args))
+
+    if args.github_token:
+        os.environ['GITHUB_TOKEN'] = args.github_token
 
     config_args = {
         'publish_results_env': args.publish_results

--- a/script/testing/oltpbench/__main__.py
+++ b/script/testing/oltpbench/__main__.py
@@ -97,6 +97,9 @@ def generate_tests(args):
 if __name__ == "__main__":
     args = parse_command_line_args()
 
+    if args.github_token:
+        os.environ['GITHUB_TOKEN'] = args.github_token
+
     exit_code = ErrorCode.ERROR
     try:
         tests = generate_tests(args)

--- a/script/testing/oltpbench/utils.py
+++ b/script/testing/oltpbench/utils.py
@@ -38,6 +38,8 @@ def parse_command_line_args():
     aparser.add_argument("--dry-run",
                          action='store_true',
                          help="Start and stop DB server without running the OLTPBench tests")
+    aparser.add_argument("--github-token", 
+                         help="GitHub token for calling REST API")
 
     args = vars(aparser.parse_args())
 


### PR DESCRIPTION
# Change How Testing Scripts Report Commit Hash

## Description
### Problem
Currently, there is an issue with how the testing scripts record the git_commit_id (the commit hash). The commit hash comes from an environment variable set by Jenkins (GIT_COMMIT). When Jenkins checks out a pull requests code from the repository it first tries to merge it with master. If this is possible it creates a new merge commit hash. If it is already up to date with master it will not create a new commit hash. I'm not sure what happens if there are merge conflicts. I would guess that it does not create a merge commit.

The problem is that this merge commit becomes the GIT_COMMIT. Then the test results are stored in the database with that value. If you later search GitHub for that commit you won't find anything. 

This especially causes problems with the performance guard because the performance guard receives events saying Jenkins completed for a particular commit hash. This commit hash is not the merge commit hash. Therefore, the performance guard queries the database for `WHERE git_commit_id = 'hash'` and finds 0 results. Currently, the performance guard handles scenarios like this by creating a "Couldn't find results message". So, this doesn't really break the performance guard, but it makes it useless in certain cases.

### Solution
This is just my proposal for a solution. If someone has a better idea I'm all ears. 

I am proposing using the GitHub API to find the latest commit to the PR. This requires using a GitHub token to make the API call because unauthorized calls have a limit of 60 per hour. We could easily exceed that. The idea would be to pass this token into the scripts and then the scripts would lookup the commit hash when they go to report the test results. 

As I am writing this up I realize a problem with the solution. If a user pushes a commit while the build is running then the latest commit will be used as the git_commit_id instead of the commit that was used in Jenkins. One solution would be to run a script as the first step in the build to get the commit hash (this doesn't eliminate the problem but it makes it much less likely to occur). 
Another more complicated but more accurate solution would be (pseudo code below):

```python
def get_commit_hash():
    jenkins_commit_sha = os.environ['GIT_COMMIT']
    commits = get_all_commits_for_pr(pr_number)
    if any([(commit['sha'] == jenkins_commit_sha) for commit in commits]):
        # It is not a merge commit
         return os.environ['GIT_COMMIT']
    else:
        # it is a merge commit
        merge_commit = get_merge_commit_details_from_github(jenkins_commit_sha)
        latest_master_commits = get_last_10_commits_to_master()
    
        # The parent commits for a merge commit will be the commit to the PR and the master branch commit
        possible_commit_hashs = [parent['sha'] for parent in merge_commit['parents']]
        for hash in possible_commit_hashs:
            if hash not in [commit['sha] for commit in latest_master_commits]:
                # Find the hash that was not a commit to the master branch which means that it was the commit to the 
                # PR.
                return hash
```

## Remaining tasks

- [ ] Create a GitHub access token and store it as a credential in Jenkins. Andy/Chad would have to do this.