### PR TITLE
Fix for BPlusTree test failures

### DIFF
--- a/script/testing/microbench/benchmarks.py
+++ b/script/testing/microbench/benchmarks.py
@@ -14,6 +14,7 @@ BENCHMARKS_TO_RUN = {
     "tuple_access_strategy_benchmark": 15,
     "tpcc_benchmark": DEFAULT_FAILURE_THRESHOLD,
     "bwtree_benchmark": DEFAULT_FAILURE_THRESHOLD,
+    "bplustree_benchmark": DEFAULT_FAILURE_THRESHOLD,
     "cuckoomap_benchmark": DEFAULT_FAILURE_THRESHOLD,
     "parser_benchmark": 20,
     "slot_iterator_benchmark": DEFAULT_FAILURE_THRESHOLD,

--- a/src/include/storage/index/bplustree.h
+++ b/src/include/storage/index/bplustree.h
@@ -70,14 +70,14 @@ class BPlusTreeBase {
   }
 
  protected:
-  /** upper size threshold for inner node split */
+  /** upper size threshold for inner node split [FAN_OUT] */
   int inner_node_size_upper_threshold_ = 128;
-  /** lower size threshold for inner node removal */
-  int inner_node_size_lower_threshold_ = 64;
+  /** lower size threshold for inner node removal [Ceil(FAN_OUT / 2) - 1] */
+  int inner_node_size_lower_threshold_ = 63;
 
-  /** upper size threshold for leaf node split */
+  /** upper size threshold for leaf node split [FAN_OUT] */
   int leaf_node_size_upper_threshold_ = 128;
-  /** lower size threshold for leaf node removal */
+  /** lower size threshold for leaf node removal [Ceil((FAN_OUT - 1) / 2)] */
   int leaf_node_size_lower_threshold_ = 64;
 
  public:


### PR DESCRIPTION

# Heading
Fix for BPlusTree test failures

## Description
The MultiThreadedInsert test in BPlusTree was broken due to an error in StructuralIntegrityVerification. This was because of inaccurate thresholds mentioned for splitting and merging a node. This PR also adds `bplustree_benchmark` to the list of microbenchmarks run by the stats script.

The correct thresholds are:

* FAN_OUT :  128
* Minimum Keys in Inner Node:  63 [Ceil (FAN_OUT / 2) - 1]
* Minimum Keys in Leaf Node:  64 [Ceil ((FAN_OUT - 1) / 2)]