### PR TITLE
Hotfix for CI Builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -751,11 +751,6 @@ add_custom_command(
 # (e.g. Make, Ninja) is now 'aware' of the target-level dependency.
 add_custom_target(bitcode_generator DEPENDS "${CMAKE_BINARY_DIR}/bin/bytecode_handlers_ir.bc")
 
-# A declarative convenience wrapper for expressing dependency on bitcode.
-function(target_requires_bitcode TARGET)
-    add_dependencies(${TARGET} bitcode_generator)
-endfunction()
-
 #######################################################################################################################
 # HEADER gen_opt_bc binary.
 # gen_opt_bc            :   Generates optimized bitcode from the LLVM IR file generated as a tpl post-build target.
@@ -767,7 +762,7 @@ target_include_directories(gen_opt_bc PRIVATE ${LLVM_INCLUDE_DIRS})
 target_link_libraries(gen_opt_bc PRIVATE ${LLVM_LIBRARIES})
 set_target_properties(gen_opt_bc PROPERTIES CXX_EXTENSIONS OFF ENABLE_EXPORTS ON)
 
-target_requires_bitcode(noisepage_static)
+add_dependencies(noisepage_static bitcode_generator)
 
 #######################################################################################################################
 # HEADER tpl binary.
@@ -776,7 +771,7 @@ target_requires_bitcode(noisepage_static)
 #######################################################################################################################
 
 add_executable(tpl util/execution/tpl.cpp)
-target_requires_bitcode(tpl)
+add_dependencies(tpl bitcode_generator)
 target_compile_options(tpl PRIVATE "-Werror" "-Wall")
 target_link_libraries(tpl PUBLIC noisepage_static util_static)
 set_target_properties(tpl PROPERTIES CXX_EXTENSIONS OFF ENABLE_EXPORTS ON)
@@ -902,7 +897,7 @@ function(add_noisepage_test
     endif ()
 
     if (${REQUIRES_BITCODE} STREQUAL "BITCODE")
-        target_requires_bitcode(${TEST_NAME})
+        add_dependencies(${TEST_NAME} bitcode_generator)
     endif()
 
     set_target_properties(${TEST_NAME} PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -735,8 +735,15 @@ function(target_requires_bitcode TARGET)
             DEPENDS "${PROJECT_SOURCE_DIR}/src/include/execution/vm/bytecodes.h" "${PROJECT_SOURCE_DIR}/src/include/execution/vm/bytecode_handlers.h"
             POST_BUILD
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-            COMMAND cmake -E echo "Generating optimized bitcodes..."
-            COMMAND ${BUILD_SUPPORT_DIR}/generate-bitcodes.sh ${PROJECT_SOURCE_DIR} ${CMAKE_BINARY_DIR} ${CLANG}
+            COMMAND cmake -E echo "Generating optimized bitcode ..."
+            COMMAND cmake -E echo "Running: ${PROJECT_SOURCE_DIR}/build-support/tpl_bytecode_handlers_ir_compiler.py ${CLANG} ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR}/util/execution/bytecode_handlers_ir.cpp ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_ir.bc"
+            COMMAND ${PROJECT_SOURCE_DIR}/build-support/tpl_bytecode_handlers_ir_compiler.py ${CLANG} ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR}/util/execution/bytecode_handlers_ir.cpp ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_ir.bc
+            COMMAND cmake -E echo "Running: ${CMAKE_BINARY_DIR}/bin/gen_opt_bc ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_ir.bc ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_opt.bc"
+            COMMAND ${CMAKE_BINARY_DIR}/bin/gen_opt_bc ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_ir.bc ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_opt.bc
+            COMMAND cmake -E echo "Running: mv ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_opt.bc ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_ir.bc"
+            COMMAND mv ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_opt.bc ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_ir.bc
+            COMMAND cmake -E echo "Generated optimized bitcode at ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_ir.bc."
+            USES_TERMINAL
     )
 endfunction()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -727,24 +727,33 @@ add_library(hack_bytecode_handlers_ir EXCLUDE_FROM_ALL util/execution/bytecode_h
 target_link_libraries(hack_bytecode_handlers_ir PRIVATE noisepage_static)
 set_target_properties(hack_bytecode_handlers_ir PROPERTIES CXX_EXTENSIONS OFF)
 
+# On MacOS, the clang++ we want is not the clang++ in PATH. On Linux, it is.
+# NOTE(Kyle): It is important that CLANG is resolved prior to the commands
+# below, so the location of the following definition matters.
+if (APPLE)
+    set(CLANG "${LLVM_TOOLS_BINARY_DIR}/clang++")
+else ()
+    find_program(CLANG NAMES "clang++-8" "clang++" REQUIRED)
+endif ()
+
+# Run the build-support script that generates and optimizes bitcode.
+add_custom_command(
+        OUTPUT "${CMAKE_BINARY_DIR}/bin/bytecode_handlers_ir.bc"
+        DEPENDS gen_opt_bc "${PROJECT_SOURCE_DIR}/src/include/execution/vm/bytecodes.h" "${PROJECT_SOURCE_DIR}/src/include/execution/vm/bytecode_handlers.h"
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMAND ${BUILD_SUPPORT_DIR}/generate-bitcodes.sh ${PROJECT_SOURCE_DIR} ${CMAKE_BINARY_DIR} ${CLANG}
+)
+
+# Here, we create a custom target that merely wraps the output file
+# from the custom command above; this ensures that the custom command
+# is actually only ever invoked once even when multiple indepdendent
+# targets that require bitcode are built because the build system 
+# (e.g. Make, Ninja) is now 'aware' of the target-level dependency.
+add_custom_target(bitcode_generator DEPENDS "${CMAKE_BINARY_DIR}/bin/bytecode_handlers_ir.bc")
+
+# A declarative convenience wrapper for expressing dependency on bitcode.
 function(target_requires_bitcode TARGET)
-    # If the target requires optimized bitcodes, the gen_opt_bc binary must be built prior to generation
-    add_dependencies(${TARGET} gen_opt_bc)
-    add_custom_command(
-            TARGET ${TARGET}
-            DEPENDS "${PROJECT_SOURCE_DIR}/src/include/execution/vm/bytecodes.h" "${PROJECT_SOURCE_DIR}/src/include/execution/vm/bytecode_handlers.h"
-            POST_BUILD
-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-            COMMAND cmake -E echo "Generating optimized bitcode ..."
-            COMMAND cmake -E echo "Running: ${PROJECT_SOURCE_DIR}/build-support/tpl_bytecode_handlers_ir_compiler.py ${CLANG} ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR}/util/execution/bytecode_handlers_ir.cpp ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_ir.bc"
-            COMMAND ${PROJECT_SOURCE_DIR}/build-support/tpl_bytecode_handlers_ir_compiler.py ${CLANG} ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR}/util/execution/bytecode_handlers_ir.cpp ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_ir.bc
-            COMMAND cmake -E echo "Running: ${CMAKE_BINARY_DIR}/bin/gen_opt_bc ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_ir.bc ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_opt.bc"
-            COMMAND ${CMAKE_BINARY_DIR}/bin/gen_opt_bc ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_ir.bc ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_opt.bc
-            COMMAND cmake -E echo "Running: mv ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_opt.bc ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_ir.bc"
-            COMMAND mv ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_opt.bc ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_ir.bc
-            COMMAND cmake -E echo "Generated optimized bitcode at ${CMAKE_BINARY_DIR}/bin/bytecode_handlers_ir.bc."
-            USES_TERMINAL
-    )
+    add_dependencies(${TARGET} bitcode_generator)
 endfunction()
 
 #######################################################################################################################
@@ -757,13 +766,6 @@ target_compile_options(gen_opt_bc PRIVATE "-Werror" "-Wall")
 target_include_directories(gen_opt_bc PRIVATE ${LLVM_INCLUDE_DIRS})
 target_link_libraries(gen_opt_bc PRIVATE ${LLVM_LIBRARIES})
 set_target_properties(gen_opt_bc PROPERTIES CXX_EXTENSIONS OFF ENABLE_EXPORTS ON)
-
-# On MacOS, the clang++ we want is not the clang++ in PATH. On Linux, it is.
-if (APPLE)
-    set(CLANG "${LLVM_TOOLS_BINARY_DIR}/clang++")
-else ()
-    find_program(CLANG NAMES "clang++-8" "clang++" REQUIRED)
-endif ()
 
 target_requires_bitcode(noisepage_static)
 

--- a/build-support/generate-bitcodes.sh
+++ b/build-support/generate-bitcodes.sh
@@ -10,6 +10,8 @@ BINARY_DIR=$2
 # The path to clang
 CLANG_PATH=$3
 
+echo "Generating optimized bitcodes..."
+
 # Run the compiler
 echo "Running: ${PROJECT_ROOT}/build-support/tpl_bytecode_handlers_ir_compiler.py ${CLANG_PATH} ${BINARY_DIR} ${PROJECT_ROOT}/util/execution/bytecode_handlers_ir.cpp ${BINARY_DIR}/bin/bytecode_handlers_ir.bc"
 ${PROJECT_ROOT}/build-support/tpl_bytecode_handlers_ir_compiler.py ${CLANG_PATH} ${BINARY_DIR} ${PROJECT_ROOT}/util/execution/bytecode_handlers_ir.cpp ${BINARY_DIR}/bin/bytecode_handlers_ir.bc || exit 1


### PR DESCRIPTION
As the conversation below indicates, updates that I made in a previous PR lead to issues with parallel builds. Specifically, the changes I introduced made it so that multiple top-level targets depend on generation of the bytecode handlers file, `bytecode_handlers_ir.bc` (e.g. one of the execution jumbotests and the TPL runtime are not interdependent, but both depend on generating the bytecode handlers). This leads to concurrency issues in parallel builds wherein the script that is responsible for compiling the bytecode and subsequently optimizing it fails to locate a temporary file upon which it depends because it has been renamed / overwritten by a concurrently-running invocation of the custom command. Gross.

The (proposed) fix here is pretty simple, and follows in that great computer science tradition of solving problems by introducing an additional layer of indirection: construct a custom target (via `add_custom_target()`) for bytecode file generation that expresses dependency on the file itself, and have each of the top-level targets then depend on this custom target. This ensures that, once this target is "built", it is never built again because the dependency is already satisfied, thus avoiding the race entirely. You can confirm this is taking place by comparing the output from previous failing builds with the build progress output on this branch; you will observe that, whereas in prior builds the output from the `generate-bitcodes.sh` script appeared multiple times, it now always appears exactly once.