### PR TITLE
EXPLAIN (FORMAT TPL) and EXPLAIN (FORMAT TBC).

### DIFF
--- a/src/include/parser/explain_statement.h
+++ b/src/include/parser/explain_statement.h
@@ -7,6 +7,8 @@
 
 namespace noisepage::parser {
 
+enum class ExplainStatementFormat : uint8_t { JSON, TPL };
+
 /**
  * Represents the SQL "EXPLAIN ..."
  */
@@ -20,11 +22,19 @@ class ExplainStatement : public SQLStatement {
 
   void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) override { v->Visit(common::ManagedPointer(this)); }
 
+  /** @brief override the default format of this EXPLAIN statement */
+  void SetFormat(const ExplainStatementFormat format) { format_ = format; }
+
   /** @return the SQL statement to be explained */
-  common::ManagedPointer<SQLStatement> GetSQLStatement() { return common::ManagedPointer(real_sql_stmt_); }
+  common::ManagedPointer<SQLStatement> GetSQLStatement() const { return common::ManagedPointer(real_sql_stmt_); }
+
+  /** @return format of the EXPLAIN */
+  ExplainStatementFormat GetFormat() const { return format_; }
 
  private:
   std::unique_ptr<SQLStatement> real_sql_stmt_;
+  ExplainStatementFormat format_ = ExplainStatementFormat::JSON;  // default to JSON since we rely on serializing the
+                                                                  // physical plan via dumping to JSON
 };
 
 }  // namespace noisepage::parser

--- a/src/include/traffic_cop/traffic_cop.h
+++ b/src/include/traffic_cop/traffic_cop.h
@@ -229,6 +229,7 @@ class TrafficCop {
    */
   TrafficCopResult ExecuteExplainStatement(common::ManagedPointer<network::ConnectionContext> connection_ctx,
                                            common::ManagedPointer<network::PostgresPacketWriter> out,
+                                           common::ManagedPointer<network::Statement> statement,
                                            common::ManagedPointer<planner::AbstractPlanNode> physical_plan) const;
 
   /**

--- a/src/network/postgres/postgres_network_commands.cpp
+++ b/src/network/postgres/postgres_network_commands.cpp
@@ -46,7 +46,10 @@ static void ExecutePortal(const common::ManagedPointer<network::ConnectionContex
     }
     if (query_type == network::QueryType::QUERY_CREATE_INDEX) {
       result = t_cop->ExecuteCreateStatement(connection_ctx, physical_plan, query_type);
+      NOISEPAGE_ASSERT(result.type_ == trafficcop::ResultType::COMPLETE,
+                       "Got through the binder as a valid index name, so we don't expect this to fail.");
       result = t_cop->CodegenPhysicalPlan(connection_ctx, out, portal);
+      // TODO(Matt): do something with result here in case codegen fails
       result = t_cop->RunExecutableQuery(connection_ctx, out, portal);
     } else {
       result = t_cop->ExecuteCreateStatement(connection_ctx, physical_plan, query_type);
@@ -60,7 +63,7 @@ static void ExecutePortal(const common::ManagedPointer<network::ConnectionContex
     }
     result = t_cop->ExecuteDropStatement(connection_ctx, physical_plan, query_type);
   } else if (query_type == network::QueryType::QUERY_EXPLAIN) {
-    result = t_cop->ExecuteExplainStatement(connection_ctx, out, physical_plan);
+    result = t_cop->ExecuteExplainStatement(connection_ctx, out, portal->GetStatement(), physical_plan);
   }
 
   if (result.type_ == trafficcop::ResultType::COMPLETE) {

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1874,9 +1874,33 @@ std::vector<common::ManagedPointer<AbstractExpression>> PostgresParser::ParamLis
 }
 
 std::unique_ptr<ExplainStatement> PostgresParser::ExplainTransform(ParseResult *parse_result, ExplainStmt *root) {
+  static constexpr char k_format_tok[] = "format";
   std::unique_ptr<ExplainStatement> result;
   auto query = NodeTransform(parse_result, root->query_);
   result = std::make_unique<ExplainStatement>(std::move(query));
+
+  if (root->options_ != nullptr) {
+    for (ListCell *cell = root->options_->head; cell != nullptr; cell = cell->next) {
+      NOISEPAGE_ASSERT(reinterpret_cast<Node *>(cell->data.ptr_value)->type == T_DefElem, "Expect a DefElem.");
+      const auto *const def_elem UNUSED_ATTRIBUTE = reinterpret_cast<DefElem *>(cell->data.ptr_value);
+
+      if (strncmp(def_elem->defname_, k_format_tok, sizeof(k_format_tok)) == 0) {
+        const auto *const format_cstr = reinterpret_cast<value *>(def_elem->arg_)->val_.str_;
+        // lowercase
+        if (strncmp(format_cstr, "tpl", 3) == 0) {
+          result->SetFormat(ExplainStatementFormat::TPL);
+        } else if (strncmp(format_cstr, "json", 4) == 0) {
+          // this is the default format for us anyway so it's a noop
+          NOISEPAGE_ASSERT(result->GetFormat() == ExplainStatementFormat::JSON,
+                           "We assume this is the default format.");
+        } else {
+          throw ParserException("Unsupported format string for EXPLAIN.", __FILE__, __LINE__, def_elem->location_);
+        }
+      } else {
+        throw ParserException("Unsupported option string for EXPLAIN.", __FILE__, __LINE__, def_elem->location_);
+      }
+    }
+  }
   return result;
 }
 


### PR DESCRIPTION
This PR adds support for `explain (format tpl) select * from foo;` and `explain (format tbc) select * from foo;`.

---

This branch has the front-end work (`PostgresParser`, `TrafficCop`, `ExplainStatement`, etc.) for `EXPLAIN (FORMAT TPL) ...` to get TPL of queries back via SQL. However, it still remains unclear how to accomplish the back-end work. `AstPrettyPrint` works on an AST, but that's ephemeral and discarded after compilation. Saving that with the `ExecutableQuery` every time seems wasteful (and maybe incorrect, not sure of the AST's memory life cycle). Instead we could build the string in the compilation phase, but then the question becomes how do we return it back? Is there an empty string in every `CompilationContext` that can optionally retain the TPL AST that's been pretty-printed to it? Maybe -- is there something more general purpose to store artifacts of compilation (@turingcompl33t might want this?). For now I'm opening this PR to document discussion before we figure out a path forward.