### PR TITLE
Invoke ninja instead of ninja noisepage so that microbenchmarks are built.

### DIFF
--- a/Jenkinsfile-utils.groovy
+++ b/Jenkinsfile-utils.groovy
@@ -330,7 +330,7 @@ void stageNightlyPerformance() {
 void stageNightlyMicrobenchmark() {
     stagePre()
     installPackages()
-    buildNoisePage([buildCommand:'ninja noisepage', cmake:
+    buildNoisePage([buildCommand:'ninja', cmake:
         '-DCMAKE_BUILD_TYPE=Release -DNOISEPAGE_BUILD_BENCHMARKS=ON -DNOISEPAGE_UNITY_BUILD=ON -DNOISEPAGE_USE_JEMALLOC=ON -DNOISEPAGE_USE_LOGGING=OFF'
     ])
 


### PR DESCRIPTION
# Heading

Invoke ninja instead of ninja noisepage so that microbenchmarks are built.

## Description

Should fix the nightly build. One-liner, just going to merge and rerun.