### PR TITLE
Fix nightly oltpbenchmark and microbenchmark builds.

### DIFF
--- a/Jenkinsfile-nightly
+++ b/Jenkinsfile-nightly
@@ -106,7 +106,7 @@ pipeline {
                 //  WAL Path: Ramdisk
                 sh script:'''
                 cd script/testing
-                PYTHONPATH=.. python3 -m script.testing.microbench --num-threads=4 --benchmark-path $(pwd)/../../build/benchmark --logfile-path=/mnt/ramdisk/benchmark.log --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
+                PYTHONPATH=../.. python3 -m script.testing.microbench --num-threads=4 --benchmark-path $(pwd)/../../build/benchmark --logfile-path=/mnt/ramdisk/benchmark.log --publish-results=prod --publish-username=${PSS_CREATOR_USR} --publish-password=${PSS_CREATOR_PSW}
                 ''', label:'Microbenchmark'
 
                 archiveArtifacts 'script/testing/*.json'

--- a/script/testing/util/db_server.py
+++ b/script/testing/util/db_server.py
@@ -91,7 +91,7 @@ class NoisePageServer:
                 LOG.info(f'DB process is verified as running in {round(now - start_time, 2)} sec.')
                 self.db_process = db_process
                 return True
-            else:
+            elif log_line.strip() != '':
                 logs.append(log_line)
 
             if now - start_time >= 60:
@@ -123,6 +123,7 @@ class NoisePageServer:
         return_code = self.db_process.poll()
         if return_code is None:
             self.db_process.terminate()
+            self.db_process.wait()
             LOG.info("DBMS stopped successfully.")
             self.db_process = None
         else:

--- a/script/testing/util/db_server.py
+++ b/script/testing/util/db_server.py
@@ -122,8 +122,15 @@ class NoisePageServer:
 
         return_code = self.db_process.poll()
         if return_code is None:
-            self.db_process.terminate()
-            self.db_process.wait()
+            try:
+                # Try to kill the process politely and wait for 60 seconds.
+                self.db_process.terminate()
+                self.db_process.wait(60)
+            except:
+                # Otherwise, try to kill the process forcefully and wait another 60 seconds.
+                # If the process hasn't died yet, then something terrible has happened and we raise an error.
+                self.db_process.kill()
+                self.db_process.wait(60)
             LOG.info(f"DBMS stopped successfully, code: {self.db_process.returncode}")
             self.db_process = None
         else:

--- a/script/testing/util/db_server.py
+++ b/script/testing/util/db_server.py
@@ -124,7 +124,7 @@ class NoisePageServer:
         if return_code is None:
             self.db_process.terminate()
             self.db_process.wait()
-            LOG.info("DBMS stopped successfully.")
+            LOG.info(f"DBMS stopped successfully, code: {self.db_process.returncode}")
             self.db_process = None
         else:
             msg = f"DBMS already terminated, code: {self.db_process.returncode}"


### PR DESCRIPTION
# Heading

Fix nightly oltpbenchmark and microbenchmark builds.

## Description

Attempt to fix nightly build.

- Add wait to DBServer stop. I think it was racing between sending the terminate signal to the old process (and not waiting for that to die), and the next iteration of the OLTPBenchmark run, which would cause the new DB process to die since it couldn't grab the port.
- No longer log useless lines.
- Fix path issues for nightly microbenchmark.