### PR TITLE
Switch gcc/Debug/Coverage/unittest to only use h0.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,6 @@ pipeline {
             agent {
                 docker {
                     image 'noisepage:focal'
-                    label 'h0-only'
                     args '-v /jenkins/ccache:/home/jenkins/.ccache'
                 }
             }
@@ -136,6 +135,7 @@ pipeline {
                     agent {
                         docker {
                             image 'noisepage:focal'
+                            label 'h0-only'
                             args '--cap-add sys_ptrace -v /jenkins/ccache:/home/jenkins/.ccache'
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
             agent {
                 docker {
                     image 'noisepage:focal'
+                    label 'h0-only'
                     args '-v /jenkins/ccache:/home/jenkins/.ccache'
                 }
             }


### PR DESCRIPTION
Per @malin1993ml ,

> Another minor CI improvement I've been thinking is that maybe we can set ubuntu-20.04/gcc-9.3 (Debug/Coverage/unittest) to always run on h0 . It is building 3x more targets than other builds, and seems always to be the bottleneck in our Test stage.


This is done by introducing a new `h0-only` label to h0, and manually specifying that this specific job can only execute on nodes with the `h0-only` label.