### PR TITLE
Add support for arbitrary SHOW. Add "set log_level_blah".

### DIFF
--- a/src/include/loggers/loggers_util.h
+++ b/src/include/loggers/loggers_util.h
@@ -3,6 +3,9 @@
 // flush the debug logs, every <n> seconds
 #define DEBUG_LOG_FLUSH_INTERVAL 3
 
+#include <optional>
+#include <string_view>
+
 #include "common/sanctioned_shared_pointer.h"
 #include "spdlog/fmt/ostr.h"
 #include "spdlog/sinks/basic_file_sink.h"
@@ -29,5 +32,11 @@ class LoggersUtil {
    * Shut down all of the debug loggers in the system.
    */
   static void ShutDown();
+
+  /** @return The specified level. */
+  static std::optional<spdlog::level::level_enum> GetLevel(const std::string_view &name);
+
+  /** @return The logger for the specified component. */
+  static noisepage::common::SanctionedSharedPtr<spdlog::logger>::Ptr GetLogger(const std::string_view &name);
 };
 }  // namespace noisepage

--- a/src/include/main/db_main.h
+++ b/src/include/main/db_main.h
@@ -1060,8 +1060,8 @@ class DBMain {
       bytecode_handlers_path_ = settings_manager->GetString(settings::Param::bytecode_handlers_path);
 
       query_trace_metrics_ = settings_manager->GetBool(settings::Param::query_trace_metrics_enable);
-      query_trace_metrics_output_ = static_cast<metrics::MetricsOutput>(metrics::MetricsUtil::FromMetricsOutputString(
-          settings_manager->GetString(settings::Param::query_trace_metrics_output)));
+      query_trace_metrics_output_ = *metrics::MetricsUtil::FromMetricsOutputString(
+          settings_manager->GetString(settings::Param::query_trace_metrics_output));
       forecast_sample_limit_ = settings_manager->GetInt(settings::Param::forecast_sample_limit);
       pipeline_metrics_ = settings_manager->GetBool(settings::Param::pipeline_metrics_enable);
       pipeline_metrics_sample_rate_ = settings_manager->GetInt(settings::Param::pipeline_metrics_sample_rate);

--- a/src/include/metrics/metrics_util.h
+++ b/src/include/metrics/metrics_util.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>  // NOLINT
+#include <optional>
 #include <string>
 
 #include "execution/util/cpu_info.h"
@@ -39,15 +40,16 @@ struct MetricsUtil {
    * @param metrics output string
    * @return MetricsOutput corresponding to it
    */
-  static MetricsOutput FromMetricsOutputString(const std::string &metrics) {
-    if (metrics == "CSV") return MetricsOutput::CSV;
-
-    if (metrics == "DB") return MetricsOutput::DB;
-
-    if (metrics == "CSV_AND_DB") return MetricsOutput::CSV_AND_DB;
-
-    NOISEPAGE_ASSERT(false, "Unknown metrics type specified");
-    return MetricsOutput::CSV;
+  static std::optional<MetricsOutput> FromMetricsOutputString(const std::string_view &metrics) {
+    std::optional<MetricsOutput> type{std::nullopt};
+    if (metrics == "CSV") {
+      type = MetricsOutput::CSV;
+    } else if (metrics == "DB") {
+      type = MetricsOutput::DB;
+    } else if (metrics == "CSV_AND_DB") {
+      type = MetricsOutput::CSV_AND_DB;
+    }
+    return type;
   }
 
   /**

--- a/src/include/settings/settings_callbacks.h
+++ b/src/include/settings/settings_callbacks.h
@@ -28,204 +28,108 @@ class Callbacks {
   static void NoOp(void *old_value, void *new_value, DBMain *db_main,
                    common::ManagedPointer<common::ActionContext> action_context);
 
-  /**
-   * Changes the buffer segment pool size limit.
-   * @param old_value old settings value
-   * @param new_value new settings value
-   * @param db_main pointer to db_main
-   * @param action_context pointer to the action context for this settings change
-   */
+  /** Change the buffer segment pool size limit. */
   static void BufferSegmentPoolSizeLimit(void *old_value, void *new_value, DBMain *db_main,
                                          common::ManagedPointer<common::ActionContext> action_context);
 
-  /**
-   * Changes the buffer segment pool reuse limit.
-   * @param old_value old settings value
-   * @param new_value new settings value
-   * @param db_main pointer to db_main
-   * @param action_context pointer to the action context for this settings change
-   */
+  /** Change the buffer segment pool reuse limit. */
   static void BufferSegmentPoolReuseLimit(void *old_value, void *new_value, DBMain *db_main,
                                           common::ManagedPointer<common::ActionContext> action_context);
 
-  /**
-   * Changes the block store size limit.
-   * @param old_value old settings value
-   * @param new_value new settings value
-   * @param db_main pointer to db_main
-   * @param action_context pointer to the action context for this settings change
-   */
+  /** Change the block store size limit. */
   static void BlockStoreSizeLimit(void *old_value, void *new_value, DBMain *db_main,
                                   common::ManagedPointer<common::ActionContext> action_context);
 
-  /**
-   * Changes the block store reuse limit.
-   * @param old_value old settings value
-   * @param new_value new settings value
-   * @param db_main pointer to db_main
-   * @param action_context pointer to the action context for this settings change
-   */
+  /** Change the block store reuse limit. */
   static void BlockStoreReuseLimit(void *old_value, void *new_value, DBMain *db_main,
                                    common::ManagedPointer<common::ActionContext> action_context);
 
-  /**
-   * Changes the number of buffers the log manager uses.
-   * @param old_value old settings value
-   * @param new_value new settings value
-   * @param db_main pointer to db_main
-   * @param action_context pointer to the action context for this settings change
-   */
+  /** Change the number of buffers the log manager uses. */
   static void WalNumBuffers(void *old_value, void *new_value, DBMain *db_main,
                             common::ManagedPointer<common::ActionContext> action_context);
 
-  /**
-   * Changes the number of buffers the log manager uses.
-   * @param old_value old settings value
-   * @param new_value new settings value
-   * @param db_main pointer to db_main
-   * @param action_context pointer to the action context for this settings change
-   */
+  /** Change the number of buffers the log manager uses. */
   static void WalSerializationInterval(void *old_value, void *new_value, DBMain *db_main,
                                        common::ManagedPointer<common::ActionContext> action_context);
 
-  /**
-   * Enable or disable metrics collection for Logging component
-   * @param old_value old settings value
-   * @param new_value new settings value
-   * @param db_main pointer to db_main
-   * @param action_context pointer to the action context for this settings change
-   */
+  /** Enable or disable metrics collection for Logging component. */
   static void MetricsLogging(void *old_value, void *new_value, DBMain *db_main,
                              common::ManagedPointer<common::ActionContext> action_context);
 
-  /**
-   * Enable or disable metrics collection for TransactionManager component
-   * @param old_value old settings value
-   * @param new_value new settings value
-   * @param db_main pointer to db_main
-   * @param action_context pointer to the action context for this settings change
-   */
+  /** Enable or disable metrics collection for TransactionManager component. */
   static void MetricsTransaction(void *old_value, void *new_value, DBMain *db_main,
                                  common::ManagedPointer<common::ActionContext> action_context);
 
-  /**
-   * Enable or disable metrics collection for GarbageCollector component
-   * @param old_value old settings value
-   * @param new_value new settings value
-   * @param db_main pointer to db_main
-   * @param action_context pointer to the action context for this settings change
-   */
+  /** Enable or disable metrics collection for GarbageCollector component. */
   static void MetricsGC(void *old_value, void *new_value, DBMain *db_main,
                         common::ManagedPointer<common::ActionContext> action_context);
 
-  /**
-   * Enable or disable metrics collection for Execution component
-   * @param old_value old settings value
-   * @param new_value new settings value
-   * @param db_main pointer to db_main
-   * @param action_context pointer to the action context for this settings change
-   */
+  /** Enable or disable metrics collection for Execution component. */
   static void MetricsExecution(void *old_value, void *new_value, DBMain *db_main,
                                common::ManagedPointer<common::ActionContext> action_context);
 
-  /**
-   * Enable or disable metrics collection for ExecutionEngine pipeline
-   * @param old_value old settings value
-   * @param new_value new settings value
-   * @param db_main pointer to db_main
-   * @param action_context pointer to the action context for this settings change
-   */
+  /** Enable or disable metrics collection for ExecutionEngine pipeline. */
   static void MetricsPipeline(void *old_value, void *new_value, DBMain *db_main,
                               common::ManagedPointer<common::ActionContext> action_context);
 
-  /**
-   * Update the sampling interval for logging
-   * @param old_value old settings value
-   * @param new_value new settings value
-   * @param db_main pointer to db_main
-   * @param action_context pointer to the action context for this settings change
-   */
+  /** Update the sampling interval for logging. */
   static void MetricsLoggingSampleRate(void *old_value, void *new_value, DBMain *db_main,
                                        common::ManagedPointer<common::ActionContext> action_context);
 
-  /**
-   * Update the sampling interval for ExecutionEngine pipelines
-   * @param old_value old settings value
-   * @param new_value new settings value
-   * @param db_main pointer to db_main
-   * @param action_context pointer to the action context for this settings change
-   */
+  /** Update the sampling interval for ExecutionEngine pipelines. */
   static void MetricsPipelineSampleRate(void *old_value, void *new_value, DBMain *db_main,
                                         common::ManagedPointer<common::ActionContext> action_context);
 
-  /**
-   * Enable or disable metrics collection for bind command
-   * @param old_value old settings value
-   * @param new_value new settings value
-   * @param db_main pointer to db_main
-   * @param action_context pointer to the action context for this settings change
-   */
+  /** Enable or disable metrics collection for bind command. */
   static void MetricsBindCommand(void *old_value, void *new_value, DBMain *db_main,
                                  common::ManagedPointer<common::ActionContext> action_context);
 
-  /**
-   * Enable or disable metrics collection for execute command
-   * @param old_value old settings value
-   * @param new_value new settings value
-   * @param db_main pointer to db_main
-   * @param action_context pointer to the action context for this settings change
-   */
+  /** Enable or disable metrics collection for execute command. */
   static void MetricsExecuteCommand(void *old_value, void *new_value, DBMain *db_main,
                                     common::ManagedPointer<common::ActionContext> action_context);
 
-  /**
-   * Enable or disable metrics collection for Query Trace component
-   * @param old_value old settings value
-   * @param new_value new settings value
-   * @param db_main pointer to db_main
-   * @param action_context pointer to the action context for this settings change
-   */
+  /** Enable or disable metrics collection for Query Trace component. */
   static void MetricsQueryTrace(void *old_value, void *new_value, DBMain *db_main,
                                 common::ManagedPointer<common::ActionContext> action_context);
 
-  /**
-   * Update the metrics output type being used by a metric component
-   * @param old_value old settings value
-   * @param new_value new settings value
-   * @param db_main pointer to db_main
-   * @param action_context pointer to the action context for this settings change
-   */
+  /** Update the metrics output type being used by a metric component. */
   static void MetricsQueryTraceOutput(void *old_value, void *new_value, DBMain *db_main,
                                       common::ManagedPointer<common::ActionContext> action_context);
 
-  /**
-   * Set the forecast sample limit
-   * @param old_value old settings value
-   * @param new_value new settings value
-   * @param db_main pointer to db_main
-   * @param action_context pointer to the action context for this settings change
-   */
+  /** Set the forecast sample limit. */
   static void ForecastSampleLimit(void *old_value, void *new_value, DBMain *db_main,
                                   common::ManagedPointer<common::ActionContext> action_context);
 
-  /**
-   * Set the number of task manager threads
-   * @param old_value old settings value
-   * @param new_value new settings value
-   * @param db_main pointer to db_main
-   * @param action_context pointer to the action context for this settings change
-   */
+  /** Set the number of task manager threads. */
   static void TaskPoolSize(void *old_value, void *new_value, DBMain *db_main,
                            common::ManagedPointer<common::ActionContext> action_context);
 
-  /**
-   * Enable or disable planning in Pilot thread
-   * @param old_value old settings value
-   * @param new_value new settings value
-   * @param db_main pointer to db_main
-   * @param action_context pointer to the action context for this settings change
-   */
+  /** Enable or disable planning in Pilot thread. */
   static void PilotEnablePlanning(void *old_value, void *new_value, DBMain *db_main,
                                   common::ManagedPointer<common::ActionContext> action_context);
+
+#define SETTINGS_GENERATE_LOGGER_CALLBACK(component)                                    \
+  /** Set the log level for the component. */                                           \
+  static void LogLevelSet##component(void *old_value, void *new_value, DBMain *db_main, \
+                                     common::ManagedPointer<common::ActionContext> action_context);
+
+  SETTINGS_GENERATE_LOGGER_CALLBACK(binder)
+  SETTINGS_GENERATE_LOGGER_CALLBACK(catalog)
+  SETTINGS_GENERATE_LOGGER_CALLBACK(common)
+  SETTINGS_GENERATE_LOGGER_CALLBACK(execution)
+  SETTINGS_GENERATE_LOGGER_CALLBACK(index)
+  SETTINGS_GENERATE_LOGGER_CALLBACK(messenger)
+  SETTINGS_GENERATE_LOGGER_CALLBACK(metrics)
+  SETTINGS_GENERATE_LOGGER_CALLBACK(modelserver)
+  SETTINGS_GENERATE_LOGGER_CALLBACK(network)
+  SETTINGS_GENERATE_LOGGER_CALLBACK(optimizer)
+  SETTINGS_GENERATE_LOGGER_CALLBACK(parser)
+  SETTINGS_GENERATE_LOGGER_CALLBACK(replication)
+  SETTINGS_GENERATE_LOGGER_CALLBACK(selfdriving)
+  SETTINGS_GENERATE_LOGGER_CALLBACK(settings)
+  SETTINGS_GENERATE_LOGGER_CALLBACK(storage)
+  SETTINGS_GENERATE_LOGGER_CALLBACK(transaction)
+
+#undef SETTINGS_GENERATE_LOGGER_CALLBACK
 };
 }  // namespace noisepage::settings

--- a/src/include/settings/settings_defs.h
+++ b/src/include/settings/settings_defs.h
@@ -560,4 +560,34 @@ SETTING_string(
     false,
     noisepage::settings::Callbacks::NoOp
 )
+
+// The default log level is unspecified because people may have inserted calls
+// to set_level directly in the codebase, which would make a default inaccurate.
+#define SETTINGS_LOG_LEVEL(component)                      \
+SETTING_string(                                            \
+    log_level_##component,                                 \
+    "Set the log level for the component.",                \
+    "(unspecified)",                                       \
+    true,                                                  \
+    noisepage::settings::Callbacks::LogLevelSet##component \
+)
+
+SETTINGS_LOG_LEVEL(binder)
+SETTINGS_LOG_LEVEL(catalog)
+SETTINGS_LOG_LEVEL(common)
+SETTINGS_LOG_LEVEL(execution)
+SETTINGS_LOG_LEVEL(index)
+SETTINGS_LOG_LEVEL(messenger)
+SETTINGS_LOG_LEVEL(metrics)
+SETTINGS_LOG_LEVEL(modelserver)
+SETTINGS_LOG_LEVEL(network)
+SETTINGS_LOG_LEVEL(optimizer)
+SETTINGS_LOG_LEVEL(parser)
+SETTINGS_LOG_LEVEL(replication)
+SETTINGS_LOG_LEVEL(selfdriving)
+SETTINGS_LOG_LEVEL(settings)
+SETTINGS_LOG_LEVEL(storage)
+SETTINGS_LOG_LEVEL(transaction)
+
+#undef SETTINGS_LOG_LEVEL
     // clang-format on

--- a/src/include/settings/settings_manager.h
+++ b/src/include/settings/settings_manager.h
@@ -152,6 +152,9 @@ class SettingsManager {
   /** @return The ParamInfo corresponding to the given parameter; throws exception if doesn't exist. */
   const ParamInfo &GetParamInfo(const settings::Param &param) const;
 
+  /** @return The Param corresponding to the given name; throws exception if doesn't exist. */
+  Param GetParam(const std::string &name) const;
+
  private:
   common::ManagedPointer<DBMain> db_main_;
   std::unordered_map<settings::Param, settings::ParamInfo> param_map_;
@@ -161,9 +164,6 @@ class SettingsManager {
 
   void ValidateSetting(Param param, const parser::ConstantValueExpression &min_value,
                        const parser::ConstantValueExpression &max_value);
-
-  /** @return The Param corresponding to the given name; throws exception if doesn't exist. */
-  Param GetParam(const std::string &name) const;
 
   parser::ConstantValueExpression &GetValue(Param param);
   bool SetValue(Param param, parser::ConstantValueExpression value);

--- a/src/include/settings/settings_param.h
+++ b/src/include/settings/settings_param.h
@@ -77,6 +77,9 @@ class ParamInfo {
         max_value_(max_value),
         callback_(callback) {}
 
+  /** @return The current value of the parameter. */
+  const parser::ConstantValueExpression &GetValue() const { return value_; }
+
  private:
   friend void noisepage::runner::InitializeRunnersState();
   friend class noisepage::DBMain;

--- a/src/loggers/loggers_util.cpp
+++ b/src/loggers/loggers_util.cpp
@@ -68,4 +68,61 @@ void LoggersUtil::ShutDown() {
   }
 #endif
 }
+
+std::optional<spdlog::level::level_enum> LoggersUtil::GetLevel(const std::string_view &name) {
+  std::optional<spdlog::level::level_enum> level_val{std::nullopt};
+  if (name == "off") {
+    level_val = spdlog::level::off;
+  } else if (name == "trace") {
+    level_val = spdlog::level::trace;
+  } else if (name == "debug") {
+    level_val = spdlog::level::debug;
+  } else if (name == "info") {
+    level_val = spdlog::level::info;
+  } else if (name == "err") {
+    level_val = spdlog::level::err;
+  } else if (name == "critical") {
+    level_val = spdlog::level::critical;
+  }
+  return level_val;
+}
+
+common::SanctionedSharedPtr<spdlog::logger>::Ptr LoggersUtil::GetLogger(const std::string_view &name) {
+  common::SanctionedSharedPtr<spdlog::logger>::Ptr logger = nullptr;
+  if (name == "binder") {
+    logger = binder::binder_logger;
+  } else if (name == "catalog") {
+    logger = catalog::catalog_logger;
+  } else if (name == "common") {
+    logger = common::common_logger;
+  } else if (name == "execution") {
+    logger = execution::execution_logger;
+  } else if (name == "index") {
+    logger = storage::index_logger;
+  } else if (name == "messenger") {
+    logger = messenger::messenger_logger;
+  } else if (name == "metrics") {
+    logger = metrics::metrics_logger;
+  } else if (name == "modelserver") {
+    logger = modelserver::model_server_logger;
+  } else if (name == "network") {
+    logger = network::network_logger;
+  } else if (name == "optimizer") {
+    logger = optimizer::optimizer_logger;
+  } else if (name == "parser") {
+    logger = parser::parser_logger;
+  } else if (name == "replication") {
+    logger = replication::replication_logger;
+  } else if (name == "selfdriving") {
+    logger = selfdriving::selfdriving_logger;
+  } else if (name == "settings") {
+    logger = settings::settings_logger;
+  } else if (name == "storage") {
+    logger = storage::storage_logger;
+  } else if (name == "transaction") {
+    logger = transaction::transaction_logger;
+  }
+  return logger;
+}
+
 }  // namespace noisepage

--- a/src/loggers/loggers_util.cpp
+++ b/src/loggers/loggers_util.cpp
@@ -89,6 +89,7 @@ std::optional<spdlog::level::level_enum> LoggersUtil::GetLevel(const std::string
 
 common::SanctionedSharedPtr<spdlog::logger>::Ptr LoggersUtil::GetLogger(const std::string_view &name) {
   common::SanctionedSharedPtr<spdlog::logger>::Ptr logger = nullptr;
+#ifdef NOISEPAGE_USE_LOGGING
   if (name == "binder") {
     logger = binder::binder_logger;
   } else if (name == "catalog") {
@@ -122,6 +123,7 @@ common::SanctionedSharedPtr<spdlog::logger>::Ptr LoggersUtil::GetLogger(const st
   } else if (name == "transaction") {
     logger = transaction::transaction_logger;
   }
+#endif
   return logger;
 }
 

--- a/src/settings/settings_callbacks.cpp
+++ b/src/settings/settings_callbacks.cpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "loggers/loggers_util.h"
 #include "main/db_main.h"
 
 namespace noisepage::settings {
@@ -176,9 +177,12 @@ void Callbacks::MetricsQueryTrace(void *const old_value, void *const new_value, 
 void Callbacks::MetricsQueryTraceOutput(void *const old_value, void *const new_value, DBMain *const db_main,
                                         common::ManagedPointer<common::ActionContext> action_context) {
   action_context->SetState(common::ActionState::IN_PROGRESS);
-  auto output = static_cast<metrics::MetricsOutput>(
-      metrics::MetricsUtil::FromMetricsOutputString(*static_cast<std::string *>(new_value)));
-  db_main->GetMetricsManager()->SetMetricOutput(metrics::MetricsComponent::QUERY_TRACE, output);
+  auto metrics_output = metrics::MetricsUtil::FromMetricsOutputString(*static_cast<std::string_view *>(new_value));
+  if (metrics_output == std::nullopt) {
+    action_context->SetState(common::ActionState::FAILURE);
+    return;
+  }
+  db_main->GetMetricsManager()->SetMetricOutput(metrics::MetricsComponent::QUERY_TRACE, *metrics_output);
   action_context->SetState(common::ActionState::SUCCESS);
 }
 
@@ -208,5 +212,55 @@ void Callbacks::PilotEnablePlanning(void *const old_value, void *const new_value
     db_main->GetPilotThread()->DisablePilot();
   action_context->SetState(common::ActionState::SUCCESS);
 }
+
+#define SETTINGS_GENERATE_LOGGER_CALLBACK(component)                                                     \
+  void Callbacks::LogLevelSet##component(void *old_value, void *new_value, DBMain *db_main,              \
+                                         common::ManagedPointer<common::ActionContext> action_context) { \
+    action_context->SetState(common::ActionState::IN_PROGRESS);                                          \
+    auto level = *static_cast<std::string_view *>(new_value);                                            \
+    auto level_val = LoggersUtil::GetLevel(level);                                                       \
+    auto logger = LoggersUtil::GetLogger(#component);                                                    \
+                                                                                                         \
+    if (!level_val.has_value() || logger == nullptr) {                                                   \
+      action_context->SetState(common::ActionState::FAILURE);                                            \
+      return;                                                                                            \
+    }                                                                                                    \
+                                                                                                         \
+    logger->set_level(*level_val);                                                                       \
+    action_context->SetState(common::ActionState::SUCCESS);                                              \
+  }
+
+void Callbacks::LogLevelSetbinder(void *old_value, void *new_value, DBMain *db_main,
+                                  common::ManagedPointer<common::ActionContext> action_context) {
+  action_context->SetState(common::ActionState::IN_PROGRESS);
+  auto level = *static_cast<std::string_view *>(new_value);
+  std::cout << level << '\n';
+  auto level_val = LoggersUtil::GetLevel(level);
+  auto logger = LoggersUtil::GetLogger("binder");
+  if (!level_val.has_value() || logger == nullptr) {
+    action_context->SetState(common::ActionState::FAILURE);
+    return;
+  }
+  logger->set_level(*level_val);
+  action_context->SetState(common::ActionState::SUCCESS);
+}
+// SETTINGS_GENERATE_LOGGER_CALLBACK(binder)
+SETTINGS_GENERATE_LOGGER_CALLBACK(catalog)
+SETTINGS_GENERATE_LOGGER_CALLBACK(common)
+SETTINGS_GENERATE_LOGGER_CALLBACK(execution)
+SETTINGS_GENERATE_LOGGER_CALLBACK(index)
+SETTINGS_GENERATE_LOGGER_CALLBACK(messenger)
+SETTINGS_GENERATE_LOGGER_CALLBACK(metrics)
+SETTINGS_GENERATE_LOGGER_CALLBACK(modelserver)
+SETTINGS_GENERATE_LOGGER_CALLBACK(network)
+SETTINGS_GENERATE_LOGGER_CALLBACK(optimizer)
+SETTINGS_GENERATE_LOGGER_CALLBACK(parser)
+SETTINGS_GENERATE_LOGGER_CALLBACK(replication)
+SETTINGS_GENERATE_LOGGER_CALLBACK(selfdriving)
+SETTINGS_GENERATE_LOGGER_CALLBACK(settings)
+SETTINGS_GENERATE_LOGGER_CALLBACK(storage)
+SETTINGS_GENERATE_LOGGER_CALLBACK(transaction)
+
+#undef SETTINGS_GENERATE_LOGGER_CALLBACK
 
 }  // namespace noisepage::settings

--- a/src/settings/settings_callbacks.cpp
+++ b/src/settings/settings_callbacks.cpp
@@ -230,21 +230,7 @@ void Callbacks::PilotEnablePlanning(void *const old_value, void *const new_value
     action_context->SetState(common::ActionState::SUCCESS);                                              \
   }
 
-void Callbacks::LogLevelSetbinder(void *old_value, void *new_value, DBMain *db_main,
-                                  common::ManagedPointer<common::ActionContext> action_context) {
-  action_context->SetState(common::ActionState::IN_PROGRESS);
-  auto level = *static_cast<std::string_view *>(new_value);
-  std::cout << level << '\n';
-  auto level_val = LoggersUtil::GetLevel(level);
-  auto logger = LoggersUtil::GetLogger("binder");
-  if (!level_val.has_value() || logger == nullptr) {
-    action_context->SetState(common::ActionState::FAILURE);
-    return;
-  }
-  logger->set_level(*level_val);
-  action_context->SetState(common::ActionState::SUCCESS);
-}
-// SETTINGS_GENERATE_LOGGER_CALLBACK(binder)
+SETTINGS_GENERATE_LOGGER_CALLBACK(binder)
 SETTINGS_GENERATE_LOGGER_CALLBACK(catalog)
 SETTINGS_GENERATE_LOGGER_CALLBACK(common)
 SETTINGS_GENERATE_LOGGER_CALLBACK(execution)

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -30,12 +30,14 @@
 #include "optimizer/statistics/stats_storage.h"
 #include "parser/drop_statement.h"
 #include "parser/explain_statement.h"
+#include "parser/expression/constant_value_expression.h"
 #include "parser/postgresparser.h"
 #include "parser/variable_set_statement.h"
 #include "parser/variable_show_statement.h"
 #include "planner/plannodes/abstract_plan_node.h"
 #include "planner/plannodes/analyze_plan_node.h"
 #include "settings/settings_manager.h"
+#include "settings/settings_param.h"
 #include "storage/recovery/replication_log_provider.h"
 #include "traffic_cop/traffic_cop_defs.h"
 #include "traffic_cop/traffic_cop_util.h"
@@ -225,16 +227,19 @@ TrafficCopResult TrafficCop::ExecuteShowStatement(
   const auto &show_stmt UNUSED_ATTRIBUTE =
       statement->RootStatement().CastManagedPointerTo<parser::VariableShowStatement>();
 
-  NOISEPAGE_ASSERT(show_stmt->GetName() == "transaction_isolation", "Nothing else is supported right now.");
+  const std::string &param_name = show_stmt->GetName();
+  settings::Param param = settings_manager_->GetParam(param_name);
+  const settings::ParamInfo &param_info = settings_manager_->GetParamInfo(param);
+  std::string param_val = param_info.GetValue().ToString();
 
   auto expr = std::make_unique<parser::ConstantValueExpression>(type::TypeId::VARCHAR);
-  expr->SetAlias("transaction_isolation");
+  expr->SetAlias(param_name);
   std::vector<noisepage::planner::OutputSchema::Column> cols;
-  cols.emplace_back("transaction_isolation", type::TypeId::VARCHAR, std::move(expr));
-  execution::sql::StringVal dummy_result("snapshot isolation");
+  cols.emplace_back(param_name, type::TypeId::VARCHAR, std::move(expr));
+  execution::sql::StringVal result{param_val.c_str()};
 
   out->WriteRowDescription(cols, {network::FieldFormat::text});
-  out->WriteDataRow(reinterpret_cast<const byte *>(&dummy_result), cols, {network::FieldFormat::text});
+  out->WriteDataRow(reinterpret_cast<const byte *>(&result), cols, {network::FieldFormat::text});
   return {ResultType::COMPLETE, 0u};
 }
 


### PR DESCRIPTION
# Heading

Add support for arbitrary SHOW. Add "set log_level_blah".

## Description

Fix #1188.

Added support for arbitrary SHOW.
This requires exposing GetParam from settings -- ok?

Added set log_level_(binder|catalog|etc) support.
e.g., `set log_level_binder = 'debug'`

Also fix set query_trace_metrics_output which would ASAN out if you actually tried to use it.


If anyone has objections to exposing `settings_manager_->GetParam(std::string)` please bring them up.