### PR TITLE
Re-fix model server cache due to merge conflict

### DIFF
--- a/script/self_driving/model_server.py
+++ b/script/self_driving/model_server.py
@@ -169,7 +169,7 @@ class AbstractModel(ABC):
         save_path_str = str(save_path)
 
         # Load from cache
-        if self.model_cache.get(save_path, None) is not None:
+        if self.model_cache.get(save_path_str, None) is not None:
             return self.model_cache[save_path_str]
 
         # Load into cache

--- a/src/self_driving/model_server/model_server_manager.cpp
+++ b/src/self_driving/model_server/model_server_manager.cpp
@@ -276,7 +276,7 @@ std::pair<Result, bool> ModelServerManager::InferModel(ModelType::Type model, co
 
   // Callback to notify waiter with result
   auto callback = [&](common::ManagedPointer<messenger::Messenger> messenger, const messenger::ZmqMessage &msg) {
-    MODEL_SERVER_LOG_INFO("Callback :recv_cb_id={}, message={}", msg.GetDestinationCallbackId(), msg.GetMessage());
+    MODEL_SERVER_LOG_DEBUG("Callback :recv_cb_id={}, message={}", msg.GetDestinationCallbackId(), msg.GetMessage());
     future.Done(msg.GetMessage());
   };
 


### PR DESCRIPTION
The improper model serve caching was fixed in #1458, but then later on broke due to a merge conflict. This fixes the broken line.

It's a one-line fix so I don't think this needs to go-through CI.