### PR TITLE
Add support for aliases in GROUP BY. Add Postgres-style date_part.

### DIFF
--- a/script/testing/junit/traces/groupby.test
+++ b/script/testing/junit/traces/groupby.test
@@ -1,0 +1,30 @@
+statement ok
+CREATE TABLE foo (a INT, b INT);
+
+statement ok
+INSERT INTO foo VALUES (1, 2);
+
+statement ok
+INSERT INTO foo VALUES (1, 3);
+
+statement ok
+INSERT INTO foo VALUES (2, 2);
+
+query I rowsort
+SELECT a, sum(b) FROM foo GROUP BY a;
+----
+1
+5
+2
+2
+
+query I rowsort
+SELECT a as x, sum(b) FROM foo GROUP BY x;
+----
+1
+5
+2
+2
+
+statement ok
+DROP TABLE foo;

--- a/src/execution/vm/vm.cpp
+++ b/src/execution/vm/vm.cpp
@@ -2590,6 +2590,13 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {  // NOLINT
     DISPATCH_NEXT();
   }
 
+  OP(ExtractYearFromTimestamp) : {
+    auto *result = frame->LocalAt<sql::Integer *>(READ_LOCAL_ID());
+    auto *input = frame->LocalAt<sql::TimestampVal *>(READ_LOCAL_ID());
+    OpExtractYearFromTimestamp(result, input);
+    DISPATCH_NEXT();
+  }
+
   // -------------------------------------------------------
   // Replication functions
   // -------------------------------------------------------

--- a/src/include/binder/bind_node_visitor.h
+++ b/src/include/binder/bind_node_visitor.h
@@ -107,12 +107,30 @@ class BindNodeVisitor final : public SqlNodeVisitor {
   static void InitTableRef(common::ManagedPointer<parser::TableRef> node);
 
   /**
-   * Change the type of exprs_ of order_by_description from ConstantValueExpression to ColumnValueExpression.
-   * @param order_by_description OrderByDescription
-   * @param select_items select columns
+   * Replace integer constants in an ORDER BY with the corresponding expressions from the SELECT columns.
+   * @param order_by_description    The ORDER BY that may contain integer constants.
+   * @param select_items            The SELECT columns that the integer constants refer to.
    */
   void UnifyOrderByExpression(common::ManagedPointer<parser::OrderByDescription> order_by_description,
                               const std::vector<common::ManagedPointer<parser::AbstractExpression>> &select_items);
+
+  /**
+   * Rewrite aliases in an expression with the corresponding expressions from the SELECT columns.
+   *
+   * @param expression      The expression that may need rewriting. This expression is mutated!
+   * @param select_items    The SELECT columns that may have aliases.
+   */
+  common::ManagedPointer<parser::AbstractExpression> UnaliasExpression(
+      common::ManagedPointer<parser::AbstractExpression> expression,
+      const std::vector<common::ManagedPointer<parser::AbstractExpression>> &select_items);
+
+  /** Unalias expressions in the GROUP BY. */
+  void UnaliasGroupBy(common::ManagedPointer<parser::GroupByDescription> group_by_description,
+                      const std::vector<common::ManagedPointer<parser::AbstractExpression>> &select_items);
+
+  /** Unalias expressions in the ORDER BY. */
+  void UnaliasOrderBy(common::ManagedPointer<parser::OrderByDescription> order_by_description,
+                      const std::vector<common::ManagedPointer<parser::AbstractExpression>> &select_items);
 
   void ValidateDatabaseName(const std::string &db_name);
 

--- a/src/include/execution/ast/builtins.h
+++ b/src/include/execution/ast/builtins.h
@@ -34,6 +34,7 @@ namespace noisepage::execution::ast {
   /* SQL Functions */                                                   \
   F(Like, like)                                                         \
   F(DatePart, datePart)                                                 \
+  F(DatePartPostgres, datePartPostgres)                                 \
                                                                         \
   /* Thread State Container */                                          \
   F(ExecutionContextAddRowsAffected, execCtxAddRowsAffected)            \

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -2113,6 +2113,16 @@ VM_OP_WARM void OpExtractYearFromDate(noisepage::execution::sql::Integer *result
   }
 }
 
+VM_OP_WARM void OpExtractYearFromTimestamp(noisepage::execution::sql::Integer *result,
+                                           noisepage::execution::sql::TimestampVal *input) {
+  if (input->is_null_) {
+    result->is_null_ = true;
+  } else {
+    result->is_null_ = false;
+    result->val_ = input->val_.ExtractYear();
+  }
+}
+
 VM_OP_WARM void OpAbortTxn(noisepage::execution::exec::ExecutionContext *exec_ctx) {
   exec_ctx->GetTxn()->SetMustAbort();
   throw noisepage::ABORT_EXCEPTION("transaction aborted");

--- a/src/include/execution/vm/bytecodes.h
+++ b/src/include/execution/vm/bytecodes.h
@@ -735,8 +735,9 @@ namespace noisepage::execution::vm {
   F(Position, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                         \
   F(InitCap, OperandType::Local, OperandType::Local, OperandType::Local)                                              \
                                                                                                                       \
-  /* Date Functions */                                                                                                \
+  /* Date and timestamp functions. */                                                                                 \
   F(ExtractYearFromDate, OperandType::Local, OperandType::Local)                                                      \
+  F(ExtractYearFromTimestamp, OperandType::Local, OperandType::Local)                                                 \
                                                                                                                       \
   F(AbortTxn, OperandType::Local)                                                                                     \
                                                                                                                       \

--- a/src/include/parser/select_statement.h
+++ b/src/include/parser/select_statement.h
@@ -61,19 +61,13 @@ class OrderByDescription {
    */
   void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) { v->Visit(common::ManagedPointer(this)); }
 
-  /**
-   * @return order by types
-   */
+  /** @return The types of the ORDER BY terms. */
   std::vector<OrderType> GetOrderByTypes() { return types_; }
 
-  /**
-   * @return number of order by expressions
-   */
+  /** @return The number of ORDER BY terms. */
   size_t GetOrderByExpressionsSize() const { return exprs_.size(); }
 
-  /**
-   * @return order by expression
-   */
+  /** @return Mutable reference to the expressions representing the ORDER BY terms. */
   std::vector<common::ManagedPointer<AbstractExpression>> &GetOrderByExpressions() { return exprs_; }
 
   /**
@@ -255,8 +249,8 @@ class GroupByDescription {
    */
   void Accept(common::ManagedPointer<binder::SqlNodeVisitor> v) { v->Visit(common::ManagedPointer(this)); }
 
-  /** @return group by columns */
-  const std::vector<common::ManagedPointer<AbstractExpression>> &GetColumns() { return columns_; }
+  /** @return Mutable reference to the expressions representing the GROUP BY terms. */
+  std::vector<common::ManagedPointer<AbstractExpression>> &GetColumns() { return columns_; }
 
   /** @return having clause */
   common::ManagedPointer<AbstractExpression> GetHaving() { return common::ManagedPointer(having_); }


### PR DESCRIPTION
# Heading

Add support for aliases in GROUP BY. Add Postgres-style date_part.

## Description

Add support for aliases in GROUP BY. Add Postgres-style date_part.

Note that the Postgres parser rewrites EXTRACT(YEAR FROM some_timestamp)
as date_part("year", some_timestamp).

Note that the optimizer gives us a bad OutputSchema when the GROUP BY expression
is on an aggregated column of the table, so this does not fix chbenchmark. It is currently
unclear if this is primarily a problem with the binder, optimizer, or translator.

Reasons:

- Translator: This is where the output schema kaboom happens.
- Optimizer: This produced the output schema. Maybe it never accounted for `select abs(a) as x ... group by x`.
- Binder: But maybe the optimizer would be fine if the binder wasn't swapping out expressions (quite literally, the group by `x` child becomes the expression `abs(a)` in the above example. This seems to work for ORDER BY fwiw.)

## Further work

This is enough to merge on its own, seeing if it gets through CI.