### PR TITLE
Add -async_replication_enable command line arg.

### DIFF
--- a/src/include/settings/settings_defs.h
+++ b/src/include/settings/settings_defs.h
@@ -124,6 +124,15 @@ SETTING_bool(
     noisepage::settings::Callbacks::NoOp
 )
 
+// Asynchronous replication instead of synchronous replication, if replication is enabled.
+SETTING_bool(
+    async_replication_enable,
+    "Asynchronous replication instead of synchronous replication, if replication is enabled. (default: false)",
+    false,
+    false,
+    noisepage::settings::Callbacks::NoOp
+)
+
 // Number of buffers log manager can use to buffer logs
 SETTING_int64(
     wal_num_buffers,


### PR DESCRIPTION
# Heading

Add -async_replication_enable command line arg.

## Description

Add -async_replication_enable command line arg.
This arg has no effect unless -replication_enable is also provided,
in which case it defaults to async replication instead of sync replication.

Minimum set of flags: `-messenger_enable -replication_enable -async_replication_enable`