### PR TITLE
Small fix to compile on Mac (note that we do not support Mac builds).

### DIFF
--- a/src/optimizer/statistics/selectivity_util.cpp
+++ b/src/optimizer/statistics/selectivity_util.cpp
@@ -136,7 +136,7 @@ double SelectivityUtil::Equal(common::ManagedPointer<ColumnStats<T>> column_stat
   auto value_frequency_estimate = top_k->EstimateItemCount(value);
 
   // If all values are distinct, then there can be at most one value equal to the specified value
-  if (column_stats->GetDistinctValues() == numrows) value_frequency_estimate = std::min(value_frequency_estimate, 1lu);
+  if (column_stats->GetDistinctValues() == numrows) value_frequency_estimate = std::min<unsigned long long int>(value_frequency_estimate, 1lu);
 
   double res = value_frequency_estimate / static_cast<double>(numrows);
 

--- a/src/optimizer/statistics/selectivity_util.cpp
+++ b/src/optimizer/statistics/selectivity_util.cpp
@@ -136,7 +136,7 @@ double SelectivityUtil::Equal(common::ManagedPointer<ColumnStats<T>> column_stat
   auto value_frequency_estimate = top_k->EstimateItemCount(value);
 
   // If all values are distinct, then there can be at most one value equal to the specified value
-  if (column_stats->GetDistinctValues() == numrows) value_frequency_estimate = std::min<unsigned long long int>(value_frequency_estimate, 1lu);
+  if (column_stats->GetDistinctValues() == numrows) value_frequency_estimate = std::min<uint64_t>(value_frequency_estimate, 1lu);
 
   double res = value_frequency_estimate / static_cast<double>(numrows);
 

--- a/src/optimizer/statistics/selectivity_util.cpp
+++ b/src/optimizer/statistics/selectivity_util.cpp
@@ -136,7 +136,8 @@ double SelectivityUtil::Equal(common::ManagedPointer<ColumnStats<T>> column_stat
   auto value_frequency_estimate = top_k->EstimateItemCount(value);
 
   // If all values are distinct, then there can be at most one value equal to the specified value
-  if (column_stats->GetDistinctValues() == numrows) value_frequency_estimate = std::min<uint64_t>(value_frequency_estimate, 1lu);
+  if (column_stats->GetDistinctValues() == numrows)
+    value_frequency_estimate = std::min<uint64_t>(value_frequency_estimate, 1lu);
 
   double res = value_frequency_estimate / static_cast<double>(numrows);
 


### PR DESCRIPTION
# Small Stats Optimizer Bug

## Description

There's a small bug in the stats optimizer that causes my build to not work locally--fixed by adding template to std::min. (putting in separate pull request for modularity's sake).

### Remaining Tasks

None.

## Performance

None.

## Further Work

None.