### PR TITLE
fix broken import in binary size artifacts collection script

### DIFF
--- a/script/testing/artifact_stats/collectors/binary_size.py
+++ b/script/testing/artifact_stats/collectors/binary_size.py
@@ -1,6 +1,7 @@
 import os
 
-from ...util.db_server import get_build_path
+from ...util.constants import DEFAULT_DB_BIN
+from ...util.db_server import get_binary_directory
 from ..base_artifact_stats_collector import BaseArtifactStatsCollector
 
 
@@ -18,6 +19,6 @@ class BinarySizeCollector(BaseArtifactStatsCollector):
         """
         Measure the size of the NoisePage DBMS release binary.
         """
-        binary_path = get_build_path(build_type='release')
+        binary_path = os.path.join(get_binary_directory(build_type="release"), DEFAULT_DB_BIN)
         self.metrics['binary_size'] = os.path.getsize(binary_path)
         return 0


### PR DESCRIPTION
In PR [#1470](https://github.com/cmu-db/noisepage/pull/1470) I refactored some of the Python testing scripts. What I neglected to account for in this refactor is the fact that some (in this particular case, one) function I modified was imported and used in another script run in the nightly artifacts collection. I changed both the name and the semantics of the function, resulting in a runtime failure when the nightly artifacts stats collection was run in the nightly CI pipeline. This PR fixes this issue by updating the binary size artifact collection script to use the updated function.