### PR TITLE
Delete domain socket on DBMS shutdown. Clarify junit tracefile reporting.

### DIFF
--- a/script/testing/junit/__main__.py
+++ b/script/testing/junit/__main__.py
@@ -95,6 +95,8 @@ if __name__ == "__main__":
         set_env_vars()
         test_server = TestServer(args, quiet=True)
         errcodes = [run_tests_junit(test_server)] + run_tests_tracefiles(test_server)
+    except KeyboardInterrupt:
+        traceback.print_exc(file=sys.stderr)
     finally:
         unset_env_vars()
 

--- a/script/testing/junit/__main__.py
+++ b/script/testing/junit/__main__.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
         unset_env_vars()
 
     # Compute the final exit code.
-    final_code = 0
+    final_code = 0 if len(errcodes) > 0 else 1
     for c in errcodes:
         final_code = final_code or c
 

--- a/script/testing/junit/__main__.py
+++ b/script/testing/junit/__main__.py
@@ -60,7 +60,8 @@ def run_tests_tracefiles(test_server):
 
         return errcode
 
-    return [run_tracefile(test_server, item) for item in os.listdir(noise_trace_dir) if item.endswith(TESTFILES_SUFFIX)]
+    return [run_tracefile(test_server, item)
+            for item in sorted(os.listdir(noise_trace_dir)) if item.endswith(TESTFILES_SUFFIX)]
 
 
 if __name__ == "__main__":

--- a/script/testing/junit/src/TracefileTest.java
+++ b/script/testing/junit/src/TracefileTest.java
@@ -68,6 +68,10 @@ public class TracefileTest {
                 dTest.add(cur);
             }
             mog.queryResults.clear();
+            if (conn.isClosed()) {
+                System.err.println("Connection closed (DBMS segfault?), skipping the rest of the tests.");
+                break;
+            }
         }
         conn.close();
         return dTest;

--- a/script/testing/util/db_server.py
+++ b/script/testing/util/db_server.py
@@ -96,7 +96,7 @@ class NoisePageServer:
 
             if now - start_time >= 60:
                 LOG.error('\n'.join(logs))
-                LOG.error(f'DBMS [PID={db_process.pid} took more than 60 seconds to start up. Killing.')
+                LOG.error(f'DBMS [PID={db_process.pid}] took more than 60 seconds to start up. Killing.')
                 db_process.kill()
                 return False
 

--- a/script/testing/util/db_server.py
+++ b/script/testing/util/db_server.py
@@ -126,11 +126,18 @@ class NoisePageServer:
                 # Try to kill the process politely and wait for 60 seconds.
                 self.db_process.terminate()
                 self.db_process.wait(60)
-            except:
+            except subprocess.TimeoutExpired:
                 # Otherwise, try to kill the process forcefully and wait another 60 seconds.
                 # If the process hasn't died yet, then something terrible has happened and we raise an error.
                 self.db_process.kill()
                 self.db_process.wait(60)
+            except KeyboardInterrupt:
+                raise KeyboardInterrupt
+            finally:
+                unix_socket = os.path.join("/tmp/", f".s.PGSQL.{self.db_port}")
+                if os.path.exists(unix_socket):
+                    os.remove(unix_socket)
+                    LOG.info(f"Removing: {unix_socket}")
             LOG.info(f"DBMS stopped successfully, code: {self.db_process.returncode}")
             self.db_process = None
         else:

--- a/script/testing/util/test_server.py
+++ b/script/testing/util/test_server.py
@@ -139,7 +139,9 @@ class TestServer:
             has_error = any([x is None or x != constants.ErrorCode.SUCCESS
                              for x in exit_codes.values()])
             result = constants.ErrorCode.ERROR if has_error else constants.ErrorCode.SUCCESS
-        except:
+        except KeyboardInterrupt:
+            raise KeyboardInterrupt
+        except Exception:
             traceback.print_exc(file=sys.stdout)
         finally:
             self.run_post_suite()
@@ -179,14 +181,18 @@ class TestServer:
                         else:
                             print_file(test_case.test_output_file)
                         exit_codes[test_case] = exit_code
-                    except:
+                    except KeyboardInterrupt:
+                        raise KeyboardInterrupt
+                    except Exception:
                         print_file(test_case.test_output_file)
                         if not self.continue_on_error:
                             raise
                         else:
                             traceback.print_exc(file=sys.stdout)
                             exit_codes[test_case] = constants.ErrorCode.ERROR
-            except:
+            except KeyboardInterrupt:
+                raise KeyboardInterrupt
+            except Exception:
                 traceback.print_exc(file=sys.stdout)
                 exit_codes[test_case] = constants.ErrorCode.ERROR
                 # Terminate early in case the DBMS was unable to start.

--- a/script/testing/util/test_server.py
+++ b/script/testing/util/test_server.py
@@ -113,7 +113,6 @@ class TestServer:
                 collect_mem_thread.stop()
 
             test_case.run_post_test()
-            self.db_instance.delete_wal()
 
         return ret_val
 
@@ -201,5 +200,6 @@ class TestServer:
         # persist create/load data.
         if dbms_started:
             self.db_instance.stop_db(self.is_dry_run)
+            self.db_instance.delete_wal()
 
         return exit_codes

--- a/script/testing/util/test_server.py
+++ b/script/testing/util/test_server.py
@@ -103,7 +103,8 @@ class TestServer:
 
         ret_val = constants.ErrorCode.ERROR
         try:
-            with open(test_case.test_output_file, "a+") as test_output_fd:
+            LOG.info(f"Logging output (overwrite) to: {test_case.test_output_file}")
+            with open(test_case.test_output_file, "w") as test_output_fd:
                 ret_val, _, _ = run_command(test_case.test_command,
                                             stdout=test_output_fd,
                                             stderr=test_output_fd,

--- a/script/testing/util/test_server.py
+++ b/script/testing/util/test_server.py
@@ -1,6 +1,5 @@
 import sys
 import traceback
-from typing import List
 
 from . import constants
 from .common import print_file, run_command, update_mem_info


### PR DESCRIPTION
# Heading

Delete domain socket on DBMS shutdown. Clarify junit tracefile reporting.

## Description

Normally when you spin up a DBMS we get the network socket and then the domain socket.

```
[2021-02-19 11:50:54.637] [network_logger] [info] Listening on networked socket with port 15721 [PID=3372]
// my PR got stuck here
[2021-02-19 11:50:54.637] [network_logger] [info] Listening on Unix domain socket with port 15721 [PID=3372]
```

I noticed that one of my CI runs was failing because it couldn't get the domain socket, so this PR will try to delete the domain socket if it exists when the DBMS is stopped. In theory our DBMS startup code already does this but `¯\_(ツ)_/¯` maybe this helps.

Also, good news: we're _not_ running the tracefiles a million times, the scripts were just opening `junit_log.txt` in append "a+" mode and the entire file would get printed each time. Changed it to open the file in "w", seems to have the desired behavior locally when I introduce errors in two different trace files (only prints the relevant bit).

Other small qol fixes:

- stop Java tracefile stuff early if the DBMS crashes so that you don't see a huge list of "connection closed" errors
- add protection to some bare `except` handlers so that `KeyboardInterrupt` can go through
- sort tracefiles before running
- typo fix