### PR TITLE
Binder catches WHERE clause with incorrect return type

### DIFF
--- a/script/testing/junit/traces/select.test
+++ b/script/testing/junit/traces/select.test
@@ -1279,3 +1279,48 @@ SELECT a FROM t WHERE b IN ('a','nananananabanana','catdogelephantfishgiraffehor
 
 statement ok
 DROP TABLE t;
+
+statement ok
+CREATE TABLE t (a INT);
+
+statement ok
+INSERT INTO t VALUES (1), (2), (3), (4);
+
+statement error
+SELECT a FROM t WHERE 5;
+----
+
+query I rowsort
+SELECT a FROM t WHERE 5=4;
+----
+
+query I rowsort
+SELECT a FROM t WHERE 5=5;
+----
+1
+2
+3
+4
+
+query I rowsort
+SELECT a FROM t WHERE 1 = NULL;
+----
+
+# query I rowsort
+# SELECT a FROM t WHERE NULL;
+# ----
+
+# query I rowsort
+# SELECT a FROM t WHERE true;
+# ----
+# 1
+# 2
+# 3
+# 4
+
+# query I rowsort
+# SELECT a FROM t WHERE false;
+# ----
+
+statement ok
+DROP TABLE t;

--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -277,6 +277,7 @@ void BindNodeVisitor::Visit(common::ManagedPointer<parser::DeleteStatement> node
 
   if (node->GetDeleteCondition() != nullptr) {
     node->GetDeleteCondition()->Accept(common::ManagedPointer(this).CastManagedPointerTo<SqlNodeVisitor>());
+    BinderUtil::ValidateWhereClause(node->GetDeleteCondition());
   }
 
   context_ = nullptr;
@@ -402,6 +403,7 @@ void BindNodeVisitor::Visit(common::ManagedPointer<parser::SelectStatement> node
 
   if (node->GetSelectCondition() != nullptr) {
     node->GetSelectCondition()->Accept(common::ManagedPointer(this).CastManagedPointerTo<SqlNodeVisitor>());
+    BinderUtil::ValidateWhereClause(node->GetSelectCondition());
     node->GetSelectCondition()->DeriveDepth();
     node->GetSelectCondition()->DeriveSubqueryFlag();
   }
@@ -474,8 +476,10 @@ void BindNodeVisitor::Visit(common::ManagedPointer<parser::UpdateStatement> node
 
   auto table_ref = node->GetUpdateTable();
   table_ref->Accept(common::ManagedPointer(this).CastManagedPointerTo<SqlNodeVisitor>());
-  if (node->GetUpdateCondition() != nullptr)
+  if (node->GetUpdateCondition() != nullptr) {
     node->GetUpdateCondition()->Accept(common::ManagedPointer(this).CastManagedPointerTo<SqlNodeVisitor>());
+    BinderUtil::ValidateWhereClause(node->GetUpdateCondition());
+  }
 
   auto binder_table_data = context_->GetTableMapping(table_ref->GetTableName());
   const auto &table_schema = std::get<2>(*binder_table_data);

--- a/src/binder/binder_util.cpp
+++ b/src/binder/binder_util.cpp
@@ -5,10 +5,18 @@
 
 #include "common/error/error_code.h"
 #include "network/postgres/postgres_defs.h"
+#include "parser/expression/abstract_expression.h"
 #include "parser/expression/constant_value_expression.h"
 #include "spdlog/fmt/fmt.h"
 
 namespace noisepage::binder {
+
+void BinderUtil::ValidateWhereClause(const common::ManagedPointer<parser::AbstractExpression> value) {
+  if (value->GetReturnValueType() != type::TypeId::BOOLEAN) {
+    // TODO(Matt): NULL literal (type::TypeId::INVALID and cve->IsNull()) should be allowed but breaks stuff downstream
+    throw BINDER_EXCEPTION("argument of WHERE must be type boolean", common::ErrorCode::ERRCODE_DATATYPE_MISMATCH);
+  }
+}
 
 void BinderUtil::PromoteParameters(
     const common::ManagedPointer<std::vector<parser::ConstantValueExpression> > parameters,

--- a/src/include/binder/binder_util.h
+++ b/src/include/binder/binder_util.h
@@ -40,6 +40,11 @@ class BinderUtil {
   static void CheckAndTryPromoteType(common::ManagedPointer<parser::ConstantValueExpression> value,
                                      type::TypeId desired_type);
 
+  /**
+   * Predicate for evaluating expressions that serve as WHERE clauses. This is mostly defined by postgres and what we
+   * support, and should evolve as stuff gets fixed (mostly related to literals, at the moment).
+   * @param value expression that serves as the condition in a WHERE clause (SELECT, UPDATE, INSERT)
+   */
   static void ValidateWhereClause(common::ManagedPointer<parser::AbstractExpression> value);
 
   /**

--- a/src/include/binder/binder_util.h
+++ b/src/include/binder/binder_util.h
@@ -9,7 +9,8 @@
 
 namespace noisepage::parser {
 class ConstantValueExpression;
-}
+class AbstractExpression;
+}  // namespace noisepage::parser
 
 namespace noisepage::binder {
 
@@ -38,6 +39,8 @@ class BinderUtil {
    */
   static void CheckAndTryPromoteType(common::ManagedPointer<parser::ConstantValueExpression> value,
                                      type::TypeId desired_type);
+
+  static void ValidateWhereClause(common::ManagedPointer<parser::AbstractExpression> value);
 
   /**
    * @return True if the value of @p int_val fits in the Output type, false otherwise.

--- a/src/optimizer/statistics/stats_calculator.cpp
+++ b/src/optimizer/statistics/stats_calculator.cpp
@@ -163,7 +163,7 @@ double StatsCalculator::CalculateSelectivityForPredicate(const TableStats &predi
     NOISEPAGE_ASSERT(
         cve->GetReturnValueType() == type::TypeId::BOOLEAN,
         "Single child ConstantValueExpression should be a boolean since WHERE clauses must resolve to boolean.");
-    if (cve->IsNull() || cve->GetBoolVal().val_ == false) {
+    if (cve->IsNull() || !cve->GetBoolVal().val_) {
       selectivity = 0;
     }
   } else if (expr->GetExpressionType() == parser::ExpressionType::OPERATOR_CAST) {


### PR DESCRIPTION
@abigalekim #1234 identified an issue with `WHERE` clauses that don't reference columns. If it's a literal or arithmetic expression things go kaboom, in a few different places. This fixes immediate errors in the `stats_calculator` for selectivity, adds a helper method in the Binder to verify a `WHERE`'s return type, and adds a couple of tests.

The simplest of literals are still broken though. I'll open an issue for that since it's a big rabbit hole.