### PR TITLE
Delete WAL in tests if it is specified as a relative path

### DIFF
--- a/script/testing/util/db_server.py
+++ b/script/testing/util/db_server.py
@@ -176,9 +176,17 @@ class NoisePageServer:
         """
         if not self.server_args.get('wal_enable', True):
             return
+
+        # WAL location can be specified as absolute path
         wal = self.server_args.get('wal_file_path', DEFAULT_DB_WAL_FILE)
         if os.path.exists(wal):
             os.remove(wal)
+            return
+
+        # If WAL isn't absolute path then it is relative to the binary path
+        wal_path = os.path.join(self.binary_dir, wal)
+        if os.path.exists(wal_path):
+            os.remove(wal_path)
 
     def print_db_logs(self):
         """


### PR DESCRIPTION
## Description
The WAL file location can be specified as either a relative path or an absolute path. In our test framework, we often start instances of the database with the WAL enabled, and after the test we attempt to delete the WAL. The test framework was only successfully deleting the WAL when it was specified as an absolute path, so this PR adds the functionality to delete the WAL when it's specified as a relative path.