### PR TITLE
fix Jenkinsfile-utils for self-driving e2e tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -523,7 +523,6 @@ pipeline {
                         script{
                             utils = utils ?: load(utilsFileName)
                             utils.noisePageBuild(buildType:utils.RELEASE_BUILD, isBuildTests:false, isBuildSelfDrivingTests: true)
-                            utils.noisePageBuild(buildType:utils.RELEASE_BUILD, isBuildTests:false)
                         }
 
                         // This scripts runs TPCC benchmark with query trace enabled. It also uses SET command to turn

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -523,6 +523,7 @@ pipeline {
                         script{
                             utils = utils ?: load(utilsFileName)
                             utils.noisePageBuild(buildType:utils.RELEASE_BUILD, isBuildTests:false, isBuildSelfDrivingTests: true)
+                            utils.noisePageBuild(buildType:utils.RELEASE_BUILD, isBuildTests:false)
                         }
 
                         // This scripts runs TPCC benchmark with query trace enabled. It also uses SET command to turn

--- a/Jenkinsfile-utils
+++ b/Jenkinsfile-utils
@@ -49,7 +49,7 @@ String generateCompileCmd(Map config = [:]) {
         '-DNOISEPAGE_GENERATE_COVERAGE': DISABLED,
         '-DNOISEPAGE_BUILD_BENCHMARKS': DISABLED,
         '-DNOISEPAGE_USE_JUMBOTESTS': DISABLED,
-        '-DNOISEPAGE_BUILD_SELF_DRIVING_TESTS': DISABLED,
+        '-DNOISEPAGE_BUILD_SELF_DRIVING_E2E_TESTS': DISABLED,
     ]
 
     if (config.useCache) {
@@ -90,7 +90,7 @@ String generateCompileCmd(Map config = [:]) {
     }
 
     if (config.isBuildSelfDrivingTests) {
-        cmakeArgs['-DNOISEPAGE_BUILD_SELF_DRIVING_TESTS'] = ENABLED
+        cmakeArgs['-DNOISEPAGE_BUILD_SELF_DRIVING_E2E_TESTS'] = ENABLED
     }
 
     String compileCmd = 'cmake -GNinja'


### PR DESCRIPTION
jenkinsfile-utils wasn't updated when #1426 renamed the e2e test build option, so we've had:
```
CMake Warning:
  Manually-specified variables were not used by the project:

    NOISEPAGE_BUILD_SELF_DRIVING_TESTS
```
in every CI build since then.