### PR TITLE
Favor std::mutex over SpinLatch for OutputWriter synchronization.

### DIFF
--- a/src/execution/exec/output.cpp
+++ b/src/execution/exec/output.cpp
@@ -92,7 +92,7 @@ void OutputPrinter::operator()(byte *tuples, uint32_t num_tuples, uint32_t tuple
 }
 
 void OutputWriter::operator()(byte *tuples, uint32_t num_tuples, uint32_t tuple_size) {
-  common::SpinLatch::ScopedSpinLatch guard(&latch_);
+  std::scoped_lock latch(output_synchronization_);
 
   // Write out the rows for this batch
   for (uint32_t row = 0; row < num_tuples; row++) {

--- a/src/include/execution/exec/output.h
+++ b/src/include/execution/exec/output.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
@@ -159,8 +160,11 @@ class OutputWriter {
  private:
   /** Captures the number of rows written.  */
   uint32_t num_rows_ = 0;
-  /** Latch for synchronizing calls to operator() */
-  common::SpinLatch latch_;
+  /** Latch for synchronizing calls to operator().
+   * We favor std::mutex over a spin latch since this is not a short operation when synchronization is necessary
+   * (parallel scan)
+   */
+  std::mutex output_synchronization_;
   const common::ManagedPointer<planner::OutputSchema> schema_;
   const common::ManagedPointer<network::PostgresPacketWriter> out_;
   const std::vector<network::FieldFormat> &field_formats_;

--- a/src/include/execution/exec/output.h
+++ b/src/include/execution/exec/output.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <memory>
-#include <mutex>
+#include <mutex>  // NOLINT
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>


### PR DESCRIPTION
Found this will looking at instrumenting the output layer. We shouldn't be using `SpinLatch` for operations longer than ~20 instructions (per Intel). Since writing to the network layer for a large number of tuples is definitely going to involve sys calls and more instructions than that, we should favor a `std::mutex` for synchronization here.