### PR TITLE
Fix DurabilityPolicy::DISABLE configuration.

### DIFF
--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -212,7 +212,9 @@ class TransactionContext {
 
   /** Set the replication policy of the entire transaction. */
   void SetReplicationPolicy(ReplicationPolicy replication_policy) {
-    NOISEPAGE_ASSERT(durability_policy_ != DurabilityPolicy::DISABLE, "Replication needs durability enabled.");
+    NOISEPAGE_ASSERT(
+        replication_policy == ReplicationPolicy::DISABLE || durability_policy_ != DurabilityPolicy::DISABLE,
+        "Replication needs durability enabled.");
     replication_policy_ = replication_policy;
   }
 

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -66,6 +66,7 @@ struct CommitCallbackArg {
     const transaction::DurabilityPolicy &dur = policy.durability_;
     const transaction::ReplicationPolicy &rep = policy.replication_;
 
+    // Commit callback is always invoked at least once.
     persist_countdown_ += 1;
     if (rep != transaction::ReplicationPolicy::DISABLE) {
       if (dur == transaction::DurabilityPolicy::ASYNC && rep == transaction::ReplicationPolicy::ASYNC) {

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -73,6 +73,7 @@ void TransactionManager::LogCommit(TransactionContext *const txn, const timestam
     } else {
       NOISEPAGE_ASSERT(txn->GetDurabilityPolicy() == DurabilityPolicy::DISABLE, "Durability should be disabled.");
       timestamp_manager_->RemoveTransaction(txn->StartTime());
+      commit_callback(commit_callback_arg);
     }
   } else {
     // Otherwise, logging is disabled. We should pretend to have serialized and flushed the record so the rest of the

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -72,6 +72,7 @@ void TransactionManager::LogCommit(TransactionContext *const txn, const timestam
       commit_callback(commit_callback_arg);
     } else {
       NOISEPAGE_ASSERT(txn->GetDurabilityPolicy() == DurabilityPolicy::DISABLE, "Durability should be disabled.");
+      timestamp_manager_->RemoveTransaction(txn->StartTime());
     }
   } else {
     // Otherwise, logging is disabled. We should pretend to have serialized and flushed the record so the rest of the


### PR DESCRIPTION
# Heading

Fix DurabilityPolicy::DISABLE configuration.

## Description

Fix #1595.

- Allow ReplicationPolicy::DISABLE to be set if DurabilityPolicy::DISABLE is also set.
- Immediately release the buffer segment if durability is disabled.
- Immediately remove any txn that commits if durability is disabled. (is this fine?)

Essentially trying to emulate the log manager off configuration.