### PR TITLE
Refactor Tasks to use builders. Do not replicate startup DDL.

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -112,6 +112,9 @@ db_oid_t Catalog::CreateDatabase(const common::ManagedPointer<transaction::Trans
   const db_oid_t db_oid = next_oid_++;
   const auto success = Catalog::CreateDatabase(common::ManagedPointer(txn), name, bootstrap, db_oid);
   if (!success) return INVALID_DATABASE_OID;
+  if (name == DEFAULT_DATABASE) {
+    default_db_oid_ = db_oid;
+  }
   return db_oid;
 }
 

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -113,6 +113,9 @@ class Catalog {
    */
   db_oid_t GetDatabaseOid(common::ManagedPointer<transaction::TransactionContext> txn, const std::string &name);
 
+  /** @return The OID of the default database as named by catalog::DEFAULT_DATABASE. */
+  db_oid_t GetDefaultDatabaseOid() const { return default_db_oid_; }
+
   /**
    * Gets the database-specific catalog object.
    * @param txn for the catalog query
@@ -146,6 +149,7 @@ class Catalog {
   const common::ManagedPointer<storage::BlockStore> catalog_block_store_;
   const common::ManagedPointer<storage::GarbageCollector> garbage_collector_;
   std::atomic<db_oid_t> next_oid_;
+  db_oid_t default_db_oid_;  ///< The OID of the default database as named by catalog::DEFAULT_DATABASE.
 
   storage::SqlTable *databases_;
   storage::index::Index *databases_name_index_;

--- a/src/include/common/future.h
+++ b/src/include/common/future.h
@@ -141,4 +141,10 @@ class Future {
   std::mutex mtx_;
 };
 
+/** Type meant to represent a dummy result value, because a Future<void> doesn't work. */
+struct FutureDummyResult {};
+
+/** A future dummy is used when the caller doesn't care about the result's value. */
+using FutureDummy = Future<FutureDummyResult>;
+
 }  // namespace noisepage::common

--- a/src/include/metrics/abstract_raw_data.h
+++ b/src/include/metrics/abstract_raw_data.h
@@ -5,13 +5,17 @@
 #include "common/macros.h"
 #include "metrics/metrics_defs.h"
 
+namespace noisepage::task {
+class TaskManager;
+}  // namespace noisepage::task
+
+namespace noisepage::transaction {
+struct TransactionPolicy;
+}  // namespace noisepage::transaction
+
 namespace noisepage::util {
 class QueryExecUtil;
 }  // namespace noisepage::util
-
-namespace noisepage::task {
-class TaskManager;
-}
 
 namespace noisepage::metrics {
 /**
@@ -44,10 +48,12 @@ class AbstractRawData {
   virtual MetricsComponent GetMetricType() const = 0;
 
   /**
-   * Writes the data to internal tables
-   * @param task_manager Task manager to submit tasks to
+   * Write the data to internal tables.
+   * @param task_manager    Task manager to submit tasks to.
+   * @param txn_policy      The policy under which data should be written.
    */
-  virtual void ToDB(common::ManagedPointer<task::TaskManager> task_manager) {}
+  virtual void ToDB(common::ManagedPointer<task::TaskManager> task_manager,
+                    const transaction::TransactionPolicy &txn_policy) {}
 
   /**
    * Writes the data to files, and then clears the data

--- a/src/include/metrics/metrics_manager.h
+++ b/src/include/metrics/metrics_manager.h
@@ -113,6 +113,9 @@ class MetricsManager {
     return metrics_output_[static_cast<uint8_t>(component)];
   }
 
+  /** @return The transaction policy under which all metrics data is written. */
+  const transaction::TransactionPolicy &GetTransactionPolicy() const { return txn_policy_; }
+
  private:
   /**
    * Dump aggregated metrics to CSV files.
@@ -135,6 +138,8 @@ class MetricsManager {
 
   std::array<std::vector<bool>, NUM_COMPONENTS> samples_mask_;  // std::vector<bool> may use a bitset for efficiency
   std::array<MetricsOutput, NUM_COMPONENTS> metrics_output_;
+
+  transaction::TransactionPolicy txn_policy_;  ///< Transaction policy for metrics which are written to DB.
 };
 
 }  // namespace noisepage::metrics

--- a/src/include/metrics/query_trace_metric.h
+++ b/src/include/metrics/query_trace_metric.h
@@ -160,7 +160,8 @@ class QueryTraceMetricRawData : public AbstractRawData {
    */
   MetricsComponent GetMetricType() const override { return MetricsComponent::QUERY_TRACE; }
 
-  void ToDB(common::ManagedPointer<task::TaskManager> task_manager) final;
+  void ToDB(common::ManagedPointer<task::TaskManager> task_manager,
+            const transaction::TransactionPolicy &txn_policy) final;
 
   /**
    * Perform a write to the internal tables. Inserts are performed asynchronously on a background thread.
@@ -168,13 +169,14 @@ class QueryTraceMetricRawData : public AbstractRawData {
    * the data out of this class.
    *
    * @param task_manager Task manager to submit jobs to
+   * @param txn_policy The policy under which data should be written.
    * @param write_parameters Whether to write all parameters or not
    * @param write_timestamp Timestamp at which WriteToDB was invoked
    * @param out_metadata Pass out cached query metadata
    * @param out_params Pass out cached parameters
    */
-  void WriteToDB(common::ManagedPointer<task::TaskManager> task_manager, bool write_parameters,
-                 uint64_t write_timestamp,
+  void WriteToDB(common::ManagedPointer<task::TaskManager> task_manager,
+                 const transaction::TransactionPolicy &txn_policy, bool write_parameters, uint64_t write_timestamp,
                  std::unordered_map<execution::query_id_t, QueryTraceMetadata::QueryMetadata> *out_metadata,
                  std::unordered_map<execution::query_id_t, std::vector<std::string>> *out_params);
 

--- a/src/include/self_driving/planning/pilot.h
+++ b/src/include/self_driving/planning/pilot.h
@@ -11,7 +11,7 @@
 #include <utility>
 #include <vector>
 
-#include "catalog/catalog.h"
+#include "catalog/catalog_defs.h"
 #include "common/action_context.h"
 #include "common/macros.h"
 #include "common/managed_pointer.h"

--- a/src/include/self_driving/planning/pilot.h
+++ b/src/include/self_driving/planning/pilot.h
@@ -24,33 +24,37 @@
 #include "self_driving/planning/planning_context.h"
 
 namespace noisepage {
+namespace catalog {
+class Catalog;
+}  // namespace catalog
+
 namespace messenger {
 class Messenger;
-}
+}  // namespace messenger
 
 namespace metrics {
 class MetricsThread;
-}
+}  // namespace metrics
 
 namespace modelserver {
 class ModelServerManager;
-}
+}  // namespace modelserver
 
 namespace optimizer {
 class StatsStorage;
-}
+}  // namespace optimizer
 
 namespace planner {
 class AbstractPlanNode;
-}
+}  // namespace planner
 
 namespace settings {
 class SettingsManager;
-}
+}  // namespace settings
 
 namespace transaction {
 class TransactionManager;
-}
+}  // namespace transaction
 
 namespace util {
 class QueryExecUtil;
@@ -58,8 +62,7 @@ class QueryExecUtil;
 
 namespace task {
 class TaskManager;
-}
-
+}  // namespace task
 }  // namespace noisepage
 
 namespace noisepage::selfdriving::pilot {

--- a/src/include/self_driving/planning/planning_context.h
+++ b/src/include/self_driving/planning/planning_context.h
@@ -73,17 +73,9 @@ class PlanningContext {
                   common::ManagedPointer<optimizer::StatsStorage> stats_storage,
                   common::ManagedPointer<transaction::TransactionManager> txn_manager,
                   std::unique_ptr<util::QueryExecUtil> query_exec_util,
-                  common::ManagedPointer<task::TaskManager> task_manager)
-      : ou_model_save_path_(std::move(ou_model_save_path)),
-        interference_model_save_path_(std::move(interference_model_save_path)),
-        catalog_(catalog),
-        metrics_thread_(metrics_thread),
-        model_server_manager_(model_server_manager),
-        settings_manager_(settings_manager),
-        stats_storage_(stats_storage),
-        txn_manager_(txn_manager),
-        query_exec_util_(std::move(query_exec_util)),
-        task_manager_(task_manager) {}
+                  common::ManagedPointer<task::TaskManager> task_manager);
+
+  ~PlanningContext();
 
   /** @brief Getter for ou_model_save_path */
   const std::string &GetOuModelSavePath() const { return ou_model_save_path_; }

--- a/src/include/self_driving/planning/planning_context.h
+++ b/src/include/self_driving/planning/planning_context.h
@@ -112,7 +112,9 @@ class PlanningContext {
   common::ManagedPointer<transaction::TransactionManager> GetTxnManager() const { return txn_manager_; }
 
   /** @brief Getter for query_exec_util_ */
-  const std::unique_ptr<util::QueryExecUtil> &GetQueryExecUtil() const { return query_exec_util_; }
+  common::ManagedPointer<util::QueryExecUtil> GetQueryExecUtil() const {
+    return common::ManagedPointer(query_exec_util_);
+  }
 
   /** @brief Getter for task_manager_ */
   common::ManagedPointer<task::TaskManager> GetTaskManager() const { return task_manager_; }

--- a/src/include/task/task.h
+++ b/src/include/task/task.h
@@ -57,7 +57,7 @@ class Task {
       query_text_ = std::move(query_text);
       return *dynamic_cast<ConcreteType *>(this);
     }
-    /** (Optional) Set the policy for the transaction that this Task will be executed in. */
+    /** Set the policy for the transaction that this Task will be executed in. */
     ConcreteType &SetTransactionPolicy(const transaction::TransactionPolicy policy) {
       policy_ = policy;
       return *dynamic_cast<ConcreteType *>(this);
@@ -70,10 +70,9 @@ class Task {
 
    protected:
     std::optional<catalog::db_oid_t> db_oid_{std::nullopt};  ///< The database to execute the task in.
-    std::optional<std::string> query_text_{
-        std::nullopt};                       ///< The query text to be executed. Must be a DDL statement or SET command.
-    transaction::TransactionPolicy policy_;  ///< The policy for the transaction that this Task is executed in.
-    common::ManagedPointer<common::FutureDummy> sync_;  ///< Future* that the caller may block on.
+    std::optional<std::string> query_text_{std::nullopt};    ///< The query text to be executed.
+    std::optional<transaction::TransactionPolicy> policy_;   ///< The policy for this Task's transaction.
+    common::ManagedPointer<common::FutureDummy> sync_;       ///< Future* that the caller may block on.
   };
 
   /** Destructor. */

--- a/src/include/task/task_manager.h
+++ b/src/include/task/task_manager.h
@@ -63,6 +63,9 @@ class TaskManager : public common::DedicatedThreadOwner {
   bool OnThreadOffered() override { return false; }
   bool OnThreadRemoval(common::ManagedPointer<common::DedicatedThreadTask> task) override { return true; }
 
+  /** @return The database being accessed by this task manager. */
+  catalog::db_oid_t GetDatabaseOid() const;
+
  private:
   friend class TaskRunner;
 

--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -212,7 +212,9 @@ class TransactionContext {
 
   /** Set the replication policy of the entire transaction. */
   void SetReplicationPolicy(ReplicationPolicy replication_policy) {
-    NOISEPAGE_ASSERT(durability_policy_ != DurabilityPolicy::DISABLE, "Replication needs durability enabled.");
+    NOISEPAGE_ASSERT(
+        replication_policy == ReplicationPolicy::DISABLE || durability_policy_ != DurabilityPolicy::DISABLE,
+        "Replication needs durability enabled.");
     replication_policy_ = replication_policy;
   }
 

--- a/src/include/util/query_exec_util.h
+++ b/src/include/util/query_exec_util.h
@@ -13,6 +13,7 @@
 #include "execution/exec_defs.h"
 #include "planner/plannodes/output_schema.h"
 #include "type/type_id.h"
+#include "util/util_defs.h"
 
 namespace noisepage::transaction {
 class TransactionContext;
@@ -56,13 +57,6 @@ class Statement;
 namespace noisepage::util {
 
 /**
- * Signature of a function that is capable of processing rows retrieved
- * from ExecuteDML or ExecuteQuery. This function is invoked once per
- * row, with the argument being a row's attributes.
- */
-using TupleFunction = std::function<void(const std::vector<execution::sql::Val *> &)>;
-
-/**
  * Utility class for query execution. This class is not thread-safe.
  *
  * A QueryExecUtil only supports running 1 transaction at a time. If multiple
@@ -104,7 +98,7 @@ class QueryExecUtil {
    * @note It is the caller's responsibility to invoke UseTransaction(nullptr)
    * once the transaction no longer requires this utility.
    *
-   * @param db_oid Database OID to use (INVALID_DATABASE_OID for default)
+   * @param db_oid Database OID to use
    * @param txn Transaction to use
    */
   void UseTransaction(catalog::db_oid_t db_oid, common::ManagedPointer<transaction::TransactionContext> txn);
@@ -216,6 +210,9 @@ class QueryExecUtil {
    */
   std::string GetError() { return error_msg_; }
 
+  /** @return The database being accessed. */
+  catalog::db_oid_t GetDatabaseOid() const { return db_oid_; }
+
  private:
   void ResetError();
   void SetDatabase(catalog::db_oid_t db_oid);
@@ -227,7 +224,7 @@ class QueryExecUtil {
   uint64_t optimizer_timeout_;
 
   /** Database being accessed */
-  catalog::db_oid_t db_oid_{catalog::INVALID_DATABASE_OID};
+  catalog::db_oid_t db_oid_;
   bool own_txn_ = false;
   transaction::TransactionContext *txn_ = nullptr;
 

--- a/src/include/util/util_defs.h
+++ b/src/include/util/util_defs.h
@@ -3,7 +3,7 @@
 #include <vector>
 
 namespace noisepage::execution::sql {
-class Val;
+struct Val;
 }  // namespace noisepage::execution::sql
 
 namespace noisepage::util {

--- a/src/include/util/util_defs.h
+++ b/src/include/util/util_defs.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <vector>
+
+namespace noisepage::execution::sql {
+class Val;
+}  // namespace noisepage::execution::sql
+
+namespace noisepage::util {
+
+/**
+ * Signature of a function that is capable of processing rows retrieved
+ * from ExecuteDML or ExecuteQuery. This function is invoked once per
+ * row, with the argument being a row's attributes.
+ */
+using TupleFunction = std::function<void(const std::vector<execution::sql::Val *> &)>;
+
+}  // namespace noisepage::util

--- a/src/main/db_main.cpp
+++ b/src/main/db_main.cpp
@@ -4,53 +4,59 @@
 #include "settings/settings_defs.h"  // NOLINT
 #undef __SETTING_GFLAGS_DEFINE__     // NOLINT
 
+#include "common/error/exception.h"
 #include "common/future.h"
 #include "execution/execution_util.h"
 #include "loggers/common_logger.h"
-#include "optimizer/cost_model/trivial_cost_model.h"
-#include "storage/recovery/replication_log_provider.h"
 #include "task/task.h"
 
 namespace noisepage {
 
 void DBMain::TryLoadStartupDDL() {
-  // Load startup ddls
+  NOISEPAGE_ASSERT(settings_manager_ != nullptr, "Startup DDL requires settings manager for startup DDL path.");
+  NOISEPAGE_ASSERT(task_manager_ != nullptr, "Startup DDL requires task manager for startup DDL execution.");
+
+  // Parse the startup DDL.
   std::vector<std::string> startup_ddls;
-  if (settings_manager_ != nullptr) {
-    auto input = settings_manager_->GetString(settings::Param::startup_ddl_path);
-    std::ifstream ddl_file(input);
-    if (ddl_file.is_open() && ddl_file.good()) {
-      std::string input_line;
-      while (std::getline(ddl_file, input_line)) {
-        if (input_line.empty()) {
-          // Skip the empty line
-          continue;
-        }
-
-        if (input_line.size() > 2 && input_line[0] == '-' && input_line[1] == '-') {
-          // Skip comments of form '-- comment'
-          continue;
-        }
-
-        startup_ddls.emplace_back(std::move(input_line));
-      }
+  {
+    auto startup_ddl_location = settings_manager_->GetString(settings::Param::startup_ddl_path);
+    std::ifstream ddl_file(startup_ddl_location);
+    if (!(ddl_file.is_open() && ddl_file.good())) {
+      throw EXECUTION_EXCEPTION(fmt::format("Error locating startup DDL at \"{}\".", startup_ddl_location),
+                                common::ErrorCode::ERRCODE_INTERNAL_ERROR);
     }
-  } else {
-    COMMON_LOG_WARN("TryLoadStartupDDL() invoked without SettingsManager");
+    std::string input_line;
+    while (std::getline(ddl_file, input_line)) {
+      bool is_empty = input_line.empty();                                                       // Empty lines.
+      bool is_comment = input_line.size() > 2 && input_line[0] == '-' && input_line[1] == '-';  // -- comments.
+      // Skip certain types of lines lines.
+      if (is_empty || is_comment) {
+        continue;
+      }
+      // Otherwise, execute the SQL command, which is assumed to fit on one line.
+      startup_ddls.emplace_back(std::move(input_line));
+    }
   }
 
-  if (!startup_ddls.empty() && task_manager_ != nullptr) {
-    for (auto &ddl : startup_ddls) {
-      common::Future<task::DummyResult> sync;
-      task_manager_->AddTask(
-          std::make_unique<task::TaskDDL>(catalog::INVALID_DATABASE_OID, ddl, common::ManagedPointer(&sync)));
+  catalog::db_oid_t default_db_oid = catalog_layer_->GetCatalog()->GetDefaultDatabaseOid();
 
-      auto future_result = sync.DangerousWait();
-      NOISEPAGE_ASSERT(future_result.second, "Error encountered executing startup DDL.");
-      (void)future_result;
+  auto policy = txn_layer_->GetTransactionManager()->GetDefaultTransactionPolicy();
+  policy.replication_ = transaction::ReplicationPolicy::DISABLE;
+
+  // Run the startup DDL commands, waiting for successful completion one-by-one.
+  for (auto &ddl : startup_ddls) {
+    COMMON_LOG_INFO("Executing startup DDL: {}", ddl);
+    common::FutureDummy sync;
+    task_manager_->AddTask(task::TaskDDL::Builder()
+                               .SetDatabaseOid(default_db_oid)
+                               .SetFuture(common::ManagedPointer(&sync))
+                               .SetQueryText(std::move(ddl))
+                               .SetTransactionPolicy(policy)
+                               .Build());
+    auto future_result = sync.DangerousWait();
+    if (!future_result.second) {
+      throw EXECUTION_EXCEPTION("Error executing startup DDL.", common::ErrorCode::ERRCODE_INTERNAL_ERROR);
     }
-  } else if (task_manager_ == nullptr) {
-    COMMON_LOG_WARN("TryLoadStartupDDL() invoked without TaskManager");
   }
 }
 
@@ -89,10 +95,10 @@ void DBMain::ForceShutdown() {
   }
 
   // Shutdown the following resources to safely release the task manager.
-  (void)pilot_thread_.reset();
-  (void)pilot_.reset();
-  (void)metrics_thread_.reset();
-  (void)task_manager_.reset();
+  pilot_thread_.reset();
+  pilot_.reset();
+  metrics_thread_.reset();
+  task_manager_.reset();
 
   if (network_layer_ != DISABLED && network_layer_->GetServer()->Running()) {
     network_layer_->GetServer()->StopServer();

--- a/src/main/db_main.cpp
+++ b/src/main/db_main.cpp
@@ -49,9 +49,9 @@ void DBMain::TryLoadStartupDDL() {
     common::FutureDummy sync;
     task_manager_->AddTask(task::TaskDDL::Builder()
                                .SetDatabaseOid(default_db_oid)
-                               .SetFuture(common::ManagedPointer(&sync))
                                .SetQueryText(std::move(ddl))
                                .SetTransactionPolicy(policy)
+                               .SetFuture(common::ManagedPointer(&sync))
                                .Build());
     auto future_result = sync.DangerousWait();
     if (!future_result.second) {

--- a/src/main/db_main.cpp
+++ b/src/main/db_main.cpp
@@ -45,7 +45,7 @@ void DBMain::TryLoadStartupDDL() {
 
   // Run the startup DDL commands, waiting for successful completion one-by-one.
   for (auto &ddl : startup_ddls) {
-    COMMON_LOG_INFO("Executing startup DDL: {}", ddl);
+    COMMON_LOG_DEBUG("Executing startup DDL: {}", ddl);
     common::FutureDummy sync;
     task_manager_->AddTask(task::TaskDDL::Builder()
                                .SetDatabaseOid(default_db_oid)

--- a/src/metrics/metrics_manager.cpp
+++ b/src/metrics/metrics_manager.cpp
@@ -36,7 +36,9 @@ void OpenFiles(std::vector<std::ofstream> *outfiles) {
   }
 }
 
-MetricsManager::MetricsManager() {
+MetricsManager::MetricsManager()
+    : txn_policy_(transaction::TransactionPolicy{transaction::DurabilityPolicy::SYNC,
+                                                 transaction::ReplicationPolicy::DISABLE}) {
   // construct a bitset of all true (sampling rate 100) by default
   std::vector<bool> samples_mask(100, true);
   for (uint8_t i = 0; i < NUM_COMPONENTS; i++) {
@@ -168,7 +170,7 @@ void MetricsManager::ToOutput(common::ManagedPointer<task::TaskManager> task_man
 
 void MetricsManager::ToDB(uint8_t component, common::ManagedPointer<task::TaskManager> task_manager) const {
   NOISEPAGE_ASSERT(task_manager != nullptr, "MetricsManager::ToDB invoked with null task_manager");
-  aggregated_metrics_[component]->ToDB(task_manager);
+  aggregated_metrics_[component]->ToDB(task_manager, txn_policy_);
 }
 
 void MetricsManager::ToCSV(uint8_t component) const {

--- a/src/metrics/query_trace_metric.cpp
+++ b/src/metrics/query_trace_metric.cpp
@@ -55,16 +55,18 @@ void QueryTraceMetricRawData::SubmitFrequencyRecordJob(uint64_t timestamp,
           .Build());
 }
 
-void QueryTraceMetricRawData::ToDB(common::ManagedPointer<task::TaskManager> task_manager) {
+void QueryTraceMetricRawData::ToDB(common::ManagedPointer<task::TaskManager> task_manager,
+                                   const transaction::TransactionPolicy &txn_policy) {
   // On regular ToDB calls from metrics manager, we don't want to flush the time data or parameters.
   // Only on a forecast interval should we be doing that. Rather, ToDB will write out time-series data
   // only if a segment has elapsed.
   uint64_t timestamp = metrics::MetricsUtil::Now();
-  WriteToDB(task_manager, false, timestamp, nullptr, nullptr);
+  WriteToDB(task_manager, txn_policy, false, timestamp, nullptr, nullptr);
 }
 
 void QueryTraceMetricRawData::WriteToDB(
-    common::ManagedPointer<task::TaskManager> task_manager, bool write_parameters, uint64_t write_timestamp,
+    common::ManagedPointer<task::TaskManager> task_manager, const transaction::TransactionPolicy &txn_policy,
+    bool write_parameters, uint64_t write_timestamp,
     std::unordered_map<execution::query_id_t, QueryTraceMetadata::QueryMetadata> *out_metadata,
     std::unordered_map<execution::query_id_t, std::vector<std::string>> *out_params) {
   NOISEPAGE_ASSERT(task_manager != nullptr, "Task Manager not initialized");

--- a/src/metrics/query_trace_metric.cpp
+++ b/src/metrics/query_trace_metric.cpp
@@ -44,12 +44,15 @@ void QueryTraceMetricRawData::SubmitFrequencyRecordJob(uint64_t timestamp,
 
   // Submit the insert request if not empty
   std::vector<type::TypeId> param_types = {type::TypeId::BIGINT, type::TypeId::INTEGER, type::TypeId::REAL};
-  task_manager->AddTask(task::TaskDML::Builder()
-                            .SetDatabaseOid(task_manager->GetDatabaseOid())
-                            .SetQueryText(std::move(query))
-                            .SetParameters(std::move(params_vec))
-                            .SetParameterTypes(std::move(param_types))
-                            .Build());
+  task_manager->AddTask(
+      task::TaskDML::Builder()
+          .SetDatabaseOid(task_manager->GetDatabaseOid())
+          .SetQueryText(std::move(query))
+          // TODO(WAN): #1595
+          .SetTransactionPolicy({transaction::DurabilityPolicy::SYNC, transaction::ReplicationPolicy::DISABLE})
+          .SetParameters(std::move(params_vec))
+          .SetParameterTypes(std::move(param_types))
+          .Build());
 }
 
 void QueryTraceMetricRawData::ToDB(common::ManagedPointer<task::TaskManager> task_manager) {

--- a/src/self_driving/forecasting/forecaster.cpp
+++ b/src/self_driving/forecasting/forecaster.cpp
@@ -261,7 +261,8 @@ std::unique_ptr<selfdriving::WorkloadForecast> Forecaster::LoadWorkloadForecast(
     if (raw != nullptr) {
       // Perform a flush to database. This will also get any temporary data.
       // This is also used to flush all parameter information at a forecast interval.
-      raw->WriteToDB(task_manager_, true, timestamp, &out_metadata, &out_params);
+      raw->WriteToDB(task_manager_, metrics_thread_->GetMetricsManager()->GetTransactionPolicy(), true, timestamp,
+                     &out_metadata, &out_params);
 
       // We don't have to worry about flushing the tasks submitted by WriteToDB.
       // The query metadata and parameters that would have been flushed out

--- a/src/self_driving/planning/pilot_util.cpp
+++ b/src/self_driving/planning/pilot_util.cpp
@@ -472,7 +472,7 @@ void PilotUtil::ComputeTableSizeRatios(const pilot::PlanningContext &planning_co
   std::unordered_map<pilot::db_table_oid_pair, uint64_t, pilot::DBTableOidPairHasher> table_sizes;
 
   // Get <table_id, num_rows> pairs with num_rows > 0
-  auto query = fmt::format(
+  std::string query = fmt::format(
       "select starelid, max(stanumrows) as num_rows from pg_statistic group by starelid "
       "having max(stanumrows) > 0;");
 

--- a/src/self_driving/planning/pilot_util.cpp
+++ b/src/self_driving/planning/pilot_util.cpp
@@ -1,6 +1,7 @@
 #include "self_driving/planning/pilot_util.h"
 
 #include "binder/bind_node_visitor.h"
+#include "catalog/catalog_accessor.h"
 #include "common/error/error_code.h"
 #include "common/error/exception.h"
 #include "common/managed_pointer.h"

--- a/src/self_driving/planning/pilot_util.cpp
+++ b/src/self_driving/planning/pilot_util.cpp
@@ -48,7 +48,8 @@ void PilotUtil::ApplyAction(const pilot::PlanningContext &planning_context, cons
   // just pick a random database in PlanningContext
   if (db_oid == catalog::INVALID_DATABASE_OID) db_oid = *planning_context.GetDBOids().begin();
 
-  auto policy = planning_context.GetTxnManager()->GetDefaultTransactionPolicy();
+  common::ManagedPointer<transaction::TransactionManager> txn_manager = planning_context.GetTxnManager();
+  auto policy = txn_manager->GetDefaultTransactionPolicy();
   policy.replication_ = transaction::ReplicationPolicy::DISABLE;
 
   auto query_exec_util = planning_context.GetQueryExecUtil();

--- a/src/self_driving/planning/pilot_util.cpp
+++ b/src/self_driving/planning/pilot_util.cpp
@@ -226,7 +226,11 @@ std::unique_ptr<metrics::PipelineMetricRawData> PilotUtil::CollectPipelineFeatur
               .SetDatabaseOid(db_oid)
               .SetQueryText(std::move(query_text))
               .SetFuture(common::ManagedPointer(&sync))
-              // TODO(WAN): Copying of params and param_types, is that intentional?
+              // Per the discussion in #1594, on the copying of params and param_types, by Lin:
+              // Synchronous tasks don't need copying, but asynchronous tasks may go out of the scope of the original
+              // params and param_types. If this becomes too expensive, we may be able to avoid copying for synchronous
+              // tasks by adding a new API (see the comments at the top of this code block). Addressing the life cycle
+              // issue for asynchronous tasks may be challenging though.
               .SetParameters(*params)
               .SetParameterTypes(*param_types)
               .SetMetricsManager(metrics_manager)

--- a/src/self_driving/planning/pilot_util.cpp
+++ b/src/self_driving/planning/pilot_util.cpp
@@ -35,6 +35,7 @@
 #include "storage/sql_table.h"
 #include "task/task.h"
 #include "task/task_manager.h"
+#include "transaction/transaction_manager.h"
 #include "util/query_exec_util.h"
 
 namespace noisepage::selfdriving::pilot {
@@ -47,8 +48,7 @@ void PilotUtil::ApplyAction(const pilot::PlanningContext &planning_context, cons
   // just pick a random database in PlanningContext
   if (db_oid == catalog::INVALID_DATABASE_OID) db_oid = *planning_context.GetDBOids().begin();
 
-  common::ManagedPointer<transaction::TransactionManager> txn_manager = planning_context.GetTxnManager();
-  auto policy = txn_manager->GetDefaultTransactionPolicy();
+  auto policy = planning_context.GetTxnManager()->GetDefaultTransactionPolicy();
   policy.replication_ = transaction::ReplicationPolicy::DISABLE;
 
   auto query_exec_util = planning_context.GetQueryExecUtil();

--- a/src/self_driving/planning/planning_context.cpp
+++ b/src/self_driving/planning/planning_context.cpp
@@ -6,6 +6,28 @@
 
 namespace noisepage::selfdriving::pilot {
 
+PlanningContext::PlanningContext(std::string ou_model_save_path, std::string interference_model_save_path,
+                                 common::ManagedPointer<catalog::Catalog> catalog,
+                                 common::ManagedPointer<metrics::MetricsThread> metrics_thread,
+                                 common::ManagedPointer<modelserver::ModelServerManager> model_server_manager,
+                                 common::ManagedPointer<settings::SettingsManager> settings_manager,
+                                 common::ManagedPointer<optimizer::StatsStorage> stats_storage,
+                                 common::ManagedPointer<transaction::TransactionManager> txn_manager,
+                                 std::unique_ptr<util::QueryExecUtil> query_exec_util,
+                                 common::ManagedPointer<task::TaskManager> task_manager)
+    : ou_model_save_path_(std::move(ou_model_save_path)),
+      interference_model_save_path_(std::move(interference_model_save_path)),
+      catalog_(catalog),
+      metrics_thread_(metrics_thread),
+      model_server_manager_(model_server_manager),
+      settings_manager_(settings_manager),
+      stats_storage_(stats_storage),
+      txn_manager_(txn_manager),
+      query_exec_util_(std::move(query_exec_util)),
+      task_manager_(task_manager) {}
+
+PlanningContext::~PlanningContext() = default;
+
 void PlanningContext::AddDatabase(catalog::db_oid_t db_oid) {
   auto txn = txn_manager_->BeginTransaction();
   db_oids_.insert(db_oid);

--- a/src/task/task.cpp
+++ b/src/task/task.cpp
@@ -18,7 +18,7 @@ std::unique_ptr<TaskDDL> TaskDDL::Builder::Build() {
   NOISEPAGE_ASSERT(*db_oid_ != catalog::INVALID_DATABASE_OID, "You're doing something hacky. Get a real database OID.");
   NOISEPAGE_ASSERT(query_text_.has_value(), "Query text must be specified.");
   NOISEPAGE_ASSERT(policy_.has_value(), "Transaction policy must be specified.");
-  return std::unique_ptr<TaskDDL>(new TaskDDL(*db_oid_, std::move(*query_text_), *policy_, sync_));
+  return std::make_unique<TaskDDL>(*db_oid_, std::move(*query_text_), *policy_, sync_);
 }
 
 std::unique_ptr<TaskDML> TaskDML::Builder::Build() {
@@ -44,34 +44,42 @@ TaskDML::Builder &TaskDML::Builder::SetCostModel(std::unique_ptr<optimizer::Abst
   cost_model_ = std::move(cost_model);
   return *this;
 }
+
 TaskDML::Builder &TaskDML::Builder::SetParameters(std::vector<std::vector<parser::ConstantValueExpression>> params) {
   params_ = std::move(params);
   return *this;
 }
+
 TaskDML::Builder &TaskDML::Builder::SetParameterTypes(std::vector<type::TypeId> param_types) {
   param_types_ = std::move(param_types);
   return *this;
 }
+
 TaskDML::Builder &TaskDML::Builder::SetMetricsManager(common::ManagedPointer<metrics::MetricsManager> metrics_manager) {
   metrics_manager_ = metrics_manager;
   return *this;
 }
+
 TaskDML::Builder &TaskDML::Builder::SetExecutionSettings(execution::exec::ExecutionSettings settings) {
   settings_ = settings;
   return *this;
 }
+
 TaskDML::Builder &TaskDML::Builder::SetShouldForceAbort(bool should_force_abort) {
   should_force_abort_ = should_force_abort;
   return *this;
 }
+
 TaskDML::Builder &TaskDML::Builder::SetShouldSkipQueryCache(bool should_skip_query_cache) {
   should_skip_query_cache_ = should_skip_query_cache;
   return *this;
 }
+
 TaskDML::Builder &TaskDML::Builder::SetOverrideQueryId(execution::query_id_t query_id) {
   override_qid_ = query_id;
   return *this;
 }
+
 TaskDML::Builder &TaskDML::Builder::SetTupleFn(util::TupleFunction tuple_fn) {
   tuple_fn_ = std::move(tuple_fn);
   return *this;

--- a/src/task/task.cpp
+++ b/src/task/task.cpp
@@ -1,51 +1,140 @@
 #include "task/task.h"
-#include "task/task_manager.h"
+
+#include <utility>
 
 #include "optimizer/cost_model/trivial_cost_model.h"
+#include "parser/expression/constant_value_expression.h"
+#include "task/task_manager.h"
 #include "util/query_exec_util.h"
 
 namespace noisepage::task {
 
+Task::Task(const catalog::db_oid_t db_oid, std::string &&query_text, const transaction::TransactionPolicy policy,
+           const common::ManagedPointer<common::FutureDummy> sync)
+    : db_oid_(db_oid), query_text_(std::move(query_text)), policy_(policy), sync_(sync) {}
+
+std::unique_ptr<TaskDDL> TaskDDL::Builder::Build() {
+  NOISEPAGE_ASSERT(db_oid_.has_value(), "Database OID must be specified.");
+  NOISEPAGE_ASSERT(*db_oid_ != catalog::INVALID_DATABASE_OID, "You're doing something hacky. Get a real database OID.");
+  NOISEPAGE_ASSERT(query_text_.has_value(), "Query text must be specified.");
+  return std::unique_ptr<TaskDDL>(new TaskDDL(*db_oid_, std::move(*query_text_), policy_, sync_));
+}
+
+std::unique_ptr<TaskDML> TaskDML::Builder::Build() {
+  // Sanity checks.
+  NOISEPAGE_ASSERT(db_oid_.has_value(), "Database OID must be specified.");
+  NOISEPAGE_ASSERT(*db_oid_ != catalog::INVALID_DATABASE_OID, "You're doing something hacky. Get a real database OID.");
+  NOISEPAGE_ASSERT(query_text_.has_value(), "Query text must be specified.");
+  NOISEPAGE_ASSERT(!override_qid_.has_value() || should_skip_query_cache_,
+                   "Cannot override query ID without skipping the query cache.");
+  NOISEPAGE_ASSERT(params_.empty() || (params_.at(0).size() == param_types_.size()),
+                   "Parameter types do not match parameters in length.");
+  // Set defaults.
+  cost_model_ = cost_model_ != nullptr ? std::move(cost_model_) : std::make_unique<optimizer::TrivialCostModel>();
+
+  return std::unique_ptr<TaskDML>(new TaskDML(*db_oid_, std::move(*query_text_), policy_, sync_, std::move(cost_model_),
+                                              std::move(params_), std::move(param_types_), settings_, override_qid_,
+                                              metrics_manager_, should_force_abort_, should_skip_query_cache_,
+                                              std::move(tuple_fn_)));
+}
+
+TaskDML::Builder &TaskDML::Builder::SetCostModel(std::unique_ptr<optimizer::AbstractCostModel> cost_model) {
+  cost_model_ = std::move(cost_model);
+  return *this;
+}
+TaskDML::Builder &TaskDML::Builder::SetParameters(std::vector<std::vector<parser::ConstantValueExpression>> params) {
+  params_ = std::move(params);
+  return *this;
+}
+TaskDML::Builder &TaskDML::Builder::SetParameterTypes(std::vector<type::TypeId> param_types) {
+  param_types_ = std::move(param_types);
+  return *this;
+}
+TaskDML::Builder &TaskDML::Builder::SetMetricsManager(common::ManagedPointer<metrics::MetricsManager> metrics_manager) {
+  metrics_manager_ = metrics_manager;
+  return *this;
+}
+TaskDML::Builder &TaskDML::Builder::SetExecutionSettings(execution::exec::ExecutionSettings settings) {
+  settings_ = settings;
+  return *this;
+}
+TaskDML::Builder &TaskDML::Builder::SetShouldForceAbort(bool should_force_abort) {
+  should_force_abort_ = should_force_abort;
+  return *this;
+}
+TaskDML::Builder &TaskDML::Builder::SetShouldSkipQueryCache(bool should_skip_query_cache) {
+  should_skip_query_cache_ = should_skip_query_cache;
+  return *this;
+}
+TaskDML::Builder &TaskDML::Builder::SetOverrideQueryId(execution::query_id_t query_id) {
+  override_qid_ = query_id;
+  return *this;
+}
+TaskDML::Builder &TaskDML::Builder::SetTupleFn(util::TupleFunction tuple_fn) {
+  tuple_fn_ = std::move(tuple_fn);
+  return *this;
+}
+
+TaskDML::TaskDML(catalog::db_oid_t db_oid, std::string &&query_text, transaction::TransactionPolicy policy,
+                 common::ManagedPointer<common::FutureDummy> sync,
+                 std::unique_ptr<optimizer::AbstractCostModel> cost_model,
+                 std::vector<std::vector<parser::ConstantValueExpression>> &&params,
+                 std::vector<type::TypeId> &&param_types, execution::exec::ExecutionSettings settings,
+                 std::optional<execution::query_id_t> override_qid,
+                 common::ManagedPointer<metrics::MetricsManager> metrics_manager, bool should_force_abort,
+                 bool should_skip_query_cache, util::TupleFunction &&tuple_fn)
+    : Task(db_oid, std::move(query_text), policy, sync),
+      cost_model_(std::move(cost_model)),
+      params_(std::move(params)),
+      param_types_(std::move(param_types)),
+      settings_(settings),
+      override_qid_(override_qid),
+      metrics_manager_(metrics_manager),
+      should_force_abort_(should_force_abort),
+      should_skip_query_cache_(should_skip_query_cache),
+      tuple_fn_(std::move(tuple_fn)) {}
+
 void TaskDDL::Execute(common::ManagedPointer<util::QueryExecUtil> query_exec_util,
                       common::ManagedPointer<task::TaskManager> task_manager) {
   query_exec_util->BeginTransaction(db_oid_);
-  bool status = query_exec_util->ExecuteDDL(query_text_, false);
-  query_exec_util->EndTransaction(status);
+  bool ddl_ok = query_exec_util->ExecuteDDL(query_text_, false);
+  query_exec_util->EndTransaction(ddl_ok);
 
-  if (sync_) {
-    if (status)
-      sync_->Success(DummyResult{});
-    else
+  if (sync_ != DISABLED) {
+    if (ddl_ok) {
+      sync_->Success(common::FutureDummyResult{});
+    } else {
       sync_->Fail(query_exec_util->GetError());
+    }
   }
 }
 
 void TaskDML::Execute(common::ManagedPointer<util::QueryExecUtil> query_exec_util,
                       common::ManagedPointer<task::TaskManager> task_manager) {
-  bool result = true;
+  bool dml_ok = true;  // Track whether the DML was executed successfully.
   query_exec_util->BeginTransaction(db_oid_);
 
-  if (skip_query_cache_) {
+  if (should_skip_query_cache_) {
     // Skipping the query cache is implemented by invalidating the plan
     // and then invalidating the plan entry after execution.
     query_exec_util->ClearPlan(query_text_);
   }
 
   if (params_.empty()) {
-    result = query_exec_util->ExecuteDML(query_text_, nullptr, nullptr, tuple_fn_, metrics_manager_,
-                                         std::make_unique<optimizer::TrivialCostModel>(), override_qid_, settings_);
+    dml_ok = query_exec_util->ExecuteDML(query_text_, nullptr, nullptr, tuple_fn_, metrics_manager_,
+                                         std::move(cost_model_), override_qid_, settings_);
   } else {
     std::vector<parser::ConstantValueExpression> &params_0 = params_[0];
-    result = query_exec_util->CompileQuery(query_text_, common::ManagedPointer(&params_0),
+    dml_ok = query_exec_util->CompileQuery(query_text_, common::ManagedPointer(&params_0),
                                            common::ManagedPointer(&param_types_), std::move(cost_model_), override_qid_,
                                            settings_);
 
     // Execute with specified parameters only if compilation succeeded
-    if (result) {
+    if (dml_ok) {
       for (auto &param_vec : params_) {
-        if (!result) break;
+        if (!dml_ok) break;
 
-        result &= query_exec_util->ExecuteQuery(query_text_, tuple_fn_, common::ManagedPointer(&param_vec),
+        dml_ok &= query_exec_util->ExecuteQuery(query_text_, tuple_fn_, common::ManagedPointer(&param_vec),
                                                 metrics_manager_, settings_);
       }
     }
@@ -54,17 +143,19 @@ void TaskDML::Execute(common::ManagedPointer<util::QueryExecUtil> query_exec_uti
     // query_exec_util->ClearPlans();
   }
 
-  if (skip_query_cache_) {
+  if (should_skip_query_cache_) {
     // Don't save this query plan
     query_exec_util->ClearPlan(query_text_);
   }
 
-  query_exec_util->EndTransaction(result && !force_abort_);
-  if (sync_) {
-    if (result)
-      sync_->Success(DummyResult{});
-    else
+  query_exec_util->EndTransaction(dml_ok && !should_force_abort_);
+
+  if (sync_ != DISABLED) {
+    if (dml_ok) {
+      sync_->Success(common::FutureDummyResult{});
+    } else {
       sync_->Fail(query_exec_util->GetError());
+    }
   }
 }
 

--- a/src/task/task.cpp
+++ b/src/task/task.cpp
@@ -34,10 +34,10 @@ std::unique_ptr<TaskDML> TaskDML::Builder::Build() {
   // Set defaults.
   cost_model_ = cost_model_ != nullptr ? std::move(cost_model_) : std::make_unique<optimizer::TrivialCostModel>();
 
-  return std::unique_ptr<TaskDML>(new TaskDML(*db_oid_, std::move(*query_text_), *policy_, sync_, std::move(cost_model_),
-                                              std::move(params_), std::move(param_types_), settings_, override_qid_,
-                                              metrics_manager_, should_force_abort_, should_skip_query_cache_,
-                                              std::move(tuple_fn_)));
+  return std::unique_ptr<TaskDML>(new TaskDML(*db_oid_, std::move(*query_text_), *policy_, sync_,
+                                              std::move(cost_model_), std::move(params_), std::move(param_types_),
+                                              settings_, override_qid_, metrics_manager_, should_force_abort_,
+                                              should_skip_query_cache_, std::move(tuple_fn_)));
 }
 
 TaskDML::Builder &TaskDML::Builder::SetCostModel(std::unique_ptr<optimizer::AbstractCostModel> cost_model) {

--- a/src/task/task.cpp
+++ b/src/task/task.cpp
@@ -18,7 +18,7 @@ std::unique_ptr<TaskDDL> TaskDDL::Builder::Build() {
   NOISEPAGE_ASSERT(*db_oid_ != catalog::INVALID_DATABASE_OID, "You're doing something hacky. Get a real database OID.");
   NOISEPAGE_ASSERT(query_text_.has_value(), "Query text must be specified.");
   NOISEPAGE_ASSERT(policy_.has_value(), "Transaction policy must be specified.");
-  return std::make_unique<TaskDDL>(*db_oid_, std::move(*query_text_), *policy_, sync_);
+  return std::unique_ptr<TaskDDL>(new TaskDDL(*db_oid_, std::move(*query_text_), *policy_, sync_));
 }
 
 std::unique_ptr<TaskDML> TaskDML::Builder::Build() {

--- a/src/task/task_manager.cpp
+++ b/src/task/task_manager.cpp
@@ -32,6 +32,8 @@ void TaskManager::AddTask(std::unique_ptr<Task> task) {
   queue_cv_.notify_one();
 }
 
+catalog::db_oid_t TaskManager::GetDatabaseOid() const { return master_util_->GetDatabaseOid(); }
+
 void TaskManager::WaitForFlush() {
   std::unique_lock<std::mutex> lock(queue_mutex_);
   if (queue_.empty() && busy_workers_ == 0) {

--- a/src/util/query_exec_util.cpp
+++ b/src/util/query_exec_util.cpp
@@ -42,7 +42,8 @@ QueryExecUtil::QueryExecUtil(common::ManagedPointer<transaction::TransactionMana
       catalog_(catalog),
       settings_(settings),
       stats_(stats),
-      optimizer_timeout_(optimizer_timeout) {}
+      optimizer_timeout_(optimizer_timeout),
+      db_oid_(catalog->GetDefaultDatabaseOid()) {}
 
 void QueryExecUtil::ClearPlans() {
   schemas_.clear();
@@ -57,13 +58,8 @@ void QueryExecUtil::ClearPlan(const std::string &query) {
 void QueryExecUtil::ResetError() { error_msg_ = ""; }
 
 void QueryExecUtil::SetDatabase(catalog::db_oid_t db_oid) {
-  if (db_oid != catalog::INVALID_DATABASE_OID) {
-    db_oid_ = db_oid;
-  } else {
-    auto *txn = txn_manager_->BeginTransaction();
-    db_oid_ = catalog_->GetDatabaseOid(common::ManagedPointer(txn), catalog::DEFAULT_DATABASE);
-    txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
-  }
+  NOISEPAGE_ASSERT(db_oid != catalog::INVALID_DATABASE_OID, "Get a real database OID.");
+  db_oid_ = db_oid;
 }
 
 void QueryExecUtil::UseTransaction(catalog::db_oid_t db_oid,
@@ -106,12 +102,8 @@ std::unique_ptr<network::Statement> QueryExecUtil::PlanStatement(
     auto parse_tree = parser::PostgresParser::BuildParseTree(query_tmp);
     statement = std::make_unique<network::Statement>(std::move(query_tmp), std::move(parse_tree));
   } catch (std::exception &e) {
-    std::ostringstream ss;
-    ss << "QueryExecUtil::PlanStatement caught error ";
-    ss << e.what() << " when parsing " << query << "\n";
-    error_msg_ = ss.str();
-
-    // Catched a parsing error
+    error_msg_ = fmt::format(R"(QueryExecUtil::PlanStatement encountered error "{}" while parsing query "{}".)",
+                             e.what(), query);
     COMMON_LOG_ERROR(error_msg_);
     return nullptr;
   }

--- a/src/util/self_driving_recording_util.cpp
+++ b/src/util/self_driving_recording_util.cpp
@@ -1,4 +1,5 @@
 #include "util/self_driving_recording_util.h"
+
 #include "catalog/catalog_defs.h"
 #include "execution/sql/value_util.h"
 #include "optimizer/cost_model/trivial_cost_model.h"
@@ -37,9 +38,12 @@ void SelfDrivingRecordingUtil::RecordQueryMetadata(
 
   if (!params_vec.empty()) {
     std::string query = SelfDrivingRecordingUtil::QUERY_TEXT_INSERT_STMT;
-    task_manager->AddTask(std::make_unique<task::TaskDML>(catalog::INVALID_DATABASE_OID, query,
-                                                          std::make_unique<optimizer::TrivialCostModel>(), false,
-                                                          std::move(params_vec), std::move(param_types)));
+    task_manager->AddTask(task::TaskDML::Builder()
+                              .SetDatabaseOid(task_manager->GetDatabaseOid())
+                              .SetQueryText(std::move(query))
+                              .SetParameters(std::move(params_vec))
+                              .SetParameterTypes(std::move(param_types))
+                              .Build());
   }
 }
 
@@ -73,9 +77,12 @@ void SelfDrivingRecordingUtil::RecordQueryParameters(
 
   if (!params_vec.empty()) {
     std::string query_text = SelfDrivingRecordingUtil::QUERY_PARAMETERS_INSERT_STMT;
-    task_manager->AddTask(std::make_unique<task::TaskDML>(catalog::INVALID_DATABASE_OID, query_text,
-                                                          std::make_unique<optimizer::TrivialCostModel>(), false,
-                                                          std::move(params_vec), std::move(param_types)));
+    task_manager->AddTask(task::TaskDML::Builder()
+                              .SetDatabaseOid(task_manager->GetDatabaseOid())
+                              .SetQueryText(std::move(query_text))
+                              .SetParameters(std::move(params_vec))
+                              .SetParameterTypes(std::move(param_types))
+                              .Build());
   }
 }
 
@@ -119,9 +126,14 @@ void SelfDrivingRecordingUtil::RecordForecastClusters(uint64_t timestamp_to_reco
     std::vector<type::TypeId> param_types = {type::TypeId::BIGINT, type::TypeId::INTEGER, type::TypeId::INTEGER,
                                              type::TypeId::INTEGER};
     std::string query_text = SelfDrivingRecordingUtil::FORECAST_CLUSTERS_INSERT_STMT;
-    task_manager->AddTask(std::make_unique<task::TaskDML>(catalog::INVALID_DATABASE_OID, query_text,
-                                                          std::make_unique<optimizer::TrivialCostModel>(), false,
-                                                          std::move(clusters_params_vec), std::move(param_types)));
+    task_manager->AddTask(
+
+        task::TaskDML::Builder()
+            .SetDatabaseOid(task_manager->GetDatabaseOid())
+            .SetQueryText(std::move(query_text))
+            .SetParameters(std::move(clusters_params_vec))
+            .SetParameterTypes(std::move(param_types))
+            .Build());
   }
 }
 
@@ -165,9 +177,12 @@ void SelfDrivingRecordingUtil::RecordForecastQueryFrequencies(uint64_t timestamp
     std::vector<type::TypeId> param_types = {type::TypeId::BIGINT, type::TypeId::INTEGER, type::TypeId::INTEGER,
                                              type::TypeId::REAL};
     std::string query_text = SelfDrivingRecordingUtil::FORECAST_FORECASTS_INSERT_STMT;
-    task_manager->AddTask(std::make_unique<task::TaskDML>(catalog::INVALID_DATABASE_OID, query_text,
-                                                          std::make_unique<optimizer::TrivialCostModel>(), false,
-                                                          std::move(forecast_params_vec), std::move(param_types)));
+    task_manager->AddTask(task::TaskDML::Builder()
+                              .SetDatabaseOid(task_manager->GetDatabaseOid())
+                              .SetQueryText(std::move(query_text))
+                              .SetParameters(std::move(forecast_params_vec))
+                              .SetParameterTypes(std::move(param_types))
+                              .Build());
   }
 }
 
@@ -193,9 +208,12 @@ void SelfDrivingRecordingUtil::RecordAppliedAction(uint64_t timestamp_to_record,
   std::vector<type::TypeId> param_types = {type::TypeId::BIGINT, type::TypeId::INTEGER, type::TypeId::REAL,
                                            type::TypeId::INTEGER, type::TypeId::VARCHAR};
   std::string query_text = SelfDrivingRecordingUtil::APPLIED_ACTIONS_INSERT_STMT;
-  task_manager->AddTask(std::make_unique<task::TaskDML>(catalog::INVALID_DATABASE_OID, query_text,
-                                                        std::make_unique<optimizer::TrivialCostModel>(), false,
-                                                        std::move(params_vec), std::move(param_types)));
+  task_manager->AddTask(task::TaskDML::Builder()
+                            .SetDatabaseOid(task_manager->GetDatabaseOid())
+                            .SetQueryText(std::move(query_text))
+                            .SetParameters(std::move(params_vec))
+                            .SetParameterTypes(std::move(param_types))
+                            .Build());
 }
 
 void SelfDrivingRecordingUtil::RecordBestActions(
@@ -234,9 +252,12 @@ void SelfDrivingRecordingUtil::RecordBestActions(
                                            type::TypeId::INTEGER, type::TypeId::REAL,    type::TypeId::INTEGER,
                                            type::TypeId::VARCHAR};
   std::string query_text = SelfDrivingRecordingUtil::BEST_ACTIONS_INSERT_STMT;
-  task_manager->AddTask(std::make_unique<task::TaskDML>(catalog::INVALID_DATABASE_OID, query_text,
-                                                        std::make_unique<optimizer::TrivialCostModel>(), false,
-                                                        std::move(params_vec), std::move(param_types)));
+  task_manager->AddTask(task::TaskDML::Builder()
+                            .SetDatabaseOid(task_manager->GetDatabaseOid())
+                            .SetQueryText(std::move(query_text))
+                            .SetParameters(std::move(params_vec))
+                            .SetParameterTypes(std::move(param_types))
+                            .Build());
 }
 
 }  // namespace noisepage::util

--- a/src/util/self_driving_recording_util.cpp
+++ b/src/util/self_driving_recording_util.cpp
@@ -38,12 +38,15 @@ void SelfDrivingRecordingUtil::RecordQueryMetadata(
 
   if (!params_vec.empty()) {
     std::string query = SelfDrivingRecordingUtil::QUERY_TEXT_INSERT_STMT;
-    task_manager->AddTask(task::TaskDML::Builder()
-                              .SetDatabaseOid(task_manager->GetDatabaseOid())
-                              .SetQueryText(std::move(query))
-                              .SetParameters(std::move(params_vec))
-                              .SetParameterTypes(std::move(param_types))
-                              .Build());
+    task_manager->AddTask(
+        task::TaskDML::Builder()
+            .SetDatabaseOid(task_manager->GetDatabaseOid())
+            .SetQueryText(std::move(query))
+            // TODO(WAN): #1595
+            .SetTransactionPolicy({transaction::DurabilityPolicy::SYNC, transaction::ReplicationPolicy::DISABLE})
+            .SetParameters(std::move(params_vec))
+            .SetParameterTypes(std::move(param_types))
+            .Build());
   }
 }
 
@@ -77,12 +80,15 @@ void SelfDrivingRecordingUtil::RecordQueryParameters(
 
   if (!params_vec.empty()) {
     std::string query_text = SelfDrivingRecordingUtil::QUERY_PARAMETERS_INSERT_STMT;
-    task_manager->AddTask(task::TaskDML::Builder()
-                              .SetDatabaseOid(task_manager->GetDatabaseOid())
-                              .SetQueryText(std::move(query_text))
-                              .SetParameters(std::move(params_vec))
-                              .SetParameterTypes(std::move(param_types))
-                              .Build());
+    task_manager->AddTask(
+        task::TaskDML::Builder()
+            .SetDatabaseOid(task_manager->GetDatabaseOid())
+            .SetQueryText(std::move(query_text))
+            // TODO(WAN): #1595
+            .SetTransactionPolicy({transaction::DurabilityPolicy::SYNC, transaction::ReplicationPolicy::DISABLE})
+            .SetParameters(std::move(params_vec))
+            .SetParameterTypes(std::move(param_types))
+            .Build());
   }
 }
 
@@ -131,6 +137,8 @@ void SelfDrivingRecordingUtil::RecordForecastClusters(uint64_t timestamp_to_reco
         task::TaskDML::Builder()
             .SetDatabaseOid(task_manager->GetDatabaseOid())
             .SetQueryText(std::move(query_text))
+            // TODO(WAN): #1595
+            .SetTransactionPolicy({transaction::DurabilityPolicy::SYNC, transaction::ReplicationPolicy::DISABLE})
             .SetParameters(std::move(clusters_params_vec))
             .SetParameterTypes(std::move(param_types))
             .Build());
@@ -177,12 +185,15 @@ void SelfDrivingRecordingUtil::RecordForecastQueryFrequencies(uint64_t timestamp
     std::vector<type::TypeId> param_types = {type::TypeId::BIGINT, type::TypeId::INTEGER, type::TypeId::INTEGER,
                                              type::TypeId::REAL};
     std::string query_text = SelfDrivingRecordingUtil::FORECAST_FORECASTS_INSERT_STMT;
-    task_manager->AddTask(task::TaskDML::Builder()
-                              .SetDatabaseOid(task_manager->GetDatabaseOid())
-                              .SetQueryText(std::move(query_text))
-                              .SetParameters(std::move(forecast_params_vec))
-                              .SetParameterTypes(std::move(param_types))
-                              .Build());
+    task_manager->AddTask(
+        task::TaskDML::Builder()
+            .SetDatabaseOid(task_manager->GetDatabaseOid())
+            .SetQueryText(std::move(query_text))
+            // TODO(WAN): #1595
+            .SetTransactionPolicy({transaction::DurabilityPolicy::SYNC, transaction::ReplicationPolicy::DISABLE})
+            .SetParameters(std::move(forecast_params_vec))
+            .SetParameterTypes(std::move(param_types))
+            .Build());
   }
 }
 
@@ -208,12 +219,15 @@ void SelfDrivingRecordingUtil::RecordAppliedAction(uint64_t timestamp_to_record,
   std::vector<type::TypeId> param_types = {type::TypeId::BIGINT, type::TypeId::INTEGER, type::TypeId::REAL,
                                            type::TypeId::INTEGER, type::TypeId::VARCHAR};
   std::string query_text = SelfDrivingRecordingUtil::APPLIED_ACTIONS_INSERT_STMT;
-  task_manager->AddTask(task::TaskDML::Builder()
-                            .SetDatabaseOid(task_manager->GetDatabaseOid())
-                            .SetQueryText(std::move(query_text))
-                            .SetParameters(std::move(params_vec))
-                            .SetParameterTypes(std::move(param_types))
-                            .Build());
+  task_manager->AddTask(
+      task::TaskDML::Builder()
+          .SetDatabaseOid(task_manager->GetDatabaseOid())
+          .SetQueryText(std::move(query_text))
+          // TODO(WAN): #1595
+          .SetTransactionPolicy({transaction::DurabilityPolicy::SYNC, transaction::ReplicationPolicy::DISABLE})
+          .SetParameters(std::move(params_vec))
+          .SetParameterTypes(std::move(param_types))
+          .Build());
 }
 
 void SelfDrivingRecordingUtil::RecordBestActions(
@@ -252,12 +266,15 @@ void SelfDrivingRecordingUtil::RecordBestActions(
                                            type::TypeId::INTEGER, type::TypeId::REAL,    type::TypeId::INTEGER,
                                            type::TypeId::VARCHAR};
   std::string query_text = SelfDrivingRecordingUtil::BEST_ACTIONS_INSERT_STMT;
-  task_manager->AddTask(task::TaskDML::Builder()
-                            .SetDatabaseOid(task_manager->GetDatabaseOid())
-                            .SetQueryText(std::move(query_text))
-                            .SetParameters(std::move(params_vec))
-                            .SetParameterTypes(std::move(param_types))
-                            .Build());
+  task_manager->AddTask(
+      task::TaskDML::Builder()
+          .SetDatabaseOid(task_manager->GetDatabaseOid())
+          .SetQueryText(std::move(query_text))
+          // TODO(WAN): #1595
+          .SetTransactionPolicy({transaction::DurabilityPolicy::SYNC, transaction::ReplicationPolicy::DISABLE})
+          .SetParameters(std::move(params_vec))
+          .SetParameterTypes(std::move(param_types))
+          .Build());
 }
 
 }  // namespace noisepage::util

--- a/test/self_driving/query_trace_logging_test.cpp
+++ b/test/self_driving/query_trace_logging_test.cpp
@@ -123,8 +123,9 @@ TEST_F(QueryTraceLogging, BasicLogging) {
   raw->WriteToDB(task_manager_, false, 29, nullptr, nullptr);
   task_manager_->WaitForFlush();
 
-  auto select_count = [util](const std::string &query, size_t target) {
-    util->BeginTransaction(catalog::INVALID_DATABASE_OID);
+  auto task_manager = task_manager_;
+  auto select_count = [task_manager, util](const std::string &query, size_t target) {
+    util->BeginTransaction(task_manager->GetDatabaseOid());
     uint64_t row_count = 0;
     auto to_row_fn = [&row_count](const std::vector<execution::sql::Val *> &values) { row_count++; };
 
@@ -140,7 +141,6 @@ TEST_F(QueryTraceLogging, BasicLogging) {
   select_count("SELECT * FROM noisepage_forecast_texts", 0);
   select_count("SELECT * FROM noisepage_forecast_parameters", 0);
 
-  auto task_manager = task_manager_;
   auto check_freqs = [task_manager, &qids, &totals, &timestamps](size_t num_interval) {
     size_t seen = 0;
     std::unordered_map<size_t, std::unordered_map<size_t, size_t>> qid_map;
@@ -165,12 +165,18 @@ TEST_F(QueryTraceLogging, BasicLogging) {
     std::vector<std::vector<parser::ConstantValueExpression>> params;
     std::vector<type::TypeId> param_types;
 
-    common::Future<task::DummyResult> sync;
+    common::FutureDummy sync;
     execution::exec::ExecutionSettings settings{};
-    task_manager->AddTask(std::make_unique<task::TaskDML>(
-        catalog::INVALID_DATABASE_OID, "SELECT * FROM noisepage_forecast_frequencies",
-        std::make_unique<optimizer::TrivialCostModel>(), std::move(params), std::move(param_types), freq_check, nullptr,
-        settings, false, true, std::nullopt, common::ManagedPointer(&sync)));
+    task_manager->AddTask(task::TaskDML::Builder()
+                              .SetDatabaseOid(task_manager->GetDatabaseOid())
+                              .SetQueryText("SELECT * FROM noisepage_forecast_frequencies")
+                              .SetFuture(common::ManagedPointer(&sync))
+                              .SetParameters(std::move(params))
+                              .SetParameterTypes(std::move(param_types))
+                              .SetTupleFn(std::move(freq_check))
+                              .SetShouldSkipQueryCache(true)
+                              .SetExecutionSettings(settings)
+                              .Build());
 
     auto sync_result = sync.DangerousWait();
     bool result = sync_result.second;
@@ -195,7 +201,7 @@ TEST_F(QueryTraceLogging, BasicLogging) {
   task_manager_->WaitForFlush();
 
   {
-    util->BeginTransaction(catalog::INVALID_DATABASE_OID);
+    util->BeginTransaction(task_manager_->GetDatabaseOid());
     std::unordered_set<int64_t> val;
     auto func = [&val, qids, texts, db_oids, &parameters](const std::vector<execution::sql::Val *> &values) {
       int64_t qid = reinterpret_cast<execution::sql::Integer *>(values[1])->val_;
@@ -230,7 +236,7 @@ TEST_F(QueryTraceLogging, BasicLogging) {
   }
 
   {
-    util->BeginTransaction(catalog::INVALID_DATABASE_OID);
+    util->BeginTransaction(task_manager_->GetDatabaseOid());
     size_t row_count = 0;
     std::unordered_set<int64_t> seen;
     auto func = [&row_count, qids, &seen](const std::vector<execution::sql::Val *> &values) {


### PR DESCRIPTION
# Heading

Refactor Tasks to use builders. Do not replicate startup DDL.

## Description

Fix #1576 per current understanding, we may decide in the future to add startup SQL that does get replicated, but right now everything is internal tables. Also create everything in the default `noisepage` database instead of in database 0 aka INVALID_DB_OID.

Mainly going from constructors like this

```
    task_manager->AddTask(std::make_unique<task::TaskDML>(
        catalog::INVALID_DATABASE_OID, "SELECT * FROM noisepage_forecast_frequencies",
        std::make_unique<optimizer::TrivialCostModel>(), std::move(params), std::move(param_types), freq_check, nullptr,
        settings, false, true, std::nullopt, common::ManagedPointer(&sync)));
```
to this
```
    task_manager->AddTask(task::TaskDML::Builder()
                              .SetDatabaseOid(task_manager->GetDatabaseOid())
                              .SetQueryText("SELECT * FROM noisepage_forecast_frequencies")
                              .SetFuture(common::ManagedPointer(&sync))
                              .SetParameters(std::move(params))
                              .SetParameterTypes(std::move(param_types))
                              .SetTupleFn(std::move(freq_check))
                              .SetShouldSkipQueryCache(true)
                              .SetExecutionSettings(settings)
                              .Build());
```

Fell down a rabbit hole of making it easier to specify additional properties for tasks in the future.

- Refactor TaskDDL and TaskDML to use builders.
- Track default database OID in catalog, expose via GetDefaultDatabaseOid.
- Refuse INVALID_DB_OID to force callers to do the right thing, i.e., explicitly specify what database they are interacting with.
- Change TryLoadStartupDDL to fail loudly instead of silently.
- Disable replication of TryLoadStartupDDL.
- Add TransactionPolicy arg to QueryExecUtil::BeginTransaction.
- Change a const unique_ptr<> & to a ManagedPointer.
- Allow SetReplicationPolicy(DISABLE) if DurabilityPolicy is also DISABLE.
- Nitpick at function docstrings in QueryExecUtil.
- Question: what should DurabilityPolicy be for internal table tasks?
- Found bug, see #1595.

## Remaining tasks

Seeing if it passes CI. I am surprised replication tests did not fail sooner.