### PR TITLE
Rename port setting from Terrier to NoisePage

### DIFF
--- a/src/include/settings/settings_defs.h
+++ b/src/include/settings/settings_defs.h
@@ -3,10 +3,10 @@
 // clang-format off
 // SETTING_<type>(name, description, default_value, min_value, max_value, is_mutable, callback_fn)
 
-// Terrier port
+// NoisePage port
 SETTING_int(
     port,
-    "Terrier port (default: 15721)",
+    "NoisePage port (default: 15721)",
     15721,
     1024,
     65535,


### PR DESCRIPTION
Changes the description of the port setting from "Terrier port (default: 15721)" to "NoisePage port (default: 15721)". 

Note: The `model_save_path` setting still uses terrier for the default path. I don't know enough about this property to feel comfortable changing it though. If the reviewer thinks that it's fine to change that property, I can include it in this PR.