### PR TITLE
Jenkins: Move microbenchmark building to pre-test and to any node. Add print_docker_info.sh.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,6 +45,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh script: './build-support/print_docker_info.sh', label: 'Print image information.'
                         sh script: 'echo y | sudo ./script/installation/packages.sh build', label: 'Installing packages'
                         sh 'cd apidoc && doxygen -u Doxyfile.in && doxygen Doxyfile.in 2>warnings.txt && if [ -s warnings.txt ]; then cat warnings.txt; false; fi'
                         sh 'mkdir build'
@@ -73,6 +74,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh script: './build-support/print_docker_info.sh', label: 'Print image information.'
                         sh script: 'echo y | sudo ./script/installation/packages.sh build', label: 'Installing packages'
                         sh 'cd apidoc && doxygen -u Doxyfile.in && doxygen Doxyfile.in 2>warnings.txt && if [ -s warnings.txt ]; then cat warnings.txt; false; fi'
                         sh 'mkdir build'
@@ -91,6 +93,29 @@ pipeline {
             }
         }
 
+        stage('Microbenchmark (Build only)') {
+            agent {
+                docker {
+                    image 'noisepage:focal'
+                    args '-v /jenkins/ccache:/home/jenkins/.ccache'
+                }
+            }
+            steps {
+                sh 'echo $NODE_NAME'
+                sh script: './build-support/print_docker_info.sh', label: 'Print image information.'
+
+                script{
+                    utils = utils ?: load(utilsFileName)
+                    utils.noisePageBuild(isBuildTests:false, isBuildBenchmarks:true)
+                }
+            }
+            post {
+                cleanup {
+                    deleteDir()
+                }
+            }
+        }
+
         stage('Test') {
             parallel {
                 stage('ubuntu-20.04/gcc-9.3 (Debug/ASAN/jumbotests)') {
@@ -102,6 +127,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh script: './build-support/print_docker_info.sh', label: 'Print image information.'
 
                         script{
                             utils = utils ?: load(utilsFileName)
@@ -144,6 +170,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh script: './build-support/print_docker_info.sh', label: 'Print image information.'
 
                         script{
                             utils = utils ?: load(utilsFileName)
@@ -197,6 +224,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh script: './build-support/print_docker_info.sh', label: 'Print image information.'
 
                         script{
                             utils = utils ?: load(utilsFileName)
@@ -234,6 +262,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh script: './build-support/print_docker_info.sh', label: 'Print image information.'
 
                         script{
                             utils = utils ?: load(utilsFileName)
@@ -275,6 +304,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh script: './build-support/print_docker_info.sh', label: 'Print image information.'
 
                         script{
                             utils = utils ?: load(utilsFileName)
@@ -316,6 +346,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh script: './build-support/print_docker_info.sh', label: 'Print image information.'
 
                         script{
                             utils = utils ?: load(utilsFileName)
@@ -377,6 +408,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh script: './build-support/print_docker_info.sh', label: 'Print image information.'
 
                         script{
                             utils = utils ?: load(utilsFileName)
@@ -435,6 +467,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh script: './build-support/print_docker_info.sh', label: 'Print image information.'
 
                         script{
                             utils = utils ?: load(utilsFileName)
@@ -481,6 +514,7 @@ pipeline {
                     }
                     steps {
                         sh 'echo $NODE_NAME'
+                        sh script: './build-support/print_docker_info.sh', label: 'Print image information.'
 
                         script{
                             utils = utils ?: load(utilsFileName)
@@ -533,22 +567,6 @@ pipeline {
                             deleteDir()
                         }
                     }
-                }
-            }
-        }
-        stage('Microbenchmark') {
-            agent { label 'benchmark' }
-            steps {
-                sh 'echo $NODE_NAME'
-
-                script{
-                    utils = utils ?: load(utilsFileName)
-                    utils.noisePageBuild(isBuildTests:false, isBuildBenchmarks:true)
-                }
-            }
-            post {
-                cleanup {
-                    deleteDir()
                 }
             }
         }

--- a/build-support/print_docker_info.sh
+++ b/build-support/print_docker_info.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# The hash of the docker image.
+# On a regular system, no clue.
+IMG_NAME=$(cat /proc/self/cgroup | grep memory | cut -d/ -f 3)
+# The time that the docker image was brought up.
+# On a regular system, the time the system started.
+IMG_TIME_CREATION=$(date --date="@$(stat -c '%Y' /proc/1/cmdline)" +'%F %T %z')
+# The current time.
+IMG_TIME_NOW=$(date +'%F %T %z')
+
+echo "Image: ${IMG_NAME}"
+echo "Image creation time : ${IMG_TIME_CREATION}"
+echo "Image current time  : ${IMG_TIME_NOW}"


### PR DESCRIPTION
# Heading

Jenkins: Move microbenchmark building to pre-test and on any node. Add print_docker_info.sh.

## Description

Since microbenchmarks are only built and are not run,
- We might as well build them earlier. This avoids people having their builds pass the test stage, only to fail some microbenchmark compilation error and have to go through CI again.
- We don't need a dedicated benchmark machine just to compile the code.

This PR also adds a script `build-support/print_docker_info.sh` to print image name, uptime, current time, to check if we're somehow executing on a different left-behind docker image. This hopes to provide data for weird `mkdir build` failures.

## Remaining tasks

Run through CI.