### PR TITLE
Fix NOISEPAGE_USE_LOGGING=OFF compilation

### DIFF
--- a/src/replication/replication_manager.cpp
+++ b/src/replication/replication_manager.cpp
@@ -211,8 +211,7 @@ void ReplicationManager::ReplicaHeartbeat(const std::string &replica_name) {
   try {
     messenger_->SendMessage(
         GetReplicaConnection(replica_name), "",
-        [&replica_name, &replica](common::ManagedPointer<messenger::Messenger> messenger,
-                                  const messenger::ZmqMessage &msg) {
+        [&](common::ManagedPointer<messenger::Messenger> messenger, const messenger::ZmqMessage &msg) {
           auto epoch_now = std::chrono::system_clock::now().time_since_epoch();
           auto epoch_now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(epoch_now);
           replica.last_heartbeat_ = epoch_now_ms.count();

--- a/src/self_driving/model_server/model_server_manager.cpp
+++ b/src/self_driving/model_server/model_server_manager.cpp
@@ -7,6 +7,7 @@
 #include <sys/prctl.h>
 #endif
 #include <sys/wait.h>
+
 #include <thread>  // NOLINT
 
 #include "common/json.h"
@@ -50,8 +51,8 @@ ModelServerManager::ModelServerManager(const std::string &model_bin,
       })) {
   // Model Initialization handling logic
   auto msm_handler = [&](common::ManagedPointer<messenger::Messenger> messenger, const messenger::ZmqMessage &msg) {
-    uint64_t sender_id = msg.GetSourceCallbackId();
-    uint64_t recv_cb_id = msg.GetDestinationCallbackId();
+    uint64_t sender_id UNUSED_ATTRIBUTE = msg.GetSourceCallbackId();
+    uint64_t recv_cb_id UNUSED_ATTRIBUTE = msg.GetDestinationCallbackId();
     std::string_view message = msg.GetMessage();
 
     // ModelServer connected


### PR DESCRIPTION
Same situation as #1498. #1472 defines variables that are only used for debug logging. This breaks builds that have NOISEPAGE_USE_LOGGING=OFF, which I do for my performance testing.

We should discuss:
- Adding this flag to one of the CI builds so I don't have to keep fixing it when the build breaks.
- When to use `spdlog` vs. `<iostream>`. I view debug logging as exactly that: a debugging tool and the system should work without it. If the system needs to output something for correctness/CI reasons under any build configurations, then I argue that those events should use `<iostream>`.