### PR TITLE
Minor Catalog refactors

### DIFF
--- a/src/catalog/catalog_accessor.cpp
+++ b/src/catalog/catalog_accessor.cpp
@@ -29,7 +29,7 @@ void CatalogAccessor::SetSearchPath(std::vector<namespace_oid_t> namespaces) {
   search_path_ = std::move(namespaces);
 
   // Check if 'pg_catalog is explicitly set'
-  for (auto &ns : search_path_)
+  for (const auto &ns : search_path_)
     if (ns == postgres::PgNamespace::NAMESPACE_CATALOG_NAMESPACE_OID) return;
 
   search_path_.emplace(search_path_.begin(), postgres::PgNamespace::NAMESPACE_CATALOG_NAMESPACE_OID);
@@ -50,7 +50,7 @@ bool CatalogAccessor::DropNamespace(namespace_oid_t ns) const { return dbc_->Del
 
 table_oid_t CatalogAccessor::GetTableOid(std::string name) const {
   NormalizeObjectName(&name);
-  for (auto &path : search_path_) {
+  for (const auto &path : search_path_) {
     table_oid_t search_result = dbc_->GetTableOid(txn_, path, name);
     if (search_result != INVALID_TABLE_OID) return search_result;
   }
@@ -116,14 +116,14 @@ std::vector<index_oid_t> CatalogAccessor::GetIndexOids(table_oid_t table) const 
 }
 
 std::vector<std::pair<common::ManagedPointer<storage::index::Index>, const IndexSchema &>> CatalogAccessor::GetIndexes(
-    table_oid_t table) {
+    const table_oid_t table) {
   return dbc_->GetIndexes(txn_, table);
 }
 
 index_oid_t CatalogAccessor::GetIndexOid(std::string name) const {
   NormalizeObjectName(&name);
-  for (auto &path : search_path_) {
-    index_oid_t search_result = dbc_->GetIndexOid(txn_, path, name);
+  for (const auto &path : search_path_) {
+    const index_oid_t search_result = dbc_->GetIndexOid(txn_, path, name);
     if (search_result != INVALID_INDEX_OID) return search_result;
   }
   return INVALID_INDEX_OID;

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -335,7 +335,7 @@ bool DatabaseCatalog::CreateTableEntry(const common::ManagedPointer<transaction:
                                        const table_oid_t table_oid, const namespace_oid_t ns_oid,
                                        const std::string &name, const Schema &schema) {
   if (pg_core_.CreateTableEntry(txn, table_oid, ns_oid, name, schema)) {
-    CreateTableStatisticEntry(txn, table_oid, schema);
+    CreateTableStatisticEntry(txn, table_oid, GetSchema(txn, table_oid));
     return true;
   }
   return false;

--- a/src/catalog/postgres/pg_constraint_impl.cpp
+++ b/src/catalog/postgres/pg_constraint_impl.cpp
@@ -52,7 +52,7 @@ std::function<void(void)> PgConstraintImpl::GetTearDownFn(common::ManagedPointer
   while (table_iter != constraints_->end()) {
     constraints_->Scan(txn, &table_iter, pc);
 
-    for (uint i = 0; i < pc->NumTuples(); i++) {
+    for (uint32_t i = 0; i < pc->NumTuples(); i++) {
       expressions.emplace_back(exprs[i]);
     }
   }

--- a/src/catalog/postgres/pg_language_impl.cpp
+++ b/src/catalog/postgres/pg_language_impl.cpp
@@ -56,8 +56,8 @@ bool PgLanguageImpl::CreateLanguage(const common::ManagedPointer<transaction::Tr
   const auto tuple_slot = languages_->Insert(txn, redo);
 
   // Allocate enough space for the largest PRI.
-  auto name_pri = languages_name_index_->GetProjectedRowInitializer();
-  auto oid_pri = languages_oid_index_->GetProjectedRowInitializer();
+  const auto &name_pri = languages_name_index_->GetProjectedRowInitializer();
+  const auto &oid_pri = languages_oid_index_->GetProjectedRowInitializer();
   NOISEPAGE_ASSERT(name_pri.ProjectedRowSize() >= oid_pri.ProjectedRowSize(), "PRI too small.");
   byte *const buffer = common::AllocationUtil::AllocateAligned(name_pri.ProjectedRowSize());
 
@@ -87,7 +87,7 @@ bool PgLanguageImpl::CreateLanguage(const common::ManagedPointer<transaction::Tr
 
 language_oid_t PgLanguageImpl::GetLanguageOid(const common::ManagedPointer<transaction::TransactionContext> txn,
                                               const std::string &lanname) {
-  auto name_pri = languages_name_index_->GetProjectedRowInitializer();
+  const auto &name_pri = languages_name_index_->GetProjectedRowInitializer();
   byte *const buffer = common::AllocationUtil::AllocateAligned(pg_language_all_cols_pri_.ProjectedRowSize());
 
   auto name_pr = name_pri.InitializeRow(buffer);
@@ -121,8 +121,8 @@ language_oid_t PgLanguageImpl::GetLanguageOid(const common::ManagedPointer<trans
 bool PgLanguageImpl::DropLanguage(const common::ManagedPointer<transaction::TransactionContext> txn,
                                   language_oid_t oid) {
   NOISEPAGE_ASSERT(oid != INVALID_LANGUAGE_OID, "Invalid oid passed in to DropLanguage.");
-  auto name_pri = languages_name_index_->GetProjectedRowInitializer();
-  auto oid_pri = languages_oid_index_->GetProjectedRowInitializer();
+  const auto &name_pri = languages_name_index_->GetProjectedRowInitializer();
+  const auto &oid_pri = languages_oid_index_->GetProjectedRowInitializer();
 
   byte *const buffer = common::AllocationUtil::AllocateAligned(pg_language_all_cols_pri_.ProjectedRowSize());
   auto index_pr = oid_pri.InitializeRow(buffer);

--- a/src/catalog/postgres/pg_proc_impl.cpp
+++ b/src/catalog/postgres/pg_proc_impl.cpp
@@ -57,7 +57,7 @@ std::function<void(void)> PgProcImpl::GetTearDownFn(common::ManagedPointer<trans
   while (table_iter != procs_->end()) {
     procs_->Scan(txn, &table_iter, pc);
 
-    for (uint i = 0; i < pc->NumTuples(); i++) {
+    for (uint32_t i = 0; i < pc->NumTuples(); i++) {
       if (ctxs[i] == nullptr) {
         continue;
       }
@@ -132,8 +132,8 @@ bool PgProcImpl::CreateProcedure(const common::ManagedPointer<transaction::Trans
 
   const auto tuple_slot = procs_->Insert(txn, redo);
 
-  auto oid_pri = procs_oid_index_->GetProjectedRowInitializer();
-  auto name_pri = procs_name_index_->GetProjectedRowInitializer();
+  const auto &oid_pri = procs_oid_index_->GetProjectedRowInitializer();
+  const auto &name_pri = procs_name_index_->GetProjectedRowInitializer();
   byte *const buffer = common::AllocationUtil::AllocateAligned(name_pri.ProjectedRowSize());
 
   // Insert into pg_proc_name_index.
@@ -164,8 +164,8 @@ bool PgProcImpl::CreateProcedure(const common::ManagedPointer<transaction::Trans
 bool PgProcImpl::DropProcedure(const common::ManagedPointer<transaction::TransactionContext> txn, proc_oid_t proc) {
   NOISEPAGE_ASSERT(proc != INVALID_PROC_OID, "Invalid oid passed");
 
-  auto name_pri = procs_name_index_->GetProjectedRowInitializer();
-  auto oid_pri = procs_oid_index_->GetProjectedRowInitializer();
+  const auto &name_pri = procs_name_index_->GetProjectedRowInitializer();
+  const auto &oid_pri = procs_oid_index_->GetProjectedRowInitializer();
   byte *const buffer = common::AllocationUtil::AllocateAligned(pg_proc_all_cols_pri_.ProjectedRowSize());
 
   auto oid_pr = oid_pri.InitializeRow(buffer);
@@ -230,7 +230,7 @@ bool PgProcImpl::DropProcedure(const common::ManagedPointer<transaction::Transac
 
 bool PgProcImpl::SetProcCtxPtr(common::ManagedPointer<transaction::TransactionContext> txn, const proc_oid_t proc_oid,
                                const execution::functions::FunctionContext *func_context) {
-  auto oid_pri = procs_oid_index_->GetProjectedRowInitializer();
+  const auto &oid_pri = procs_oid_index_->GetProjectedRowInitializer();
   auto *const index_buffer = common::AllocationUtil::AllocateAligned(oid_pri.ProjectedRowSize());
 
   // Look for the procedure in pg_proc_oid_index.
@@ -257,7 +257,7 @@ bool PgProcImpl::SetProcCtxPtr(common::ManagedPointer<transaction::TransactionCo
 
 common::ManagedPointer<execution::functions::FunctionContext> PgProcImpl::GetProcCtxPtr(
     common::ManagedPointer<transaction::TransactionContext> txn, proc_oid_t proc_oid) {
-  auto oid_pri = procs_oid_index_->GetProjectedRowInitializer();
+  const auto &oid_pri = procs_oid_index_->GetProjectedRowInitializer();
   auto *const buffer = common::AllocationUtil::AllocateAligned(pg_proc_ptr_pri_.ProjectedRowSize());
 
   // Look for the procedure in pg_proc_oid_index.
@@ -289,7 +289,7 @@ common::ManagedPointer<execution::functions::FunctionContext> PgProcImpl::GetPro
 proc_oid_t PgProcImpl::GetProcOid(const common::ManagedPointer<transaction::TransactionContext> txn,
                                   const common::ManagedPointer<DatabaseCatalog> dbc, const namespace_oid_t procns,
                                   const std::string &procname, const std::vector<type_oid_t> &arg_types) {
-  auto name_pri = procs_name_index_->GetProjectedRowInitializer();
+  const auto &name_pri = procs_name_index_->GetProjectedRowInitializer();
   byte *const buffer = common::AllocationUtil::AllocateAligned(pg_proc_all_cols_pri_.ProjectedRowSize());
 
   // Look for the procedure in pg_proc_name_index.

--- a/src/catalog/postgres/pg_statistic_impl.cpp
+++ b/src/catalog/postgres/pg_statistic_impl.cpp
@@ -49,15 +49,15 @@ void PgStatisticImpl::CreateColumnStatistic(const common::ManagedPointer<transac
   }
   const auto tuple_slot = statistics_->Insert(txn, redo);
 
-  const auto oid_pri = statistic_oid_index_->GetProjectedRowInitializer();
-  auto oid_prm = statistic_oid_index_->GetKeyOidToOffsetMap();
+  const auto &oid_pri = statistic_oid_index_->GetProjectedRowInitializer();
+  const auto &oid_prm = statistic_oid_index_->GetKeyOidToOffsetMap();
   byte *const buffer = common::AllocationUtil::AllocateAligned(oid_pri.ProjectedRowSize());
 
   // Insert into pg_statistic_index.
   {
     auto *pr = oid_pri.InitializeRow(buffer);
-    pr->Set<table_oid_t, false>(oid_prm[indexkeycol_oid_t(1)], table_oid, false);
-    pr->Set<col_oid_t, false>(oid_prm[indexkeycol_oid_t(2)], col_oid, false);
+    pr->Set<table_oid_t, false>(oid_prm.at(indexkeycol_oid_t(1)), table_oid, false);
+    pr->Set<col_oid_t, false>(oid_prm.at(indexkeycol_oid_t(2)), col_oid, false);
 
     bool UNUSED_ATTRIBUTE result = statistic_oid_index_->InsertUnique(txn, *pr, tuple_slot);
     NOISEPAGE_ASSERT(result, "Assigned pg_statistic OIDs failed to be unique.");

--- a/src/include/catalog/database_catalog.h
+++ b/src/include/catalog/database_catalog.h
@@ -288,6 +288,10 @@ class DatabaseCatalog {
                         table_oid_t table_oid, index_oid_t index_oid, const std::string &name,
                         const IndexSchema &schema);
 
+  /**
+   * @brief Creates table statistics in pg_statistic. Should only be called on valid tables, currently only called by
+   * CreateTableEntry after known to succeed.
+   */
   void CreateTableStatisticEntry(common::ManagedPointer<transaction::TransactionContext> txn, table_oid_t table_oid,
                                  const Schema &schema);
   /**

--- a/src/include/catalog/database_catalog.h
+++ b/src/include/catalog/database_catalog.h
@@ -287,6 +287,9 @@ class DatabaseCatalog {
   bool CreateIndexEntry(common::ManagedPointer<transaction::TransactionContext> txn, namespace_oid_t ns_oid,
                         table_oid_t table_oid, index_oid_t index_oid, const std::string &name,
                         const IndexSchema &schema);
+
+  void CreateTableStatisticEntry(common::ManagedPointer<transaction::TransactionContext> txn, table_oid_t table_oid,
+                                 const Schema &schema);
   /**
    * @brief Delete all of the indexes for a given table.
    *

--- a/src/include/catalog/index_schema.h
+++ b/src/include/catalog/index_schema.h
@@ -299,7 +299,7 @@ class IndexSchema {
    * @throw std::out_of_range if the column doesn't exist.
    */
   const Column &GetColumn(const std::string &name) const {
-    for (auto &c : columns_) {
+    for (const auto &c : columns_) {
       if (c.Name() == name) {
         return c;
       }
@@ -375,7 +375,7 @@ class IndexSchema {
     std::deque<common::ManagedPointer<const parser::AbstractExpression>> expr_queue;
 
     // Traverse expression tree for each index key
-    for (auto &col : GetColumns()) {
+    for (const auto &col : GetColumns()) {
       NOISEPAGE_ASSERT(col.StoredExpression() != nullptr, "Index column expr should not be missing");
       // Add root of expression of tree for the column
       expr_queue.push_back(col.StoredExpression());


### PR DESCRIPTION
The only real logic change is that we were dumping columns for a new table into `pg_statistic` before we validated that creating the new table would even succeed. We should try to be more defensive in the catalog and not assume that operations will succeed.

Otherwise I just did my usual style nit fixes, trying to to focus on `const &` where we're currently doing deep copies on STL data structures that aren't changed in the local scope. I wish clang-tidy would yell at us about that.