### PR TITLE
Upgrade fast float to major version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -541,7 +541,7 @@ add_noisepage_dep(nlohmann_json https://github.com/ArthurSonzogni/nlohmann_json_
 add_noisepage_dep(spdlog https://github.com/gabime/spdlog.git v1.8.1)
 add_noisepage_dep(xbyak https://github.com/herumi/xbyak.git v5.77)
 add_noisepage_dep(xxHash https://github.com/Cyan4973/xxHash.git v0.8.0)
-add_noisepage_dep(fast_float https://github.com/lemire/fast_float.git v0.1.0)
+add_noisepage_dep(fast_float https://github.com/lemire/fast_float.git v1.0.0)
 
 # Handle other dependencies.
 


### PR DESCRIPTION
This upgrades fast float to the first major release version. I don't plan on monitoring the releases of fast float anymore, I just wanted to upgrade to a major version when one came out.