### PR TITLE
Allow sync durability with async replication

### DIFF
--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -213,13 +213,6 @@ class TransactionContext {
   /** Set the replication policy of the entire transaction. */
   void SetReplicationPolicy(ReplicationPolicy replication_policy) {
     NOISEPAGE_ASSERT(durability_policy_ != DurabilityPolicy::DISABLE, "Replication needs durability enabled.");
-    NOISEPAGE_ASSERT(!(replication_policy == ReplicationPolicy::ASYNC && durability_policy_ == DurabilityPolicy::SYNC),
-                     "In a theoretical world where fault-tolerance is supported, consider the following scenario "
-                     "adapted from SingleStore. If the primary fails, a replica will be promoted to primary. "
-                     "However, under async replication, the replica might not have received the logs that were "
-                     "supposedly committed, i.e., there is still data loss. So there's little point in having sync "
-                     "durability on the replicas when replication is async. Currently, the primary and the replicas "
-                     "all have the same transaction policy.");
     replication_policy_ = replication_policy;
   }
 


### PR DESCRIPTION
## Description
This commit allows the database to run with synchronous durability but asynchronous replication. The benefit of this is that you can run with synchronous durability and replication turned on without taking some of the performance penalties associated with synchronous replication.

As the comment suggests there is a potential for data loss if the primary crashes and one of the replicas is promoted to primary (though this promotion functionality isn't implemented yet)

## Performance

All results performed under TPCC with a scale factor of 1

### Sync Durability and Sync Replication
13.198780362740948 requests/sec

### Sync Durability and Async Replication
96.29715975379193 requests/sec
