### PR TITLE
Add ninja job pools to limit link parallelism.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,6 +350,21 @@ else ()
     message(STATUS "Colorized output: OFF (unknown compiler ${CMAKE_CXX_COMPILER_ID})")
 endif ()
 
+if ("${CMAKE_GENERATOR}" STREQUAL "Ninja")
+    # Num Logical Cores = Compile Pool + Link Pool (1) + 1
+    # The extra 1 at the end is there for good luck.
+    # A pool controls the _maximum_ parallelism of the jobs assigned to the pool.
+
+    # Force single-threaded linking because linking can consume a ton of memory.
+    cmake_host_system_information(RESULT NINJA_COMPILE_POOL_SIZE QUERY "NUMBER_OF_LOGICAL_CORES")
+    set(NINJA_LINK_POOL_SIZE 1)
+    math(EXPR NINJA_COMPILE_POOL_SIZE "${NINJA_COMPILE_POOL_SIZE} - ${NINJA_LINK_POOL_SIZE} - 1")
+    set_property(GLOBAL PROPERTY JOB_POOLS link_pool=${NINJA_LINK_POOL_SIZE} compile_pool=${NINJA_COMPILE_POOL_SIZE})
+    # Set linking and compiling limits globally for all targets by modifying the default pool options.
+    set(CMAKE_JOB_POOL_COMPILE compile_pool)
+    set(CMAKE_JOB_POOL_LINK link_pool)
+    message(STATUS "Ninja detected. Global pools: link=${NINJA_LINK_POOL_SIZE} compile=${NINJA_COMPILE_POOL_SIZE}")
+endif()
 
 #######################################################################################################################
 # HEADER Dependencies for finding dependencies. : )


### PR DESCRIPTION
# Heading

Add ninja job pools to limit link parallelism.

## Description

Staring at replication not go through CI and noticing that the junit stuff starts being very slow (slow to startup db, slow to finish test, hits the timeout) when another node on the same machine (h3) is busy running a huge parallel link.

This PR restricts linking to be single-threaded. Specifically, the job pools are sized:
```
num logical cores = compile pool + link pool (1) + 1
```
where the 1 is just there as a good luck safety buffer thing. You can re-read that as
```
link: single-threaded
compile: num logical cores - 1 for the link - 1 for good luck
```

Anecdotally, this seems to OOM my local machine less.

This is also an advantage of ninja, afaik make does not have convenient ways of limiting link parallelism.