### PR TITLE
Add explicit `u` suffix to initialize TrafficCopResult for EXPLAIN.

### DIFF
--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -364,7 +364,7 @@ TrafficCopResult TrafficCop::ExecuteExplainStatement(
   out->WriteDataRow(reinterpret_cast<const byte *const>(&plan_string_val), output_columns,
                     {network::FieldFormat::text});
 
-  return {ResultType::COMPLETE, static_cast<uint32_t>(0)};
+  return {ResultType::COMPLETE, 0u};
 }
 
 std::variant<std::unique_ptr<parser::ParseResult>, common::ErrorData> TrafficCop::ParseQuery(

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -364,7 +364,7 @@ TrafficCopResult TrafficCop::ExecuteExplainStatement(
   out->WriteDataRow(reinterpret_cast<const byte *const>(&plan_string_val), output_columns,
                     {network::FieldFormat::text});
 
-  return {ResultType::COMPLETE, 0};
+  return {ResultType::COMPLETE, static_cast<uint32_t>(0)};
 }
 
 std::variant<std::unique_ptr<parser::ParseResult>, common::ErrorData> TrafficCop::ParseQuery(


### PR DESCRIPTION
# Heading

Add explicit cast to initialize TrafficCopResult for EXPLAIN.

## Description

Had to add this to make my compiler happy in Release mode.

`-- Compiler: /usr/bin/clang++-8 Clang 8.0.1`

Explicitly cast a 0 as unsigned to help some compilers along.