### PR TITLE
Run check-clang-tidy-full on master build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1434,6 +1434,29 @@ endif ()
 unset(CLANG_TIDY_BIN)
 
 #######################################################################################################################
+# check-clang-tidy-full  :   Run clang-tidy static analysis on the codebase in "full", i.e.,
+#                            normally clang-tidy is only run on files that differ from origin/master.
+#######################################################################################################################
+
+find_program(CLANG_TIDY_BIN NAMES clang-tidy-8 clang-tidy HINTS ${CLANG_TOOLS_SEARCH_PATH})
+if ("${CLANG_TIDY_BIN}" STREQUAL "CLANG_TIDY_BIN-NOTFOUND")
+    message(STATUS "[MISSING] clang-tidy not found, no check-clang-tidy.")
+else ()
+    # Run clang-tidy and exit with a non-zero exit code if any errors are found.
+    # clang-tidy automatically searches for a .clang-tidy file in parent directories.
+    add_custom_target(check-clang-tidy-full
+            ${BUILD_SUPPORT_DIR}/run-clang-tidy.py                            # Run LLVM's clang-tidy script.
+            -clang-tidy-binary ${CLANG_TIDY_BIN}                              # Using the specified clang-tidy binary.
+            -p ${CMAKE_BINARY_DIR}                                            # Using the generated compile commands.
+            -full                                                             # Do not apply the git filter.
+            USES_TERMINAL
+            )
+    add_custom_command(TARGET check-clang-tidy-full DEPENDS benchmark gflags gtest)
+    message(STATUS "[ADDED] check-clang-tidy-full (${CLANG_TIDY_BIN})")
+endif ()
+unset(CLANG_TIDY_BIN)
+
+#######################################################################################################################
 # Apply +x permissions to all scripts in the build-support folder.
 #######################################################################################################################
 

--- a/Jenkinsfile-utils.groovy
+++ b/Jenkinsfile-utils.groovy
@@ -48,7 +48,11 @@ void stageCheck() {
     sh 'cd build && timeout 20m ninja check-format'
     sh 'cd build && timeout 20m ninja check-lint'
     sh 'cd build && timeout 20m ninja check-censored'
-    sh 'cd build && ninja check-clang-tidy'
+    if (env.BRANCH_NAME != 'master') {
+        sh 'cd build && ninja check-clang-tidy'
+    } else {
+        sh 'cd build && ninja check-clang-tidy-full'
+    }
     stagePost()
 }
 

--- a/build-support/run-clang-tidy.py
+++ b/build-support/run-clang-tidy.py
@@ -221,6 +221,8 @@ def main():
     parser.add_argument('-fix', action='store_true', help='apply fix-its')
     parser.add_argument('-format', action='store_true', help='Reformat code '
                                                              'after applying fixes')
+    parser.add_argument('-full', action='store_true',
+                        help='(NoisePage) Run clang-tidy in full, ignoring the git filter.')
     parser.add_argument('-style', default='file', help='The style of reformat '
                                                        'code after applying fixes')
     parser.add_argument('-p', dest='build_path',
@@ -283,7 +285,7 @@ def main():
     return_code = 0
     try:
         # Initialize file blacklist 
-        cc = CheckConfig()
+        cc = CheckConfig(apply_git_filter=False if args.full else True)
         # Spin up a bunch of tidy-launching threads.
         task_queue = queue.Queue(max_task)
         # List of files with a non-zero return code.

--- a/src/execution/sql/thread_state_container.cpp
+++ b/src/execution/sql/thread_state_container.cpp
@@ -119,8 +119,9 @@ void ThreadStateContainer::IterateStates(void *const ctx, ThreadStateContainer::
 }
 
 void ThreadStateContainer::IterateStatesParallel(void *const ctx, ThreadStateContainer::IterateFn iterate_fn) const {
-  tbb::parallel_for_each(impl_->states_.begin(), impl_->states_.end(),
-                         [&](auto &entry) { iterate_fn(ctx, entry.second->State()); });
+  // TODO(WAN): The below no-lints are because clang-tidy seems to think there is a null pointer deference. Unclear.
+  tbb::parallel_for_each(impl_->states_.begin(), impl_->states_.end(),                   // NOLINT
+                         [&](auto &entry) { iterate_fn(ctx, entry.second->State()); });  // NOLINT
 }
 
 uint32_t ThreadStateContainer::GetThreadStateCount() const { return impl_->states_.size(); }


### PR DESCRIPTION
# Header

Run check-clang-tidy-full on master build.

# Description

Adds `check-clang-tidy-full` target that skips applying the git filter which we introduced in #741.

The motivation is that we may sometimes hammer "Retry test from stage" on a PR through CI, which means that we could skip running clang-tidy on the contents of later commits.

- Run 1 is as-is in the PR: http://jenkins.db.cs.cmu.edu:8080/blue/organizations/jenkins/terrier/detail/PR-1567/1/pipeline
- Run 2 is manually replayed with alternative code to show that the else branch works: http://jenkins.db.cs.cmu.edu:8080/blue/organizations/jenkins/terrier/detail/PR-1567/1/pipeline

