### PR TITLE
Add missing step from Ubuntu wiki from #1507

### DIFF
--- a/docs/dev_troubleshooting.md
+++ b/docs/dev_troubleshooting.md
@@ -80,6 +80,7 @@ deb http://ddebs.ubuntu.com $(lsb_release -cs)-updates main restricted universe 
 deb http://ddebs.ubuntu.com $(lsb_release -cs)-proposed main restricted universe multiverse" | \
 sudo tee -a /etc/apt/sources.list.d/ddebs.list
 sudo apt install ubuntu-dbgsym-keyring
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F2EDC64DC5AEE1F6B9C621F0C8CAB6595FDFF622
 sudo apt-get update
 sudo apt-get install libstdc++6-dbgsym
 ```


### PR DESCRIPTION
There were some missing steps from the initial PR. @lmwnshn caught one. This adds the other.