### PR TITLE
Recover Database from WAL on Startup

### DIFF
--- a/src/include/main/db_main.h
+++ b/src/include/main/db_main.h
@@ -282,11 +282,11 @@ class DBMain {
   class NetworkLayer {
    public:
     /**
-     * @param thread_registry argument to the TerrierServer
+     * @param thread_registry argument to the NoisePageServer
      * @param traffic_cop argument to the ConnectionHandleFactor
-     * @param port argument to TerrierServer
-     * @param connection_thread_count argument to TerrierServer
-     * @param socket_directory argument to TerrierServer
+     * @param port argument to NoisePageServer
+     * @param connection_thread_count argument to NoisePageServer
+     * @param socket_directory argument to NoisePageServer
      */
     NetworkLayer(const common::ManagedPointer<common::DedicatedThreadRegistry> thread_registry,
                  const common::ManagedPointer<trafficcop::TrafficCop> traffic_cop, const uint16_t port,
@@ -295,7 +295,7 @@ class DBMain {
       command_factory_ = std::make_unique<network::PostgresCommandFactory>();
       provider_ =
           std::make_unique<network::PostgresProtocolInterpreter::Provider>(common::ManagedPointer(command_factory_));
-      server_ = std::make_unique<network::TerrierServer>(
+      server_ = std::make_unique<network::NoisePageServer>(
           common::ManagedPointer(provider_), common::ManagedPointer(connection_handle_factory_), thread_registry, port,
           connection_thread_count, socket_directory);
     }
@@ -303,14 +303,14 @@ class DBMain {
     /**
      * @return ManagedPointer to the component
      */
-    common::ManagedPointer<network::TerrierServer> GetServer() const { return common::ManagedPointer(server_); }
+    common::ManagedPointer<network::NoisePageServer> GetServer() const { return common::ManagedPointer(server_); }
 
    private:
     // Order matters here for destruction order
     std::unique_ptr<network::ConnectionHandleFactory> connection_handle_factory_;
     std::unique_ptr<network::PostgresCommandFactory> command_factory_;
     std::unique_ptr<network::ProtocolInterpreterProvider> provider_;
-    std::unique_ptr<network::TerrierServer> server_;
+    std::unique_ptr<network::NoisePageServer> server_;
   };
 
   /**

--- a/src/include/main/db_main.h
+++ b/src/include/main/db_main.h
@@ -62,6 +62,11 @@ class DBMain {
   void Run();
 
   /**
+   * Attempt to recover the system from the WAL.
+   */
+  void RecoverSystem();
+
+  /**
    * Shuts down the server.
    * It is worth noting that in normal cases, noisepage will shut down and return from Run().
    * So, use this function only when you want to shutdown the server from code.

--- a/src/include/network/connection_dispatcher_task.h
+++ b/src/include/network/connection_dispatcher_task.h
@@ -25,8 +25,8 @@ class ProtocolInterpreterProvider;
  *
  * ConnectionDispatcherTask is almost a pseudo-owner of the
  * ConnectionHandlerTask objects, but since we can't be both a DedicatedThreadTask/NotifiableTask and
- * DedicatedThreadOwner, we pass the original DedicatedThreadOwner (TerrierServer) value through to the
- * ConnectionHandlerTasks. TerrierServer ends up the DedicatedThreadOwner of both ConnectionDispatcherTask and
+ * DedicatedThreadOwner, we pass the original DedicatedThreadOwner (NoisePageServer) value through to the
+ * ConnectionHandlerTasks. NoisePageServer ends up the DedicatedThreadOwner of both ConnectionDispatcherTask and
  * ConnectionHandlerTasks for its instance.
  */
 class ConnectionDispatcherTask : public common::NotifiableTask {

--- a/src/include/network/noisepage_server.h
+++ b/src/include/network/noisepage_server.h
@@ -15,17 +15,17 @@ class ProtocolInterpreterProvider;
 // The name is based on https://www.postgresql.org/docs/9.3/runtime-config-connection.html
 constexpr std::string_view UNIX_DOMAIN_SOCKET_FORMAT_STRING = "{0}/.s.PGSQL.{1}";
 
-/** TerrierServer is the entry point to the network layer. */
-class TerrierServer : public common::DedicatedThreadOwner {
+/** NoisePageServer is the entry point to the network layer. */
+class NoisePageServer : public common::DedicatedThreadOwner {
  public:
-  /** @brief Construct a new TerrierServer instance. */
-  TerrierServer(common::ManagedPointer<ProtocolInterpreterProvider> protocol_provider,
-                common::ManagedPointer<ConnectionHandleFactory> connection_handle_factory,
-                common::ManagedPointer<common::DedicatedThreadRegistry> thread_registry, uint16_t port,
-                uint16_t connection_thread_count, std::string socket_directory);
+  /** @brief Construct a new NoisePageServer instance. */
+  NoisePageServer(common::ManagedPointer<ProtocolInterpreterProvider> protocol_provider,
+                  common::ManagedPointer<ConnectionHandleFactory> connection_handle_factory,
+                  common::ManagedPointer<common::DedicatedThreadRegistry> thread_registry, uint16_t port,
+                  uint16_t connection_thread_count, std::string socket_directory);
 
   /** @brief Destructor. */
-  ~TerrierServer() override = default;
+  ~NoisePageServer() override = default;
 
   /** @brief Spin up all of the server threads and start listening on the configured port. */
   void RunServer();

--- a/src/main/db_main.cpp
+++ b/src/main/db_main.cpp
@@ -5,6 +5,7 @@
 #undef __SETTING_GFLAGS_DEFINE__     // NOLINT
 
 #include "execution/execution_util.h"
+#include "storage/recovery/disk_log_provider.h"
 #include "storage/recovery/replication_log_provider.h"
 
 namespace noisepage {
@@ -28,6 +29,31 @@ void DBMain::Run() {
     std::unique_lock<std::mutex> lock(server->RunningMutex());
     server->RunningCV().wait(lock, [=] { return !(server->Running()); });
   }
+}
+
+void DBMain::RecoverSystem() {
+  NOISEPAGE_ASSERT(settings_manager_ != DISABLED, "Trying to recover system without SettingsManager.");
+
+  // Skip if logging is disabled
+  if (settings_manager_->GetBool(settings::Param::wal_enable) == false) {
+    return;
+  }
+
+  // Skip if the file does not exist
+  auto wal_file_path = settings_manager_->GetString(settings::Param::wal_file_path);
+  if (std::filesystem::exists(wal_file_path) == false) {
+    return;
+  }
+
+  // Instantiate recovery manager and recover the tables
+  storage::DiskLogProvider log_provider(wal_file_path);
+  storage::RecoveryManager recovery_manager(common::ManagedPointer<storage::AbstractLogProvider>(&log_provider),
+                                            catalog_layer_->GetCatalog(), txn_layer_->GetTransactionManager(),
+                                            txn_layer_->GetDeferredActionManager(), GetReplicationManager(),
+                                            GetThreadRegistry(), storage_layer_->GetBlockStore());
+
+  recovery_manager.StartRecovery();
+  recovery_manager.WaitForRecoveryToFinish();
 }
 
 void DBMain::ForceShutdown() {

--- a/src/main/noisepage.cpp
+++ b/src/main/noisepage.cpp
@@ -84,7 +84,6 @@ int main(int argc, char *argv[]) {
 
   db_main_handler_ptr = db_main.get();
 
-  db_main->RecoverSystem();
   db_main->Run();
 
   noisepage::LoggersUtil::ShutDown();

--- a/src/main/noisepage.cpp
+++ b/src/main/noisepage.cpp
@@ -84,6 +84,7 @@ int main(int argc, char *argv[]) {
 
   db_main_handler_ptr = db_main.get();
 
+  db_main->RecoverSystem();
   db_main->Run();
 
   noisepage::LoggersUtil::ShutDown();

--- a/src/network/noisepage_server.cpp
+++ b/src/network/noisepage_server.cpp
@@ -14,10 +14,11 @@
 
 namespace noisepage::network {
 
-TerrierServer::TerrierServer(common::ManagedPointer<ProtocolInterpreterProvider> protocol_provider,
-                             common::ManagedPointer<ConnectionHandleFactory> connection_handle_factory,
-                             common::ManagedPointer<common::DedicatedThreadRegistry> thread_registry,
-                             const uint16_t port, const uint16_t connection_thread_count, std::string socket_directory)
+NoisePageServer::NoisePageServer(common::ManagedPointer<ProtocolInterpreterProvider> protocol_provider,
+                                 common::ManagedPointer<ConnectionHandleFactory> connection_handle_factory,
+                                 common::ManagedPointer<common::DedicatedThreadRegistry> thread_registry,
+                                 const uint16_t port, const uint16_t connection_thread_count,
+                                 std::string socket_directory)
     : DedicatedThreadOwner(thread_registry),
       running_(false),
       port_(port),
@@ -35,8 +36,8 @@ TerrierServer::TerrierServer(common::ManagedPointer<ProtocolInterpreterProvider>
   signal(SIGPIPE, SIG_IGN);
 }
 
-template <TerrierServer::SocketType type>
-void TerrierServer::RegisterSocket() {
+template <NoisePageServer::SocketType type>
+void NoisePageServer::RegisterSocket() {
   static_assert(type == NETWORKED_SOCKET || type == UNIX_DOMAIN_SOCKET, "There should only be two socket types.");
 
   constexpr auto conn_backlog = common::Settings::CONNECTION_BACKLOG;
@@ -132,7 +133,7 @@ void TerrierServer::RegisterSocket() {
   NETWORK_LOG_INFO("Listening on {} socket with port {} [PID={}]", socket_description, port_, ::getpid());
 }
 
-void TerrierServer::RunServer() {
+void NoisePageServer::RunServer() {
   // Initialize thread support for libevent as libevent will be invoked from multiple ConnectionHandlerTask threads.
   evthread_use_pthreads();
 
@@ -154,7 +155,7 @@ void TerrierServer::RunServer() {
   }
 }
 
-void TerrierServer::StopServer() {
+void NoisePageServer::StopServer() {
   // Stop the dispatcher task and close the socket's file descriptor.
   const bool is_task_stopped UNUSED_ATTRIBUTE =
       thread_registry_->StopTask(this, dispatcher_task_.CastManagedPointerTo<common::DedicatedThreadTask>());

--- a/test/network/network_test.cpp
+++ b/test/network/network_test.cpp
@@ -48,7 +48,7 @@ class NetworkTests : public TerrierTest {
   transaction::TransactionManager *txn_manager_;
 
   storage::GarbageCollector *gc_;
-  std::unique_ptr<TerrierServer> server_;
+  std::unique_ptr<NoisePageServer> server_;
   std::unique_ptr<ConnectionHandleFactory> handle_factory_;
   common::DedicatedThreadRegistry thread_registry_ = common::DedicatedThreadRegistry(DISABLED);
   uint16_t port_ = 15721;
@@ -85,7 +85,7 @@ class NetworkTests : public TerrierTest {
 
     try {
       handle_factory_ = std::make_unique<ConnectionHandleFactory>(common::ManagedPointer(tcop_));
-      server_ = std::make_unique<TerrierServer>(
+      server_ = std::make_unique<NoisePageServer>(
           common::ManagedPointer<ProtocolInterpreterProvider>(&protocol_provider_),
           common::ManagedPointer(handle_factory_.get()), common::ManagedPointer(&thread_registry_), port_,
           connection_thread_count_, socket_directory_);


### PR DESCRIPTION
## Description
This PR does two things:

1. Attempt to recover the database from a WAL file if one already exists and logging is enabled.
2. Renamed `TerrierServer` to `NoisePageServer`

Unfortunately the WAL recovery fails because we are logging bootstrap inserts into the catalog during initialization, which we then try to replay in the WAL:

```
noisepage: /home/pavlo/wanshenl-is-a-badass/NoisePage/Github/noisepage/src/storage/recovery/recovery_manager.cpp:487: uint32_t noisepage::storage::RecoveryManager::ProcessSpecialCasePGDatabaseRecord(noisepage::transaction::TransactionContext*, std::vector<std::pair<noisepage::storage::LogRecord*, std::vector<std::byte*> > >*, uint32_t): Assertion `(result) && ("Database recreation should succeed")' failed.

Thread 7 "noisepage" received signal SIGABRT, Aborted.
[Switching to Thread 0x7fffef3fc700 (LWP 794391)]
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
50      ../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007ffff78d2859 in __GI_abort () at abort.c:79
#2  0x00007ffff78d2729 in __assert_fail_base (fmt=0x7ffff7a68588 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=0x555556961be8 "(result) && (\"Database recreation should succeed\")", 
    file=0x555556960bf0 "/home/pavlo/wanshenl-is-a-badass/NoisePage/Github/noisepage/src/storage/recovery/recovery_manager.cpp", line=487, function=<optimized out>) at assert.c:92
#3  0x00007ffff78e3f36 in __GI___assert_fail (assertion=0x555556961be8 "(result) && (\"Database recreation should succeed\")", 
    file=0x555556960bf0 "/home/pavlo/wanshenl-is-a-badass/NoisePage/Github/noisepage/src/storage/recovery/recovery_manager.cpp", line=487, 
    function=0x555556961920 "uint32_t noisepage::storage::RecoveryManager::ProcessSpecialCasePGDatabaseRecord(noisepage::transaction::TransactionContext*, std::vector<std::pair<noisepage::storage::LogRecord*, std::vector<std::byt"...) at assert.c:101
#4  0x00005555576477b0 in noisepage::storage::RecoveryManager::ProcessSpecialCasePGDatabaseRecord (this=0x7fffffffc510, txn=0x7fffdc01e880, buffered_changes=0x7fffdc0010a0, start_idx=0)
    at /home/pavlo/wanshenl-is-a-badass/NoisePage/Github/noisepage/src/storage/recovery/recovery_manager.cpp:487
#5  0x0000555557647291 in noisepage::storage::RecoveryManager::ProcessSpecialCaseCatalogRecord (this=0x7fffffffc510, txn=0x7fffdc01e880, buffered_changes=0x7fffdc0010a0, start_idx=0)
    at /home/pavlo/wanshenl-is-a-badass/NoisePage/Github/noisepage/src/storage/recovery/recovery_manager.cpp:422
#6  0x0000555557645463 in noisepage::storage::RecoveryManager::ProcessCommittedTransaction (this=0x7fffffffc510, txn_id=...)
    at /home/pavlo/wanshenl-is-a-badass/NoisePage/Github/noisepage/src/storage/recovery/recovery_manager.cpp:134
#7  0x0000555557645840 in noisepage::storage::RecoveryManager::ProcessDeferredTransactions (this=0x7fffffffc510, upper_bound_ts=...)
    at /home/pavlo/wanshenl-is-a-badass/NoisePage/Github/noisepage/src/storage/recovery/recovery_manager.cpp:173
#8  0x0000555557644e99 in noisepage::storage::RecoveryManager::RecoverFromLogs (this=0x7fffffffc510, log_provider=...) at /home/pavlo/wanshenl-is-a-badass/NoisePage/Github/noisepage/src/storage/recovery/recovery_manager.cpp:80
#9  0x0000555557656c40 in noisepage::storage::RecoveryManager::Recover (this=0x7fffffffc510) at ../src/include/storage/recovery/recovery_manager.h:190
#10 0x0000555557656bca in noisepage::storage::RecoveryManager::RecoveryTask::RunTask (this=0x5555592e4000) at ../src/include/storage/recovery/recovery_manager.h:63
#11 0x0000555557665cde in noisepage::common::DedicatedThreadRegistry::RegisterDedicatedThread<noisepage::storage::RecoveryManager::RecoveryTask, noisepage::storage::RecoveryManager*>(noisepage::common::DedicatedThreadOwner*, noisepage::storage::RecoveryManager*)::{lambda()#1}::operator()() const (this=0x555559217270) at ../src/include/common/dedicated_thread_registry.h:82
#12 0x000055555771ecdc in std::__invoke_impl<void, noisepage::common::DedicatedThreadRegistry::RegisterDedicatedThread<noisepage::storage::RecoveryManager::RecoveryTask, noisepage::storage::RecoveryManager*>(noisepage::common::DedicatedThreadOwner*, noisepage::storage::RecoveryManager*)::{lambda()#1}>(std::__invoke_other, noisepage::common::DedicatedThreadRegistry::RegisterDedicatedThread<noisepage::storage::RecoveryManager::RecoveryTask, noisepage::storage::RecoveryManager*>(noisepage::common::DedicatedThreadOwner*, noisepage::storage::RecoveryManager*)::{lambda()#1}&&) (__f=...) at /usr/include/c++/9/bits/invoke.h:60
#13 0x000055555771dbc9 in std::__invoke<noisepage::common::DedicatedThreadRegistry::RegisterDedicatedThread<noisepage::storage::RecoveryManager::RecoveryTask, noisepage::storage::RecoveryManager*>(noisepage::common::DedicatedThreadOwner*, noisepage::storage::RecoveryManager*)::{lambda()#1}>(noisepage::common::DedicatedThreadRegistry::RegisterDedicatedThread<noisepage::storage::RecoveryManager::RecoveryTask, noisepage::storage::RecoveryManager*>(noisepage::common::DedicatedThreadOwner*, noisepage::storage::RecoveryManager*)::{lambda()#1}&&) (__fn=...) at /usr/include/c++/9/bits/invoke.h:95
#14 0x000055555771c958 in std::thread::_Invoker<std::tuple<noisepage::common::DedicatedThreadRegistry::RegisterDedicatedThread<noisepage::storage::RecoveryManager::RecoveryTask, noisepage::storage::RecoveryManager*>(noisepage::common::DedicatedThreadOwner*, noisepage::storage::RecoveryManager*)::{lambda()#1}> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) (this=0x5555592e8f68) at /usr/include/c++/9/thread:244
#15 0x000055555771c060 in std::thread::_Invoker<std::tuple<noisepage::common::DedicatedThreadRegistry::RegisterDedicatedThread<noisepage::storage::RecoveryManager::RecoveryTask, noisepage::storage::RecoveryManager*>(noisepage::common::DedicatedThreadOwner*, noisepage::storage::RecoveryManager*)::{lambda()#1}> >::operator()() (this=0x5555592e8f68) at /usr/include/c++/9/thread:251
#16 0x000055555771be24 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<noisepage::common::DedicatedThreadRegistry::RegisterDedicatedThread<noisepage::storage::RecoveryManager::RecoveryTask, noisepage::storage::RecoveryManager*>(noisepage::common::DedicatedThreadOwner*, noisepage::storage::RecoveryManager*)::{lambda()#1}> > >::_M_run() (this=0x5555592e8f60) at /usr/include/c++/9/thread:195
```
### Remaining Tasks
We need to disable WAL entries for the catalog bootstrap transaction.

https://youtu.be/ie6QcPnBK1E