### PR TITLE
Support training models from psql SET commands

### DIFF
--- a/src/include/self_driving/planning/pilot.h
+++ b/src/include/self_driving/planning/pilot.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <mutex>  // NOLINT
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -136,7 +137,10 @@ class Pilot {
   /**
    * Performs training of the forecasting model
    */
-  void PerformForecasterTrain() { forecaster_.PerformTraining(); }
+  void PerformForecasterTrain() {
+    std::unique_lock<std::mutex> lock(forecaster_train_mutex_);
+    forecaster_.PerformTraining();
+  }
 
  private:
   /**
@@ -176,6 +180,7 @@ class Pilot {
   Forecaster forecaster_;
   uint64_t action_planning_horizon_{15};
   uint64_t simulation_number_{20};
+  std::mutex forecaster_train_mutex_;
   friend class noisepage::selfdriving::PilotUtil;
   friend class noisepage::selfdriving::pilot::MonteCarloTreeSearch;
 };

--- a/src/include/settings/settings_callbacks.h
+++ b/src/include/settings/settings_callbacks.h
@@ -227,5 +227,35 @@ class Callbacks {
    */
   static void PilotEnablePlanning(void *old_value, void *new_value, DBMain *db_main,
                                   common::ManagedPointer<common::ActionContext> action_context);
+
+  /**
+   * Train the forecast model
+   * @param old_value old settings value (not relevant)
+   * @param new_value new settings value (not relevant)
+   * @param db_main pointer to db_main
+   * @param action_context pointer to the action context for this settings change
+   */
+  static void TrainForecastModel(void *old_value, void *new_value, DBMain *db_main,
+                                 common::ManagedPointer<common::ActionContext> action_context);
+
+  /**
+   * Train the interference model
+   * @param old_value old settings value (not relevant)
+   * @param new_value new settings value (not relevant)
+   * @param db_main pointer to db_main
+   * @param action_context pointer to the action context for this settings change
+   */
+  static void TrainInterferenceModel(void *old_value, void *new_value, DBMain *db_main,
+                                     common::ManagedPointer<common::ActionContext> action_context);
+
+  /**
+   * Train the OU model
+   * @param old_value old settings value (not relevant)
+   * @param new_value new settings value (not relevant)
+   * @param db_main pointer to db_main
+   * @param action_context pointer to the action context for this settings change
+   */
+  static void TrainOUModel(void *old_value, void *new_value, DBMain *db_main,
+                           common::ManagedPointer<common::ActionContext> action_context);
 };
 }  // namespace noisepage::settings

--- a/src/include/settings/settings_defs.h
+++ b/src/include/settings/settings_defs.h
@@ -560,4 +560,91 @@ SETTING_string(
     false,
     noisepage::settings::Callbacks::NoOp
 )
+
+SETTING_bool(
+    train_forecast_model,
+    "Train the forecast model (the value is not relevant).",
+    false,
+    true,
+    noisepage::settings::Callbacks::TrainForecastModel
+)
+
+SETTING_bool(
+    train_interference_model,
+    "Train the interference model (the value is not relevant).",
+    false,
+    true,
+    noisepage::settings::Callbacks::TrainInterferenceModel
+)
+
+SETTING_string(
+    interference_model_input_path,
+    "Input path to the directory containing training the interference model",
+    "concurrent_runner_input/",
+    true,
+    noisepage::settings::Callbacks::NoOp
+)
+
+SETTING_string(
+    interference_model_train_methods,
+    "Methods to be used for training the interference model (comma delimited)",
+    "rf",
+    true,
+    noisepage::settings::Callbacks::NoOp
+)
+
+SETTING_int(
+    interference_model_train_timeout,
+    "Timeout in milliseconds for training the interference model (default: 2 minutes)",
+    120000,
+    1000,
+    600000,
+    true,
+    noisepage::settings::Callbacks::NoOp
+)
+
+SETTING_int(
+    interference_model_pipeline_sample_rate,
+    "Sampling rate of pipeline metrics OUs (0 is ignored)",
+    2,
+    0,
+    10,
+    true,
+    noisepage::settings::Callbacks::NoOp
+)
+
+SETTING_bool(
+    train_ou_model,
+    "Train the OU model (the value is not relevant).",
+    false,
+    true,
+    noisepage::settings::Callbacks::TrainOUModel
+)
+
+SETTING_string(
+    ou_model_input_path,
+    "Input path to the directory containing training the OU model",
+    "ou_runner_input/",
+    true,
+    noisepage::settings::Callbacks::NoOp
+)
+
+SETTING_string(
+    ou_model_train_methods,
+    "Methods to be used for training the OU model (comma delimited)",
+    "lr,rf,gbm,nn",
+    true,
+    noisepage::settings::Callbacks::NoOp
+)
+
+SETTING_int(
+    ou_model_train_timeout,
+    "Timeout in milliseconds for training the OU model (default: 2 minutes)",
+    120000,
+    1000,
+    600000,
+    true,
+    noisepage::settings::Callbacks::NoOp
+)
+
     // clang-format on

--- a/src/include/settings/settings_manager.h
+++ b/src/include/settings/settings_manager.h
@@ -18,6 +18,8 @@ class ConstantValueExpression;
 }
 
 namespace noisepage::settings {
+class Callbacks;
+
 using setter_callback_fn = void (*)(common::ManagedPointer<common::ActionContext> action_context);
 
 /**
@@ -173,6 +175,8 @@ class SettingsManager {
                                      common::ManagedPointer<common::ActionContext> action_context);
 
   static void EmptySetterCallback(common::ManagedPointer<common::ActionContext> action_context UNUSED_ATTRIBUTE) {}
+
+  friend class Callbacks;
 };
 
 }  // namespace noisepage::settings


### PR DESCRIPTION
## Description
PR adds support to perform the training of the OU model, the interference model, and the forecast model over psql by exposing three dedicated `train_X_model` knobs that can be triggered with the `SET` command.

The following additional settings are introduced (although some could possibly be coalesced) that can also be altered over psql via the `SET` command to adjust the training of the models:
- `interference_model_input_path`: input path to directory for data to train interference model with
- `interference_model_train_methods`: comma-delimited methods to use for training interference model (i.e., "rf")
- `interference_model_train_timeout`: timeout for training the interference model
- `interference_model_pipeline_sample_rate`: sampling rate of pipeline metric OUs for interference model
- `ou_model_input_path`: input path for directory to data for training OU model
- `ou_model_train_methods`: comma-delimited methods to use to train OU model (i.e., "lr,rf")
- `ou_model_train_timeout`: timeout for training the OU model
