### PR TITLE
Port LLVMEngine::Optimize to skip module passes.

### DIFF
--- a/src/execution/vm/llvm_engine.cpp
+++ b/src/execution/vm/llvm_engine.cpp
@@ -953,8 +953,7 @@ void LLVMEngine::CompiledModuleBuilder::Simplify() {
 void LLVMEngine::CompiledModuleBuilder::Optimize() {
   llvm::legacy::FunctionPassManager function_passes(llvm_module_.get());
 
-  // Add the appropriate TargetLibraryInfo and TargetTransformInfo.
-  auto tli = std::make_unique<llvm::TargetLibraryInfoImpl>(target_machine_->getTargetTriple());
+  // Add the appropriate TargetTransformInfo.
   function_passes.add(llvm::createTargetTransformInfoWrapperPass(target_machine_->getTargetIRAnalysis()));
 
   // Build up optimization pipeline.

--- a/src/execution/vm/llvm_engine.cpp
+++ b/src/execution/vm/llvm_engine.cpp
@@ -20,6 +20,9 @@
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/IPO/AlwaysInliner.h>
 #include <llvm/Transforms/IPO/PassManagerBuilder.h>
+#include <llvm/Transforms/InstCombine/InstCombine.h>
+#include <llvm/Transforms/Scalar.h>
+#include <llvm/Transforms/Scalar/GVN.h>
 
 #include <map>
 #include <memory>
@@ -948,29 +951,32 @@ void LLVMEngine::CompiledModuleBuilder::Simplify() {
 }
 
 void LLVMEngine::CompiledModuleBuilder::Optimize() {
-  llvm::legacy::PassManager module_passes;
   llvm::legacy::FunctionPassManager function_passes(llvm_module_.get());
 
-  // Add the appropriate TargetLibraryInfo and TargetTransformInfo
-  auto target_library_info_impl = std::make_unique<llvm::TargetLibraryInfoImpl>(target_machine_->getTargetTriple());
+  // Add the appropriate TargetLibraryInfo and TargetTransformInfo.
+  auto tli = std::make_unique<llvm::TargetLibraryInfoImpl>(target_machine_->getTargetTriple());
   function_passes.add(llvm::createTargetTransformInfoWrapperPass(target_machine_->getTargetIRAnalysis()));
-  module_passes.add(new llvm::TargetLibraryInfoWrapperPass(*target_library_info_impl));
-  module_passes.add(llvm::createTargetTransformInfoWrapperPass(target_machine_->getTargetIRAnalysis()));
 
-  // Build up optimization pipeline
+  // Build up optimization pipeline.
   llvm::PassManagerBuilder pm_builder;
   pm_builder.OptLevel = 3;
   pm_builder.Inliner = llvm::createFunctionInliningPass(3, 0, false);
   pm_builder.populateFunctionPassManager(function_passes);
-  pm_builder.populateModulePassManager(module_passes);
 
-  // Run optimization passes on module
+  // Add custom passes. Hand-selected based on empirical evaluation.
+  function_passes.add(llvm::createInstructionCombiningPass());
+  function_passes.add(llvm::createReassociatePass());
+  function_passes.add(llvm::createGVNPass());
+  function_passes.add(llvm::createCFGSimplificationPass());
+  function_passes.add(llvm::createAggressiveDCEPass());
+  function_passes.add(llvm::createCFGSimplificationPass());
+
+  // Run optimization passes on all functions.
   function_passes.doInitialization();
-  for (auto &func : *llvm_module_) {
+  for (llvm::Function &func : *llvm_module_) {
     function_passes.run(func);
   }
   function_passes.doFinalization();
-  module_passes.run(*llvm_module_);
 }
 
 std::unique_ptr<LLVMEngine::CompiledModule> LLVMEngine::CompiledModuleBuilder::Finalize() {

--- a/src/execution/vm/llvm_engine.cpp
+++ b/src/execution/vm/llvm_engine.cpp
@@ -958,8 +958,11 @@ void LLVMEngine::CompiledModuleBuilder::Optimize() {
 
   // Build up optimization pipeline.
   llvm::PassManagerBuilder pm_builder;
-  pm_builder.OptLevel = 3;
-  pm_builder.Inliner = llvm::createFunctionInliningPass(3, 0, false);
+  uint32_t opt_level = 3;
+  uint32_t size_opt_level = 0;
+  bool disable_inline_hot_call_site = false;
+  pm_builder.OptLevel = opt_level;
+  pm_builder.Inliner = llvm::createFunctionInliningPass(opt_level, size_opt_level, disable_inline_hot_call_site);
   pm_builder.populateFunctionPassManager(function_passes);
 
   // Add custom passes. Hand-selected based on empirical evaluation.


### PR DESCRIPTION
# Heading

Port LLVMEngine::Optimize to skip module passes.

## Description

Copies over Prashanth's commit here:
https://github.com/pmenon/tpl/commit/e2d3749032d81a9792d9b8a2e82569d063ebd1ad#diff-ed4b8c2805fa1b88ccfdd18b72ce7eebaf3485e63bf95990c7551716a9d79a5f

Unscientific timing on a separate branch showed that much
more time was spent running module passes than the singular
inlining function pass, so maybe this will help. In general, we
also would like to have function passes (as opposed to module)
wherever possible so that it is easier to time the passes.

And for a few hand-checked examples, function optimize time went up (as expected),
but overall optimize time went down.

Expect to see a speedup in the compiled tests on CI.