### PR TITLE
Add guide to getting debug symbols on clang.

### DIFF
--- a/docs/dev_troubleshooting.md
+++ b/docs/dev_troubleshooting.md
@@ -69,3 +69,16 @@ Notice that the provided path includes the filename for the binary itself.
 ## Ubuntu
 
 Record troubleshooting tips specific to Ubuntu here.
+
+**Issue:** When compiling with clang, we don't get nice `std::string` information in the debugger like we do with GCC.
+
+**Fix:** This is because clang [assumes](https://bugs.llvm.org/show_bug.cgi?id=24202#c1) that our `libstdc++` has that information available. We could "fix" this in CMake by passing `-fno-limit-debug-info`, but this bloats the binary and increases linking times. Instead, we install [Debug Symbol Packages](https://wiki.ubuntu.com/Debug%20Symbol%20Packages), the steps are reproduced here for convenience:
+
+```
+echo "deb http://ddebs.ubuntu.com $(lsb_release -cs) main restricted universe multiverse
+deb http://ddebs.ubuntu.com $(lsb_release -cs)-updates main restricted universe multiverse
+deb http://ddebs.ubuntu.com $(lsb_release -cs)-proposed main restricted universe multiverse" | \
+sudo tee -a /etc/apt/sources.list.d/ddebs.list
+sudo apt-get update
+sudo apt-get install libstdc++6-dbgsym
+```

--- a/docs/dev_troubleshooting.md
+++ b/docs/dev_troubleshooting.md
@@ -79,6 +79,7 @@ echo "deb http://ddebs.ubuntu.com $(lsb_release -cs) main restricted universe mu
 deb http://ddebs.ubuntu.com $(lsb_release -cs)-updates main restricted universe multiverse
 deb http://ddebs.ubuntu.com $(lsb_release -cs)-proposed main restricted universe multiverse" | \
 sudo tee -a /etc/apt/sources.list.d/ddebs.list
+sudo apt install ubuntu-dbgsym-keyring
 sudo apt-get update
 sudo apt-get install libstdc++6-dbgsym
 ```


### PR DESCRIPTION
# Heading

Add guide to getting debug symbols on clang.

## Description

On GCC, you can view the values of a `std::string` in the debugger.
On clang, you can't. This is because clang assumes `libstdc++` will provide it.
You can invalidate that assumption by passing a compiler flag but that makes the binary bigger and linking slower.
So if you want to easily debug things like `std::string`s when compiling with clang, you should install debug symbol packages.