### PR TITLE
Nightly Microbenchmark JSON Fixes

### DIFF
--- a/script/testing/.gitignore
+++ b/script/testing/.gitignore
@@ -1,0 +1,3 @@
+# Benchmark script output
+*.json
+*.xml

--- a/script/testing/.gitignore
+++ b/script/testing/.gitignore
@@ -1,3 +1,4 @@
 # Benchmark script output
 *.json
 *.xml
+*.csv


### PR DESCRIPTION
This PR does three things:

* Strip debug statements from our system in the JSON output of the microbenchmarks.
* Fixes the environment variables that we weren't setting correctly for the # of CPU cores + log path.
* Adds a gitignore to hide the microbenchmark output files.

https://youtu.be/iin3ZVXot74