### PR TITLE
Check for DBMS exit codes in CI's script.testing.junit.

### DIFF
--- a/script/testing/junit/__main__.py
+++ b/script/testing/junit/__main__.py
@@ -36,7 +36,7 @@ def run_test(test_server, test_command):
 
 def run_tests_junit(test_server):
     LOG.info(section_header("TEST JUNIT"))
-    return run_test(test_server, JUNIT_TEST_CMD_JUNIT)
+    return ("junit", run_test(test_server, JUNIT_TEST_CMD_JUNIT))
 
 
 def run_tests_tracefiles(test_server):
@@ -60,7 +60,7 @@ def run_tests_tracefiles(test_server):
 
         return errcode
 
-    return [run_tracefile(test_server, item)
+    return [(item, run_tracefile(test_server, item))
             for item in sorted(os.listdir(noise_trace_dir)) if item.endswith(TESTFILES_SUFFIX)]
 
 
@@ -101,9 +101,11 @@ if __name__ == "__main__":
         unset_env_vars()
 
     # Compute the final exit code.
+    LOG.info("Tests:")
     final_code = 0 if len(errcodes) > 0 else 1
-    for c in errcodes:
-        final_code = final_code or c
+    for (item, errcode) in errcodes:
+        final_code = final_code or errcode
+        LOG.info("\t{} : {}".format("FAIL" if errcode else "SUCCESS", item))
 
     LOG.info("Final Status => {}".format("FAIL" if final_code else "SUCCESS"))
     sys.exit(final_code)

--- a/script/testing/util/db_server.py
+++ b/script/testing/util/db_server.py
@@ -116,6 +116,11 @@ class NoisePageServer:
             True if the commands that will be run should be printed,
             with the commands themselves not actually executing.
 
+        Returns
+        -------
+        exit_code : int
+            The exit code of the DBMS.
+
         Raises
         ------
         RuntimeError if the DBMS is not running when this is called.
@@ -126,32 +131,35 @@ class NoisePageServer:
         if not self.db_process:
             raise RuntimeError("System is in an invalid state.")
 
+        # Check if the DBMS is still running.
         return_code = self.db_process.poll()
-        if return_code is None:
-            try:
-                # Try to kill the process politely and wait for 60 seconds.
-                self.db_process.terminate()
-                self.db_process.wait(60)
-            except subprocess.TimeoutExpired:
-                # Otherwise, try to kill the process forcefully and wait another 60 seconds.
-                # If the process hasn't died yet, then something terrible has happened and we raise an error.
-                self.db_process.kill()
-                self.db_process.wait(60)
-            except KeyboardInterrupt:
-                raise KeyboardInterrupt
-            finally:
-                unix_socket = os.path.join("/tmp/", f".s.PGSQL.{self.db_port}")
-                if os.path.exists(unix_socket):
-                    os.remove(unix_socket)
-                    LOG.info(f"Removing: {unix_socket}")
-            self.print_db_logs()
-            LOG.info(f"DBMS stopped successfully, code: {self.db_process.returncode}")
-            self.db_process = None
-        else:
+        if return_code is not None:
             msg = f"DBMS already terminated, code: {self.db_process.returncode}"
             LOG.info(msg)
             self.print_db_logs()
             raise RuntimeError(msg)
+
+        try:
+            # Try to kill the process politely and wait for 60 seconds.
+            self.db_process.terminate()
+            self.db_process.wait(60)
+        except subprocess.TimeoutExpired:
+            # Otherwise, try to kill the process forcefully and wait another 60 seconds.
+            # If the process hasn't died yet, then something terrible has happened and we raise an error.
+            self.db_process.kill()
+            self.db_process.wait(60)
+        except KeyboardInterrupt:
+            raise KeyboardInterrupt
+        finally:
+            unix_socket = os.path.join("/tmp/", f".s.PGSQL.{self.db_port}")
+            if os.path.exists(unix_socket):
+                os.remove(unix_socket)
+                LOG.info(f"Removing: {unix_socket}")
+        self.print_db_logs()
+        exit_code = self.db_process.returncode
+        LOG.info(f"DBMS stopped successfully, code: {exit_code}")
+        self.db_process = None
+        return exit_code
 
     def delete_wal(self):
         """

--- a/script/testing/util/db_server.py
+++ b/script/testing/util/db_server.py
@@ -157,7 +157,7 @@ class NoisePageServer:
                 LOG.info(f"Removing: {unix_socket}")
         self.print_db_logs()
         exit_code = self.db_process.returncode
-        LOG.info(f"DBMS stopped successfully, code: {exit_code}")
+        LOG.info(f"DBMS stopped, code: {exit_code}")
         self.db_process = None
         return exit_code
 


### PR DESCRIPTION
# Heading

Check for DBMS exit codes in CI's script.testing.junit.

## Description

Fix #1483.

The issue was that DBMS exit codes were not being checked.

This should fail CI until #1482 merges.
This should be merged before #1111.