### PR TITLE
Add Sqlancer Test Type and Installation Requirements

### DIFF
--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -179,7 +179,9 @@ install_mac() {
   fi
   # Update Homebrew.
   brew update
-  
+
+  brew install maven
+
   # Install packages.
   if [ "$INSTALL_TYPE" == "build" -o "$INSTALL_TYPE" = "all" ]; then
     for pkg in "${OSX_BUILD_PACKAGES[@]}"; do
@@ -205,7 +207,9 @@ install_mac() {
 install_linux() {
   # Update apt-get.
   apt-get -y update
-  
+
+  apt-get -y install maven
+
   # Install packages.
   if [ "$INSTALL_TYPE" == "build" -o "$INSTALL_TYPE" = "all" ]; then
     apt-get -y install `( IFS=$' '; echo "${LINUX_BUILD_PACKAGES[*]}" )`

--- a/script/testing/sqlancer/README.md
+++ b/script/testing/sqlancer/README.md
@@ -1,0 +1,6 @@
+# Sqlancer Testing
+This folder include the necessary files for running sqlancer testings.
+
+To run the sqlancer test, in terrier directory, run "PYTHONPATH=.. python3 -m script.testing.sqlancer"
+
+For detailed information about Sqlancer, go to https://github.com/sqlancer/sqlancer

--- a/script/testing/sqlancer/__main__.py
+++ b/script/testing/sqlancer/__main__.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import sys
+import traceback
+
+from script.testing.sqlancer.test_sqlancer import TestSqlancer
+from ..util.constants import LOG, ErrorCode
+from .constants import (SQLANCER_TEST_CMD_ALL, SQLANCER_TEST_CMD_CWD)
+from .test_case_sqlancer import TestCaseSqlancer
+from .utils import parse_command_line_args
+
+
+def run_test(t_server, test_command, test_command_cwd):
+    test_case = TestCaseSqlancer(args, test_command=test_command, test_command_cwd=test_command_cwd)
+    ecode = ErrorCode.ERROR
+    try:
+        ecode = t_server.run([test_case])
+    except KeyboardInterrupt:
+        LOG.error("KeyboardInterrupt received. Terminating.")
+        raise
+    except Exception as err:
+        LOG.error(f'Exception trying to run {test_command}')
+        LOG.error(err)
+        LOG.error("================ Python Error Output ==================")
+        traceback.print_exc(file=sys.stdout)
+    return ecode
+
+
+if __name__ == "__main__":
+    args = parse_command_line_args()
+    errcode = 0
+    try:
+        test_server = TestSqlancer(args)
+        errcode = run_test(test_server, SQLANCER_TEST_CMD_ALL, SQLANCER_TEST_CMD_CWD)
+    except:
+        LOG.error("Exception trying to run Sqlancer tests.")
+        traceback.print_exc(file=sys.stdout)
+
+    # Compute the final exit code.
+    LOG.info("Final Status => {}".format("FAIL" if errcode else "SUCCESS"))
+    sys.exit(errcode)

--- a/script/testing/sqlancer/constants.py
+++ b/script/testing/sqlancer/constants.py
@@ -1,0 +1,19 @@
+import os
+
+from ..util.constants import DIR_TMP
+
+# git settings for sqlancer.
+SQLANCER_GIT_URL = "https://github.com/dniu16/sqlancer.git"
+SQLANCER_GIT_LOCAL_PATH = os.path.join(DIR_TMP, "sqlancer")
+SQLANCER_GIT_CLEAN_COMMAND = "rm -rf {}".format(SQLANCER_GIT_LOCAL_PATH)
+SQLANCER_GIT_CLONE_COMMAND = "git clone {} {}".format(SQLANCER_GIT_URL,
+                                                 SQLANCER_GIT_LOCAL_PATH)
+# command to run sqlancer
+SQLANCER_TEST_CMD_ALL = "java -jar sqlancer-1.1.0.jar --num-threads 1 --num-tries 10 noisepage --oracle NoREC"
+
+# directory to run sqlancer in
+SQLANCER_TEST_CMD_CWD = os.path.join(SQLANCER_GIT_LOCAL_PATH, "target")
+SQLANCER_OUTPUT_FILE = os.path.join(SQLANCER_GIT_LOCAL_PATH, "res.txt")
+
+# command to build sqlancer
+SQLANCER_BUILD_COMMAND = "mvn package -DskipTests"

--- a/script/testing/sqlancer/test_case_sqlancer.py
+++ b/script/testing/sqlancer/test_case_sqlancer.py
@@ -1,0 +1,12 @@
+from ..util.test_case import TestCase
+from . import constants
+
+class TestCaseSqlancer(TestCase):
+    """
+    Class to run Sqlancer tests.
+    """
+    def __init__(self, args, test_command=constants.SQLANCER_TEST_CMD_ALL, test_command_cwd=constants.SQLANCER_TEST_CMD_CWD):
+           TestCase.__init__(self, args)
+           self.test_command = test_command
+           self.test_command_cwd = test_command_cwd
+           self.test_output_file = self.args.get("db_output_file", constants.SQLANCER_OUTPUT_FILE)

--- a/script/testing/sqlancer/test_sqlancer.py
+++ b/script/testing/sqlancer/test_sqlancer.py
@@ -1,0 +1,42 @@
+from ..util.common import expect_command
+from ..util.test_server import TestServer
+from . import constants
+
+
+class TestSqlancer(TestServer):
+    """
+    TestSqlancer will build Sqlancer in the pre-suite.
+    All other behavior is identical to TestServer.
+    """
+
+    def __init__(self, args):
+        super().__init__(args, quiet=False)
+
+    def run_pre_suite(self):
+        super().run_pre_suite()
+        if not self.is_dry_run:
+            self._clean_sqlancer()
+            self._download_sqlancer()
+            self._build_sqlancer()
+
+    def _clean_sqlancer(self):
+        """
+        Remove the Sqlancer directory from a hardcoded default location.
+        Raises an exception if anything goes wrong.
+        """
+        expect_command(constants.SQLANCER_GIT_CLEAN_COMMAND)
+
+    def _download_sqlancer(self):
+        """
+        Clone the Sqlancer directory to a hardcoded default location.
+        Raises an exception if anything goes wrong.
+        """
+        expect_command(constants.SQLANCER_GIT_CLONE_COMMAND)
+
+    def _build_sqlancer(self):
+        """
+        Build Sqlancer in its hardcoded default location.
+        Raises an exception if anything goes wrong.
+        Assumes that _download_sqlancer() has already been run.
+        """
+        expect_command(constants.SQLANCER_BUILD_COMMAND, cwd=constants.SQLANCER_GIT_LOCAL_PATH)

--- a/script/testing/sqlancer/utils.py
+++ b/script/testing/sqlancer/utils.py
@@ -1,0 +1,23 @@
+import argparse
+
+from ..util.constants import PERFORMANCE_STORAGE_SERVICE_API
+
+
+def parse_command_line_args():
+    """
+    Parse the command line arguments accepted by the OLTPBench module.
+    """
+
+    aparser = argparse.ArgumentParser(description="Sqlancer runner")
+
+    aparser.add_argument("--db-host", help="DB Hostname.")
+    aparser.add_argument("--db-port", type=int, help="DB Port.")
+    aparser.add_argument("--db-output-file", help="DB output log file.")
+    aparser.add_argument("--build-type",
+                         default="debug",
+                         choices=["debug", "release", "relwithdebinfo"],
+                         help="Build type (default: %(default)s")
+
+    args = vars(aparser.parse_args())
+
+    return args


### PR DESCRIPTION
This PR adds the sqlancer test type following the instruction here: https://github.com/cmu-db/noisepage/tree/master/script/testing. The test can be run using the command "PYTHONPATH=.. python3 -m script.testing.sqlancer" under the noisepage directory. 

In addition, maven is installed in installation/package.sh since it is needed to build sqlancer. 