### PR TITLE
Switch Replication Messages to Message Pack

### DIFF
--- a/src/include/replication/replication_messages.h
+++ b/src/include/replication/replication_messages.h
@@ -66,23 +66,6 @@ class MessageWrapper {
   T Get(const char *key) const;
 
   /**
-   * Deserializes a given input to a string using the CBOR (Concise Binary Object Representation) serialization
-   * format.
-   *
-   * @param cbor cbor input
-   * @return parsed string
-   *
-   */
-  static std::string FromCbor(const std::vector<uint8_t> &cbor);
-
-  /**
-   * Serializes a given input string to CBOR format
-   * @param str string to serialize
-   * @return CBOR format of string
-   */
-  static std::vector<uint8_t> ToCbor(std::string_view str);
-
-  /**
    * Serialize the message
    *
    * @return serialized version of message


### PR DESCRIPTION
## Description
This PR switches our message serialization implementation for replication from JSON to Message Pack.

See #1570 for more details

## Performance
### Current TPCC numbers
(Scale factor 1, 8 threads)

| Replication | Durability | Reqs per second |
|-----------	|-------------- |-----------------------	|
| Sync | Sync | 13.19878036 |
| Async | Sync  | 96.29715975 |
| Async | Async | 225.1782607 |
| Disabled | Sync | 208.8917964 |
| Disabled | Async | 259.5795886 |

### Updated TPCC numbers with Message Pack
(Scale factor 1, 8 threads)

| Replication | Durability | Reqs per second |
|-----------	|--------------	|-----------------------	|
| Sync | Sync | 16.099501826675176 |
| Async | Sync  | 230.38818864265522 |
| Async | Async | 223.0805671394837 |