### PR TITLE
Fix NOISEPAGE_USE_LOGGING=OFF compilation

### DIFF
--- a/src/self_driving/pilot/mcts/monte_carlo_tree_search.cpp
+++ b/src/self_driving/pilot/mcts/monte_carlo_tree_search.cpp
@@ -27,7 +27,7 @@ MonteCarloTreeSearch::MonteCarloTreeSearch(common::ManagedPointer<Pilot> pilot,
   IndexActionGenerator().GenerateActions(plans, pilot->settings_manager_, &action_map_, &candidate_actions_);
   ChangeKnobActionGenerator().GenerateActions(plans, pilot->settings_manager_, &action_map_, &candidate_actions_);
 
-  for (auto const &it : action_map_) {
+  for (const auto &it UNUSED_ATTRIBUTE : action_map_) {
     SELFDRIVING_LOG_INFO("Generated action: ID {} Command {}", it.first, it.second->GetSQLCommand());
   }
 


### PR DESCRIPTION
#1475 added a loop iterator that is only used for debug logging. This breaks builds that have `NOISEPAGE_USE_LOGGING=OFF`, which I do for my performance testing.

This PR adds the `UNUSED_ATTRIBUTE` macro to the iterator.