### PR TITLE
Backend for EXPLAIN (FORMAT TPL) queries.

### DIFF
--- a/src/execution/compiler/compilation_context.cpp
+++ b/src/execution/compiler/compilation_context.cpp
@@ -121,7 +121,8 @@ ast::FunctionDecl *CompilationContext::GenerateTearDownFunction() {
 }
 
 void CompilationContext::GeneratePlan(const planner::AbstractPlanNode &plan,
-                                      common::ManagedPointer<planner::PlanMetaData> plan_meta_data) {
+                                      common::ManagedPointer<planner::PlanMetaData> plan_meta_data,
+                                      const execution::compiler::CompilerSettings &settings) {
   exec_ctx_ =
       query_state_.DeclareStateEntry(GetCodeGen(), "execCtx", codegen_.PointerType(ast::BuiltinType::ExecutionContext));
 
@@ -186,7 +187,7 @@ void CompilationContext::GeneratePlan(const planner::AbstractPlanNode &plan,
   main_builder.AddTeardownFn(teardown);
 
   // Compile and finish.
-  fragments.emplace_back(main_builder.Compile());
+  fragments.emplace_back(main_builder.Compile(settings));
   query_->Setup(std::move(fragments), query_state_.GetSize(), codegen_.ReleasePipelineOperatingUnits());
 }
 
@@ -203,7 +204,7 @@ std::unique_ptr<ExecutableQuery> CompilationContext::Compile(
 
   // Generate the plan for the query
   CompilationContext ctx(query.get(), query->GetQueryId(), accessor, mode, exec_settings);
-  ctx.GeneratePlan(plan, plan_meta_data);
+  ctx.GeneratePlan(plan, plan_meta_data, exec_settings.GetCompilerSettings());
 
   // Done
   return query;

--- a/src/execution/compiler/compilation_context.cpp
+++ b/src/execution/compiler/compilation_context.cpp
@@ -121,8 +121,7 @@ ast::FunctionDecl *CompilationContext::GenerateTearDownFunction() {
 }
 
 void CompilationContext::GeneratePlan(const planner::AbstractPlanNode &plan,
-                                      common::ManagedPointer<planner::PlanMetaData> plan_meta_data,
-                                      const execution::compiler::CompilerSettings &settings) {
+                                      common::ManagedPointer<planner::PlanMetaData> plan_meta_data) {
   exec_ctx_ =
       query_state_.DeclareStateEntry(GetCodeGen(), "execCtx", codegen_.PointerType(ast::BuiltinType::ExecutionContext));
 
@@ -187,7 +186,7 @@ void CompilationContext::GeneratePlan(const planner::AbstractPlanNode &plan,
   main_builder.AddTeardownFn(teardown);
 
   // Compile and finish.
-  fragments.emplace_back(main_builder.Compile(settings));
+  fragments.emplace_back(main_builder.Compile(query_->GetExecutionSettings().GetCompilerSettings()));
   query_->Setup(std::move(fragments), query_state_.GetSize(), codegen_.ReleasePipelineOperatingUnits());
 }
 
@@ -204,7 +203,7 @@ std::unique_ptr<ExecutableQuery> CompilationContext::Compile(
 
   // Generate the plan for the query
   CompilationContext ctx(query.get(), query->GetQueryId(), accessor, mode, exec_settings);
-  ctx.GeneratePlan(plan, plan_meta_data, exec_settings.GetCompilerSettings());
+  ctx.GeneratePlan(plan, plan_meta_data);
 
   // Done
   return query;

--- a/src/execution/compiler/compiler.cpp
+++ b/src/execution/compiler/compiler.cpp
@@ -22,10 +22,10 @@ namespace noisepage::execution::compiler {
 //===----------------------------------------------------------------------===//
 
 Compiler::Input::Input(std::string name, ast::Context *context, const std::string *source,
-                       const CompilerSettings &settings)
+                       const CompilerSettings settings)
     : name_(std::move(name)), context_(context), root_(nullptr), source_(source), settings_(settings) {}
 
-Compiler::Input::Input(std::string name, ast::Context *context, ast::AstNode *root, const CompilerSettings &settings)
+Compiler::Input::Input(std::string name, ast::Context *context, ast::AstNode *root, const CompilerSettings settings)
     : name_(std::move(name)), context_(context), root_(root), source_(nullptr), settings_(settings) {}
 
 //===----------------------------------------------------------------------===//

--- a/src/execution/compiler/compiler.cpp
+++ b/src/execution/compiler/compiler.cpp
@@ -1,13 +1,17 @@
 #include "execution/compiler/compiler.h"
 
+#include <sstream>
+
 #include "execution/ast/ast_pretty_print.h"
 #include "execution/ast/context.h"
+#include "execution/compiler/compiler_settings.h"
 #include "execution/parsing/parser.h"
 #include "execution/parsing/scanner.h"
 #include "execution/sema/error_reporter.h"
 #include "execution/sema/sema.h"
 #include "execution/vm/bytecode_generator.h"
 #include "execution/vm/module.h"
+#include "execution/vm/module_metadata.h"
 
 namespace noisepage::execution::compiler {
 
@@ -17,11 +21,12 @@ namespace noisepage::execution::compiler {
 //
 //===----------------------------------------------------------------------===//
 
-Compiler::Input::Input(std::string name, ast::Context *context, const std::string *source)
-    : name_(std::move(name)), context_(context), root_(nullptr), source_(source) {}
+Compiler::Input::Input(std::string name, ast::Context *context, const std::string *source,
+                       const CompilerSettings &settings)
+    : name_(std::move(name)), context_(context), root_(nullptr), source_(source), settings_(settings) {}
 
-Compiler::Input::Input(std::string name, ast::Context *context, ast::AstNode *root)
-    : name_(std::move(name)), context_(context), root_(root), source_(nullptr) {}
+Compiler::Input::Input(std::string name, ast::Context *context, ast::AstNode *root, const CompilerSettings &settings)
+    : name_(std::move(name)), context_(context), root_(root), source_(nullptr), settings_(settings) {}
 
 //===----------------------------------------------------------------------===//
 //
@@ -106,7 +111,24 @@ void Compiler::Run(Compiler::Callbacks *callbacks) {
     return;
   }
 
-  auto module = std::make_unique<vm::Module>(std::move(bytecode_module));
+  // Record any metadata necessary before the relevant data-structures are destroyed.
+  const auto &settings = input_.GetSettings();
+  vm::CompileTimeModuleMetadata metadata;
+  {
+    if (settings.ShouldCaptureTPL()) {
+      std::ostringstream stream;
+      ast::AstPrettyPrint::Dump(stream, root_);
+      metadata.SetTPL(stream.str());
+    }
+    if (settings.ShouldCaptureTBC()) {
+      std::ostringstream stream;
+      bytecode_module->Dump(stream);
+      metadata.SetTBC(stream.str());
+    }
+  }
+  vm::ModuleMetadata module_metadata(std::move(metadata));
+
+  auto module = std::make_unique<vm::Module>(std::move(bytecode_module), std::move(module_metadata));
 
   // Errors?
   if (GetErrorReporter()->HasErrors()) {

--- a/src/execution/compiler/executable_query.cpp
+++ b/src/execution/compiler/executable_query.cpp
@@ -55,6 +55,8 @@ void ExecutableQuery::Fragment::Run(byte query_state[], vm::ExecutionMode mode) 
   }
 }
 
+const vm::ModuleMetadata &ExecutableQuery::Fragment::GetModuleMetadata() const { return module_->GetMetadata(); }
+
 //===----------------------------------------------------------------------===//
 //
 // Executable Query
@@ -113,7 +115,7 @@ ExecutableQuery::ExecutableQuery(const std::string &contents,
     source = contents;
   }
 
-  auto input = Compiler::Input("tpl_source", ast_context_.get(), &source);
+  auto input = Compiler::Input("tpl_source", ast_context_.get(), &source, exec_settings.GetCompilerSettings());
   auto module = compiler::Compiler::RunCompilationSimple(input);
 
   std::vector<std::string> functions{"main"};

--- a/src/execution/compiler/executable_query_builder.cpp
+++ b/src/execution/compiler/executable_query_builder.cpp
@@ -42,7 +42,8 @@ class Callbacks : public compiler::Compiler::Callbacks {
 
 }  // namespace
 
-std::unique_ptr<ExecutableQuery::Fragment> ExecutableQueryFragmentBuilder::Compile() {
+std::unique_ptr<ExecutableQuery::Fragment> ExecutableQueryFragmentBuilder::Compile(
+    const execution::compiler::CompilerSettings &settings) {
   // Build up the declaration list for the file.
   util::RegionVector<ast::Decl *> decls(ctx_->GetRegion());
   decls.reserve(structs_.size() + functions_.size());
@@ -53,7 +54,7 @@ std::unique_ptr<ExecutableQuery::Fragment> ExecutableQueryFragmentBuilder::Compi
   ast::File *generated_file = ctx_->GetNodeFactory()->NewFile({0, 0}, std::move(decls));
 
   // Compile it!
-  compiler::Compiler::Input input("", ctx_, generated_file);
+  compiler::Compiler::Input input("", ctx_, generated_file, settings);
   Callbacks callbacks;
   compiler::TimePasses timer(&callbacks);
   compiler::Compiler::RunCompilation(input, &timer);

--- a/src/execution/vm/module.cpp
+++ b/src/execution/vm/module.cpp
@@ -40,13 +40,16 @@ class Module::AsyncCompileTask : public tbb::task {
 // Module
 // ---------------------------------------------------------
 
-Module::Module(std::unique_ptr<BytecodeModule> bytecode_module) : Module(std::move(bytecode_module), nullptr) {}
+Module::Module(std::unique_ptr<BytecodeModule> bytecode_module, ModuleMetadata &&metadata)
+    : Module(std::move(bytecode_module), nullptr, std::move(metadata)) {}
 
-Module::Module(std::unique_ptr<BytecodeModule> bytecode_module, std::unique_ptr<LLVMEngine::CompiledModule> llvm_module)
+Module::Module(std::unique_ptr<BytecodeModule> bytecode_module, std::unique_ptr<LLVMEngine::CompiledModule> llvm_module,
+               ModuleMetadata &&metadata)
     : bytecode_module_(std::move(bytecode_module)),
       jit_module_(std::move(llvm_module)),
       functions_(std::make_unique<std::atomic<void *>[]>(bytecode_module_->GetFunctionCount())),
-      bytecode_trampolines_(std::make_unique<Trampoline[]>(bytecode_module_->GetFunctionCount())) {
+      bytecode_trampolines_(std::make_unique<Trampoline[]>(bytecode_module_->GetFunctionCount())),
+      metadata_(std::move(metadata)) {
   // Create the trampolines for all bytecode functions
   for (const auto &func : bytecode_module_->GetFunctionsInfo()) {
     CreateFunctionTrampoline(func.GetId());

--- a/src/include/execution/compiler/compilation_context.h
+++ b/src/include/execution/compiler/compilation_context.h
@@ -10,6 +10,10 @@
 #include "execution/compiler/executable_query.h"
 #include "execution/compiler/pipeline.h"
 
+namespace noisepage::execution::compiler {
+class CompilerSettings;
+}  // namespace noisepage::execution::compiler
+
 namespace noisepage::parser {
 class AbstractExpression;
 }  // namespace noisepage::parser
@@ -135,8 +139,8 @@ class CompilationContext {
                               CompilationMode mode, const exec::ExecutionSettings &exec_settings);
 
   // Given a plan node, compile it into a compiled query object.
-  void GeneratePlan(const planner::AbstractPlanNode &plan,
-                    common::ManagedPointer<planner::PlanMetaData> plan_meta_data);
+  void GeneratePlan(const planner::AbstractPlanNode &plan, common::ManagedPointer<planner::PlanMetaData> plan_meta_data,
+                    const execution::compiler::CompilerSettings &settings);
 
   // Generate the query initialization function.
   ast::FunctionDecl *GenerateInitFunction();

--- a/src/include/execution/compiler/compilation_context.h
+++ b/src/include/execution/compiler/compilation_context.h
@@ -139,8 +139,8 @@ class CompilationContext {
                               CompilationMode mode, const exec::ExecutionSettings &exec_settings);
 
   // Given a plan node, compile it into a compiled query object.
-  void GeneratePlan(const planner::AbstractPlanNode &plan, common::ManagedPointer<planner::PlanMetaData> plan_meta_data,
-                    const execution::compiler::CompilerSettings &settings);
+  void GeneratePlan(const planner::AbstractPlanNode &plan,
+                    common::ManagedPointer<planner::PlanMetaData> plan_meta_data);
 
   // Generate the query initialization function.
   ast::FunctionDecl *GenerateInitFunction();

--- a/src/include/execution/compiler/compiler.h
+++ b/src/include/execution/compiler/compiler.h
@@ -31,6 +31,8 @@ class Module;
 
 namespace compiler {
 
+class CompilerSettings;
+
 /**
  * Primary interface to drive compilation of TPL programs into TPL modules. TPL modules support
  * hybrid interpreted and JIT execution modes.
@@ -62,8 +64,9 @@ class Compiler {
      * @param name The name to assign the input.
      * @param context The TPL context to use.
      * @param source The TPL source code.
+     * @param settings The settings to use when compiling the TPL.
      */
-    Input(std::string name, ast::Context *context, const std::string *source);
+    Input(std::string name, ast::Context *context, const std::string *source, const CompilerSettings &settings);
 
     /**
      * Construct input from a pre-generated TPL AST. The region that created the AST must also be
@@ -71,8 +74,9 @@ class Compiler {
      * @param name The name to assign the input.
      * @param context The TPL context the AST belongs to.
      * @param root The root of the AST.
+     * @param settings The settings to use when compiling the TPL.
      */
-    Input(std::string name, ast::Context *context, ast::AstNode *root);
+    Input(std::string name, ast::Context *context, ast::AstNode *root, const CompilerSettings &settings);
 
     /**
      * @return The name of the input.
@@ -94,6 +98,9 @@ class Compiler {
      */
     ast::Context *GetContext() const noexcept { return context_; }
 
+    /** @return The settings to be used when compiling the input. */
+    const CompilerSettings &GetSettings() const noexcept { return settings_; }
+
    private:
     // The name to assign the input
     const std::string name_;
@@ -103,6 +110,7 @@ class Compiler {
     ast::AstNode *root_;
     // The TPL source, if any
     const std::string *source_;
+    const CompilerSettings &settings_;  ///< The settings to be used when compiling the TPL input.
   };
 
   /**

--- a/src/include/execution/compiler/compiler.h
+++ b/src/include/execution/compiler/compiler.h
@@ -7,6 +7,7 @@
 
 #include "common/macros.h"
 #include "common/managed_pointer.h"
+#include "execution/compiler/compiler_settings.h"
 #include "execution/util/timer.h"
 
 namespace noisepage::execution {
@@ -66,7 +67,7 @@ class Compiler {
      * @param source The TPL source code.
      * @param settings The settings to use when compiling the TPL.
      */
-    Input(std::string name, ast::Context *context, const std::string *source, const CompilerSettings &settings);
+    Input(std::string name, ast::Context *context, const std::string *source, CompilerSettings settings);
 
     /**
      * Construct input from a pre-generated TPL AST. The region that created the AST must also be
@@ -76,7 +77,7 @@ class Compiler {
      * @param root The root of the AST.
      * @param settings The settings to use when compiling the TPL.
      */
-    Input(std::string name, ast::Context *context, ast::AstNode *root, const CompilerSettings &settings);
+    Input(std::string name, ast::Context *context, ast::AstNode *root, CompilerSettings settings);
 
     /**
      * @return The name of the input.
@@ -110,7 +111,7 @@ class Compiler {
     ast::AstNode *root_;
     // The TPL source, if any
     const std::string *source_;
-    const CompilerSettings &settings_;  ///< The settings to be used when compiling the TPL input.
+    const CompilerSettings settings_;  ///< The settings to be used when compiling the TPL input.
   };
 
   /**

--- a/src/include/execution/compiler/compiler_settings.h
+++ b/src/include/execution/compiler/compiler_settings.h
@@ -11,9 +11,9 @@ class CompilerSettings {
   void SetShouldCaptureTBC(bool should_capture_tbc) { should_capture_tbc_ = should_capture_tbc; }
 
   /** @return True if TPL should be captured. */
-  bool ShouldCaptureTPL() const noexcept { return should_capture_tpl_; }
+  [[nodiscard]] bool ShouldCaptureTPL() const noexcept { return should_capture_tpl_; }
   /** @return True if TBC should be captured. */
-  bool ShouldCaptureTBC() const noexcept { return should_capture_tbc_; }
+  [[nodiscard]] bool ShouldCaptureTBC() const noexcept { return should_capture_tbc_; }
 
  private:
   bool should_capture_tpl_{false};

--- a/src/include/execution/compiler/compiler_settings.h
+++ b/src/include/execution/compiler/compiler_settings.h
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace noisepage::execution::compiler {
+
+/** Settings to be applied when compiling the input. */
+class CompilerSettings {
+ public:
+  /** Set whether TPL should be captured during compilation. */
+  void SetShouldCaptureTPL(bool should_capture_tpl) { should_capture_tpl_ = should_capture_tpl; }
+  /** Set whether TBC should be captured during compilation. */
+  void SetShouldCaptureTBC(bool should_capture_tbc) { should_capture_tbc_ = should_capture_tbc; }
+
+  /** @return True if TPL should be captured. */
+  bool ShouldCaptureTPL() const noexcept { return should_capture_tpl_; }
+  /** @return True if TBC should be captured. */
+  bool ShouldCaptureTBC() const noexcept { return should_capture_tbc_; }
+
+ private:
+  bool should_capture_tpl_{false};
+  bool should_capture_tbc_{false};
+};
+
+}  // namespace noisepage::execution::compiler

--- a/src/include/execution/compiler/executable_query.h
+++ b/src/include/execution/compiler/executable_query.h
@@ -33,6 +33,7 @@ class Region;
 
 namespace vm {
 class Module;
+class ModuleMetadata;
 }  // namespace vm
 }  // namespace execution
 
@@ -88,6 +89,9 @@ class ExecutableQuery {
      * @return True if this fragment is compiled and executable.
      */
     bool IsCompiled() const { return module_ != nullptr; }
+
+    /** @return The metadata of this module. */
+    const vm::ModuleMetadata &GetModuleMetadata() const;
 
    private:
     // The functions that must be run (in the provided order) to execute this
@@ -156,6 +160,9 @@ class ExecutableQuery {
 
   /** @return The Query Identifier */
   query_id_t GetQueryId() { return query_id_; }
+
+  /** @return The query fragments in this module. */
+  const std::vector<std::unique_ptr<Fragment>> &GetFragments() const { return fragments_; }
 
  private:
   // The plan.

--- a/src/include/execution/compiler/executable_query_builder.h
+++ b/src/include/execution/compiler/executable_query_builder.h
@@ -17,6 +17,8 @@ class Module;
 
 namespace noisepage::execution::compiler {
 
+class CompilerSettings;
+
 /**
  * A container for code in a single TPL file.
  */
@@ -76,9 +78,10 @@ class ExecutableQueryFragmentBuilder {
 
   /**
    * Compile the code in the container.
+   * @param settings The settings to use to compile the code.
    * @return True if the compilation was successful; false otherwise.
    */
-  std::unique_ptr<ExecutableQuery::Fragment> Compile();
+  std::unique_ptr<ExecutableQuery::Fragment> Compile(const execution::compiler::CompilerSettings &settings);
 
   /**
    * Add the teardown function to the query.

--- a/src/include/execution/exec/execution_settings.h
+++ b/src/include/execution/exec/execution_settings.h
@@ -2,6 +2,7 @@
 
 #include "common/constants.h"
 #include "common/managed_pointer.h"
+#include "execution/compiler/compiler_settings.h"
 #include "execution/util/execution_common.h"
 
 namespace noisepage::settings {
@@ -50,6 +51,14 @@ class EXPORT ExecutionSettings {
    */
   void UpdateFromSettingsManager(common::ManagedPointer<settings::SettingsManager> settings);
 
+  /** Update the settings used in compilation of TPL. */
+  void SetCompilerSettings(execution::compiler::CompilerSettings compiler_settings) {
+    compiler_settings_ = std::move(compiler_settings);
+  }
+
+  /** @return The current settings used for compilation of TPL. */
+  const execution::compiler::CompilerSettings &GetCompilerSettings() const { return compiler_settings_; }
+
   /** @return The vector active element threshold past which full auto-vectorization is done on vectors. */
   constexpr double GetSelectOptThreshold() const { return select_opt_threshold_; }
 
@@ -91,6 +100,7 @@ class EXPORT ExecutionSettings {
   bool is_pipeline_metrics_enabled_{common::Constants::IS_PIPELINE_METRICS_ENABLED};
   int number_of_parallel_execution_threads_{common::Constants::NUM_PARALLEL_EXECUTION_THREADS};
   bool is_static_partitioner_enabled_{common::Constants::IS_STATIC_PARTITIONER_ENABLED};
+  compiler::CompilerSettings compiler_settings_{};  ///< The settings for compiling the TPL input.
 
   // MiniRunners needs to set query_identifier and pipeline_operating_units_.
   friend class noisepage::runner::ExecutionRunners;

--- a/src/include/execution/exec/execution_settings.h
+++ b/src/include/execution/exec/execution_settings.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "common/constants.h"
 #include "common/managed_pointer.h"
 #include "execution/compiler/compiler_settings.h"

--- a/src/include/execution/exec/execution_settings.h
+++ b/src/include/execution/exec/execution_settings.h
@@ -55,7 +55,7 @@ class EXPORT ExecutionSettings {
 
   /** Update the settings used in compilation of TPL. */
   void SetCompilerSettings(execution::compiler::CompilerSettings compiler_settings) {
-    compiler_settings_ = std::move(compiler_settings);
+    compiler_settings_ = compiler_settings;
   }
 
   /** @return The current settings used for compilation of TPL. */

--- a/src/include/execution/vm/module.h
+++ b/src/include/execution/vm/module.h
@@ -11,6 +11,7 @@
 #include "execution/ast/type.h"
 #include "execution/vm/bytecode_module.h"
 #include "execution/vm/llvm_engine.h"
+#include "execution/vm/module_metadata.h"
 #include "execution/vm/vm_defs.h"
 
 namespace noisepage::execution::vm {
@@ -32,15 +33,18 @@ class Module {
   /**
    * Create a TPL module using the given bytecode module as the initial implementation.
    * @param bytecode_module The bytecode module implementation.
+   * @param metadata Additional non-essential metadata about the TPL module.
    */
-  explicit Module(std::unique_ptr<BytecodeModule> bytecode_module);
+  explicit Module(std::unique_ptr<BytecodeModule> bytecode_module, ModuleMetadata &&metadata);
 
   /**
    * Construct a TPL module with the given bytecode and LLVM implementations.
    * @param bytecode_module The bytecode module implementation.
    * @param llvm_module The compiled code.
+   * @param metadata Additional non-essential metadata about the TPL module.
    */
-  Module(std::unique_ptr<BytecodeModule> bytecode_module, std::unique_ptr<LLVMEngine::CompiledModule> llvm_module);
+  Module(std::unique_ptr<BytecodeModule> bytecode_module, std::unique_ptr<LLVMEngine::CompiledModule> llvm_module,
+         ModuleMetadata &&metadata);
 
   /**
    * This class cannot be copied or moved.
@@ -98,6 +102,9 @@ class Module {
    * @return The TPL bytecode module.
    */
   const BytecodeModule *GetBytecodeModule() const { return bytecode_module_.get(); }
+
+  /** @return The non-essential metadata for this module. */
+  const ModuleMetadata &GetMetadata() const { return metadata_; }
 
  private:
   friend class VM;                            // For the VM to access raw bytecode.
@@ -168,6 +175,8 @@ class Module {
 
   // Flag to indicate if the JIT compilation has occurred.
   std::once_flag compiled_flag_;
+
+  ModuleMetadata metadata_;  ///< Non-essential metadata about the TPL module.
 };
 
 // ---------------------------------------------------------

--- a/src/include/execution/vm/module.h
+++ b/src/include/execution/vm/module.h
@@ -35,7 +35,7 @@ class Module {
    * @param bytecode_module The bytecode module implementation.
    * @param metadata Additional non-essential metadata about the TPL module.
    */
-  explicit Module(std::unique_ptr<BytecodeModule> bytecode_module, ModuleMetadata &&metadata);
+  Module(std::unique_ptr<BytecodeModule> bytecode_module, ModuleMetadata &&metadata);
 
   /**
    * Construct a TPL module with the given bytecode and LLVM implementations.

--- a/src/include/execution/vm/module_metadata.h
+++ b/src/include/execution/vm/module_metadata.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+namespace noisepage::execution::vm {
+
+/** Compile-time information about a module. */
+class CompileTimeModuleMetadata {
+ public:
+  /** Set the TPL in this module. */
+  void SetTPL(std::string &&tpl) { map_["tpl"] = std::move(tpl); }
+  /** Set the TBC in this module. */
+  void SetTBC(std::string &&tbc) { map_["tbc"] = std::move(tbc); }
+
+  /** @return The TPL in the module, if it exists. Otherwise empty string. */
+  std::string GetTPL() const { return map_.find("tpl") == map_.end() ? "" : map_.at("tpl"); }
+  /** @return The TBC in the module, if it exists. Otherwise empty string. */
+  std::string GetTBC() const { return map_.find("tbc") == map_.end() ? "" : map_.at("tbc"); }
+
+ private:
+  // TODO(WAN): The value-type may change in the future depending on what tagged dictionaries need.
+  std::unordered_map<std::string, std::string> map_;  ///< Compile-time information representable as strings.
+};
+
+/** Non-essential metadata associated with a module. */
+class ModuleMetadata {
+ public:
+  /** Constructor. */
+  explicit ModuleMetadata(CompileTimeModuleMetadata &&compile_time_metadata)
+      : compile_time_metadata_(compile_time_metadata) {}
+
+  /** @return The metadata collected at compile-time for this module. */
+  const CompileTimeModuleMetadata &GetCompileTimeMetadata() const { return compile_time_metadata_; }
+
+ private:
+  CompileTimeModuleMetadata compile_time_metadata_;  ///< Metadata that was gathered at compile-time.
+};
+
+}  // namespace noisepage::execution::vm

--- a/src/include/execution/vm/module_metadata.h
+++ b/src/include/execution/vm/module_metadata.h
@@ -15,9 +15,9 @@ class CompileTimeModuleMetadata {
   void SetTBC(std::string &&tbc) { map_["tbc"] = std::move(tbc); }
 
   /** @return The TPL in the module, if it exists. Otherwise empty string. */
-  std::string GetTPL() const { return map_.find("tpl") == map_.end() ? "" : map_.at("tpl"); }
+  [[nodiscard]] std::string GetTPL() const { return map_.find("tpl") == map_.end() ? "" : map_.at("tpl"); }
   /** @return The TBC in the module, if it exists. Otherwise empty string. */
-  std::string GetTBC() const { return map_.find("tbc") == map_.end() ? "" : map_.at("tbc"); }
+  [[nodiscard]] std::string GetTBC() const { return map_.find("tbc") == map_.end() ? "" : map_.at("tbc"); }
 
  private:
   // TODO(WAN): The value-type may change in the future depending on what tagged dictionaries need.
@@ -35,7 +35,7 @@ class ModuleMetadata {
       : compile_time_metadata_(compile_time_metadata) {}
 
   /** @return The metadata collected at compile-time for this module. */
-  const CompileTimeModuleMetadata &GetCompileTimeMetadata() const { return compile_time_metadata_; }
+  [[nodiscard]] const CompileTimeModuleMetadata &GetCompileTimeMetadata() const { return compile_time_metadata_; }
 
  private:
   CompileTimeModuleMetadata compile_time_metadata_;  ///< Metadata that was gathered at compile-time.

--- a/src/include/execution/vm/module_metadata.h
+++ b/src/include/execution/vm/module_metadata.h
@@ -27,6 +27,9 @@ class CompileTimeModuleMetadata {
 /** Non-essential metadata associated with a module. */
 class ModuleMetadata {
  public:
+  /** Constructor for no-information case. */
+  ModuleMetadata() = default;
+
   /** Constructor. */
   explicit ModuleMetadata(CompileTimeModuleMetadata &&compile_time_metadata)
       : compile_time_metadata_(compile_time_metadata) {}

--- a/src/include/traffic_cop/traffic_cop.h
+++ b/src/include/traffic_cop/traffic_cop.h
@@ -224,12 +224,12 @@ class TrafficCop {
    * Contains the logic to reason about EXPLAIN execution.
    * @param connection_ctx context to be used to access the internal txn
    * @param out packet writer to return results
-   * @param physical_plan to be executed
+   * @param portal to be executed
    * @return result of the operation
    */
   TrafficCopResult ExecuteExplainStatement(common::ManagedPointer<network::ConnectionContext> connection_ctx,
                                            common::ManagedPointer<network::PostgresPacketWriter> out,
-                                           common::ManagedPointer<planner::AbstractPlanNode> physical_plan) const;
+                                           common::ManagedPointer<network::Portal> portal) const;
 
   /**
    * Contains the logic to reason about DML execution. Responsible for outputting results because we don't want to

--- a/src/network/postgres/postgres_network_commands.cpp
+++ b/src/network/postgres/postgres_network_commands.cpp
@@ -60,7 +60,7 @@ static void ExecutePortal(const common::ManagedPointer<network::ConnectionContex
     }
     result = t_cop->ExecuteDropStatement(connection_ctx, physical_plan, query_type);
   } else if (query_type == network::QueryType::QUERY_EXPLAIN) {
-    result = t_cop->ExecuteExplainStatement(connection_ctx, out, physical_plan);
+    result = t_cop->ExecuteExplainStatement(connection_ctx, out, portal);
   }
 
   if (result.type_ == trafficcop::ResultType::COMPLETE) {

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -359,6 +359,7 @@ TrafficCopResult TrafficCop::ExecuteExplainStatement(
 
   // TODO(WAN): Integrate with Matt's PR.
 #if 0
+  {
     // Codegen must happen for certain types of EXPLAIN metadata to be collected, e.g., collection of TPL.
     auto codegen = CodegenPhysicalPlan(connection_ctx, out, portal);
     if (codegen.type_ != ResultType::COMPLETE) {

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -480,7 +480,7 @@ TrafficCopResult TrafficCop::CodegenPhysicalPlan(
     // if (portal->GetStatement()->RootStatement().CastManagedPointerTo<parser::ExplainStatement>().GetFormat()...)
     settings.SetShouldCaptureTPL(true);
     settings.SetShouldCaptureTBC(true);
-    exec_settings.SetCompilerSettings(std::move(settings));
+    exec_settings.SetCompilerSettings(settings);
   }
 
   auto exec_query = execution::compiler::CompilationContext::Compile(

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -25,7 +25,6 @@
 #include "network/postgres/portal.h"
 #include "network/postgres/postgres_packet_writer.h"
 #include "network/postgres/statement.h"
-#include "nlohmann/json.hpp"
 #include "optimizer/cost_model/trivial_cost_model.h"
 #include "optimizer/statistics/stats_storage.h"
 #include "parser/drop_statement.h"
@@ -349,7 +348,7 @@ TrafficCopResult TrafficCop::ExecuteDropStatement(
 TrafficCopResult TrafficCop::ExecuteExplainStatement(
     const common::ManagedPointer<network::ConnectionContext> connection_ctx,
     const common::ManagedPointer<network::PostgresPacketWriter> out,
-    const common::ManagedPointer<planner::AbstractPlanNode> physical_plan) const {
+    const common::ManagedPointer<network::Portal> portal) const {
   NOISEPAGE_ASSERT(connection_ctx->TransactionState() == network::NetworkTransactionStateType::BLOCK,
                    "Not in a valid txn. This should have been caught before calling this function.");
 
@@ -358,6 +357,24 @@ TrafficCopResult TrafficCop::ExecuteExplainStatement(
   std::vector<planner::OutputSchema::Column> output_columns;
   output_columns.emplace_back("QUERY PLAN", type::TypeId::VARCHAR, nullptr);
 
+  // TODO(WAN): Integrate with Matt's PR.
+#if 0
+    // Codegen must happen for certain types of EXPLAIN metadata to be collected, e.g., collection of TPL.
+    auto codegen = CodegenPhysicalPlan(connection_ctx, out, portal);
+    if (codegen.type_ != ResultType::COMPLETE) {
+      return {ResultType::ERROR, common::ErrorData(common::ErrorSeverity::ERROR, "Failed to execute codegen.",
+                                                   common::ErrorCode::ERRCODE_DATA_EXCEPTION)};
+    }
+
+    const auto &fragments = portal->GetStatement()->GetExecutableQuery()->GetFragments();
+    NOISEPAGE_ASSERT(fragments.size() == 1, "We currently always compile with just one query fragment.");
+    const auto &metadata = fragments.at(0)->GetModuleMetadata().GetCompileTimeMetadata();
+    std::string output = metadata.GetTPL() + "\n\n" + metadata.GetTBC();
+    const execution::sql::StringVal plan_string_val = execution::sql::StringVal(output.c_str(), output.length());
+  }
+#endif
+
+  const auto physical_plan = portal->OptimizeResult()->GetPlanNode();
   const std::string plan_string = physical_plan->ToJson().dump(4);
   const execution::sql::StringVal plan_string_val =
       execution::sql::StringVal(plan_string.c_str(), plan_string.length());
@@ -430,13 +447,21 @@ TrafficCopResult TrafficCop::CodegenPhysicalPlan(
     const common::ManagedPointer<network::Portal> portal) const {
   NOISEPAGE_ASSERT(connection_ctx->TransactionState() == network::NetworkTransactionStateType::BLOCK,
                    "Not in a valid txn. This should have been caught before calling this function.");
-  const auto query_type UNUSED_ATTRIBUTE = portal->GetStatement()->GetQueryType();
+  // For an EXPLAIN statement, the query type is the type of the wrapped SQL statement.
+  const auto query_type UNUSED_ATTRIBUTE =
+      portal->GetStatement()->GetQueryType() == network::QueryType::QUERY_EXPLAIN
+          ? trafficcop::TrafficCopUtil::QueryTypeForStatement(portal->GetStatement()
+                                                                  ->RootStatement()
+                                                                  .CastManagedPointerTo<parser::ExplainStatement>()
+                                                                  ->GetSQLStatement())
+          : portal->GetStatement()->GetQueryType();
   const auto physical_plan = portal->OptimizeResult()->GetPlanNode();
+
   NOISEPAGE_ASSERT(
       query_type == network::QueryType::QUERY_SELECT || query_type == network::QueryType::QUERY_INSERT ||
           query_type == network::QueryType::QUERY_CREATE_INDEX || query_type == network::QueryType::QUERY_UPDATE ||
           query_type == network::QueryType::QUERY_DELETE || query_type == network::QueryType::QUERY_ANALYZE,
-      "CodegenAndRunPhysicalPlan called with invalid QueryType.");
+      "CodegenPhysicalPlan called with invalid QueryType.");
 
   if (portal->GetStatement()->GetExecutableQuery() != nullptr && use_query_cache_) {
     // We've already codegen'd this, move on...
@@ -446,6 +471,16 @@ TrafficCopResult TrafficCop::CodegenPhysicalPlan(
   // TODO(WAN): see #1047
   execution::exec::ExecutionSettings exec_settings{};
   exec_settings.UpdateFromSettingsManager(settings_manager_);
+
+  // TODO(WAN): Integrate with Matt's PR.
+  // Set any compilation settings based on the original query type.
+  if (portal->GetStatement()->GetQueryType() == network::QueryType::QUERY_EXPLAIN) {
+    execution::compiler::CompilerSettings settings;
+    // if (portal->GetStatement()->RootStatement().CastManagedPointerTo<parser::ExplainStatement>().GetFormat()...)
+    settings.SetShouldCaptureTPL(true);
+    settings.SetShouldCaptureTBC(true);
+    exec_settings.SetCompilerSettings(std::move(settings));
+  }
 
   auto exec_query = execution::compiler::CompilationContext::Compile(
       *physical_plan, exec_settings, connection_ctx->Accessor().Get(),

--- a/test/execution/atomics_test.cpp
+++ b/test/execution/atomics_test.cpp
@@ -5,6 +5,7 @@
 #include "execution/ast/context.h"
 #include "execution/compiled_tpl_test.h"
 #include "execution/compiler/compiler.h"
+#include "execution/compiler/compiler_settings.h"
 #include "execution/sema/error_reporter.h"
 #include "execution/util/region.h"
 #include "execution/vm/llvm_engine.h"
@@ -41,7 +42,7 @@ class AtomicsTest : public CompiledTplTest {
                                          tpl_type);
 
     // Compile it...
-    auto input = compiler::Compiler::Input("Atomic Definitions", &context, &src);
+    auto input = compiler::Compiler::Input("Atomic Definitions", &context, &src, compiler::CompilerSettings{});
     auto module = compiler::Compiler::RunCompilationSimple(input);
     ASSERT_FALSE(module == nullptr);
 
@@ -102,7 +103,7 @@ class AtomicsTest : public CompiledTplTest {
                                          tpl_type);
 
     // Compile it...
-    auto input = compiler::Compiler::Input("Atomic Definitions", &context, &src);
+    auto input = compiler::Compiler::Input("Atomic Definitions", &context, &src, compiler::CompilerSettings{});
     auto module = compiler::Compiler::RunCompilationSimple(input);
     ASSERT_FALSE(module == nullptr);
 

--- a/test/execution/compiler_test.cpp
+++ b/test/execution/compiler_test.cpp
@@ -81,7 +81,7 @@ TEST_F(CompilerTest, CompileFromSource) {
 
   for (uint32_t i = 1; i < 4; i++) {
     auto src = std::string("fun test() -> int32 { return " + std::to_string(i * 10) + " }");
-    auto input = Compiler::Input("Simple Test", &context, &src);
+    auto input = Compiler::Input("Simple Test", &context, &src, CompilerSettings{});
     auto module = Compiler::RunCompilationSimple(input);
 
     // The module should be valid since the input source is valid
@@ -116,7 +116,7 @@ TEST_F(CompilerTest, CompileToAst) {
   };
 
   auto src = std::string("fun BLAH() -> int32 { return 10 }");
-  auto input = Compiler::Input("Simple Test", &context, &src);
+  auto input = Compiler::Input("Simple Test", &context, &src, CompilerSettings{});
   auto callback = CompileToAstCallback();
   Compiler::RunCompilation(input, &callback);
 

--- a/test/include/execution/vm/module_compiler.h
+++ b/test/include/execution/vm/module_compiler.h
@@ -33,7 +33,7 @@ class ModuleCompiler {
   std::unique_ptr<Module> CompileToModule(const std::string &source) {
     auto *ast = CompileToAst(source);
     if (HasErrors()) return nullptr;
-    return std::make_unique<Module>(vm::BytecodeGenerator::Compile(ast, "test"));
+    return std::make_unique<Module>(vm::BytecodeGenerator::Compile(ast, "test"), ModuleMetadata{});
   }
 
   // Does the error reporter have any errors?

--- a/util/execution/tpl.cpp
+++ b/util/execution/tpl.cpp
@@ -31,6 +31,7 @@
 #include "execution/vm/bytecode_module.h"
 #include "execution/vm/llvm_engine.h"
 #include "execution/vm/module.h"
+#include "execution/vm/module_metadata.h"
 #include "execution/vm/vm.h"
 #include "loggers/execution_logger.h"
 #include "main/db_main.h"
@@ -183,7 +184,9 @@ static void CompileAndRun(const std::string &source, const std::string &name = "
     bytecode_module->Dump(std::cout);  // NOLINT
   }
 
-  auto module = std::make_unique<vm::Module>(std::move(bytecode_module));
+  vm::CompileTimeModuleMetadata compile_metadata{};
+  vm::ModuleMetadata module_metadata{std::move(compile_metadata)};
+  auto module = std::make_unique<vm::Module>(std::move(bytecode_module), std::move(module_metadata));
 
   //
   // Interpret


### PR DESCRIPTION
# Heading

First pass at supplying backend for EXPLAIN (FORMAT TPL) queries.

## Description

#1588 provides the frontend for EXPLAIN (FORMAT ...) queries.

This PR attempts to provide the backend to that, structured as follows:

- `ExecutionSettings` is currently described as "ExecutionSettings stores settings that are passed down from the upper layers.", so we are passing down a new `CompilerSettings` that determines what information should be gathered at compile-time. This can be set from the tcop upon detecting that this is an EXPLAIN statement of a relevant type. See comment below.
- `CompilerSettings` just describes whether to collect TPL and/or TBC, and is threaded down into `compiler.cpp`.
- Information is maintained in `CompileTimeModuleMetadata` which is currently just a `unordered_map<string, string>`. Two main considerations went into this decision:
  - You will either need to extend the lifetime of the objects you want metadata for, or grab the relevant information before the objects get destroyed. In this case, the AST for example is destroyed after compilation is done.
  - I cannot foresee any usages of manipulating the AST after `compiler.cpp`, so it might as well be serialized to string there instead of having its lifetime extended.