### PR TITLE
Unify pilot namespace

### DIFF
--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -21,9 +21,9 @@ class GarbageCollector;
 class RecoveryManager;
 }  // namespace noisepage::storage
 
-namespace noisepage::selfdriving {
+namespace noisepage::selfdriving::pilot {
 class PilotUtil;
-}  // namespace noisepage::selfdriving
+}  // namespace noisepage::selfdriving::pilot
 
 namespace noisepage::catalog {
 
@@ -141,7 +141,7 @@ class Catalog {
  private:
   DISALLOW_COPY_AND_MOVE(Catalog);
   friend class storage::RecoveryManager;
-  friend class selfdriving::PilotUtil;
+  friend class selfdriving::pilot::PilotUtil;
   const common::ManagedPointer<transaction::TransactionManager> txn_manager_;
   const common::ManagedPointer<storage::BlockStore> catalog_block_store_;
   const common::ManagedPointer<storage::GarbageCollector> garbage_collector_;

--- a/src/include/execution/compiler/executable_query.h
+++ b/src/include/execution/compiler/executable_query.h
@@ -14,7 +14,9 @@
 namespace noisepage {
 namespace selfdriving {
 class PipelineOperatingUnits;
+namespace pilot {
 class PilotUtil;
+}  // namespace pilot
 }  // namespace selfdriving
 
 namespace execution {
@@ -207,7 +209,7 @@ class ExecutableQuery {
   // MiniRunners needs to set query_identifier and pipeline_operating_units_.
   friend class noisepage::runner::ExecutionRunners;
   friend class noisepage::runner::ExecutionRunners_SEQ0_OutputRunners_Benchmark;
-  friend class noisepage::selfdriving::PilotUtil;
+  friend class noisepage::selfdriving::pilot::PilotUtil;
   friend class noisepage::execution::compiler::CompilationContext;  // SetQueryId
   friend class noisepage::runner::ExecutionRunners_SEQ10_0_IndexInsertRunners_Benchmark;
 };

--- a/src/include/execution/exec/execution_settings.h
+++ b/src/include/execution/exec/execution_settings.h
@@ -33,7 +33,9 @@ class Workload;
 }  // namespace noisepage::tpch
 
 namespace noisepage::selfdriving {
+namespace pilot {
 class PilotUtil;
+}  // namespace pilot
 }  // namespace noisepage::selfdriving
 
 namespace noisepage::task {
@@ -115,6 +117,6 @@ class EXPORT ExecutionSettings {
   friend class noisepage::optimizer::IdxJoinTest_BarOnlyScan_Test;
   friend class noisepage::optimizer::IdxJoinTest_IndexToIndexJoin_Test;
   friend class noisepage::task::TaskDML;
-  friend class noisepage::selfdriving::PilotUtil;
+  friend class noisepage::selfdriving::pilot::PilotUtil;
 };
 }  // namespace noisepage::execution::exec

--- a/src/include/main/db_main.h
+++ b/src/include/main/db_main.h
@@ -532,21 +532,21 @@ class DBMain {
             model_server_path_, messenger_layer->GetMessenger(), model_server_enable_python_coverage_);
       }
 
-      std::unique_ptr<selfdriving::PilotThread> pilot_thread = DISABLED;
-      std::unique_ptr<selfdriving::Pilot> pilot = DISABLED;
+      std::unique_ptr<selfdriving::pilot::PilotThread> pilot_thread = DISABLED;
+      std::unique_ptr<selfdriving::pilot::Pilot> pilot = DISABLED;
       if (use_pilot_thread_) {
         NOISEPAGE_ASSERT(use_model_server_, "Pilot requires model server manager.");
         std::unique_ptr<util::QueryExecUtil> util =
             query_exec_util ? util::QueryExecUtil::ConstructThreadLocal(common::ManagedPointer(query_exec_util))
                             : nullptr;
-        pilot = std::make_unique<selfdriving::Pilot>(
+        pilot = std::make_unique<selfdriving::pilot::Pilot>(
             ou_model_save_path_, interference_model_save_path_, forecast_model_save_path_,
             common::ManagedPointer(catalog_layer->GetCatalog()), common::ManagedPointer(metrics_thread),
             common::ManagedPointer(model_server_manager), common::ManagedPointer(settings_manager),
             common::ManagedPointer(stats_storage), common::ManagedPointer(txn_layer->GetTransactionManager()),
             std::move(util), common::ManagedPointer(task_manager), workload_forecast_interval_, sequence_length_,
             horizon_length_);
-        pilot_thread = std::make_unique<selfdriving::PilotThread>(
+        pilot_thread = std::make_unique<selfdriving::pilot::PilotThread>(
             common::ManagedPointer(pilot), std::chrono::microseconds{pilot_interval_},
             std::chrono::microseconds{forecast_train_interval_}, pilot_planning_);
       }
@@ -1182,12 +1182,12 @@ class DBMain {
   /**
    * @return ManagedPointer to the component, can be nullptr if disabled
    */
-  common::ManagedPointer<selfdriving::Pilot> GetPilot() const { return common::ManagedPointer(pilot_); }
+  common::ManagedPointer<selfdriving::pilot::Pilot> GetPilot() const { return common::ManagedPointer(pilot_); }
 
   /**
    * @return ManagedPointer to the component, can be nullptr if disabled
    */
-  common::ManagedPointer<selfdriving::PilotThread> GetPilotThread() const {
+  common::ManagedPointer<selfdriving::pilot::PilotThread> GetPilotThread() const {
     return common::ManagedPointer(pilot_thread_);
   }
 
@@ -1249,8 +1249,8 @@ class DBMain {
   std::unique_ptr<MessengerLayer> messenger_layer_;
   std::unique_ptr<replication::ReplicationManager> replication_manager_;  // Depends on messenger.
   std::unique_ptr<storage::RecoveryManager> recovery_manager_;            // Depends on replication manager.
-  std::unique_ptr<selfdriving::PilotThread> pilot_thread_;
-  std::unique_ptr<selfdriving::Pilot> pilot_;
+  std::unique_ptr<selfdriving::pilot::PilotThread> pilot_thread_;
+  std::unique_ptr<selfdriving::pilot::Pilot> pilot_;
   std::unique_ptr<modelserver::ModelServerManager> model_server_manager_;
   std::unique_ptr<util::QueryExecUtil> query_exec_util_;
   std::unique_ptr<task::TaskManager> task_manager_;

--- a/src/include/metrics/pipeline_metric.h
+++ b/src/include/metrics/pipeline_metric.h
@@ -17,10 +17,10 @@
 #include "self_driving/modeling/operating_unit_util.h"
 #include "transaction/transaction_defs.h"
 
-namespace noisepage::selfdriving {
+namespace noisepage::selfdriving::pilot {
 class PilotUtil;
 class Pilot;
-}  // namespace noisepage::selfdriving
+}  // namespace noisepage::selfdriving::pilot
 
 namespace noisepage::metrics {
 
@@ -90,8 +90,8 @@ class PipelineMetricRawData : public AbstractRawData {
 
  private:
   friend class PipelineMetric;
-  friend class selfdriving::PilotUtil;
-  friend class selfdriving::Pilot;
+  friend class selfdriving::pilot::PilotUtil;
+  friend class selfdriving::pilot::Pilot;
   FRIEND_TEST(MetricsTests, PipelineCSVTest);
   struct PipelineData;
 

--- a/src/include/self_driving/forecasting/workload_forecast.h
+++ b/src/include/self_driving/forecasting/workload_forecast.h
@@ -86,7 +86,7 @@ class WorkloadForecast {
   }
 
  private:
-  friend class PilotUtil;
+  friend class pilot::PilotUtil;
 
   uint64_t GetForecastInterval() const { return forecast_interval_; }
 

--- a/src/include/self_driving/forecasting/workload_forecast.h
+++ b/src/include/self_driving/forecasting/workload_forecast.h
@@ -13,6 +13,9 @@
 #include "self_driving/forecasting/workload_forecast_segment.h"
 
 namespace noisepage::selfdriving {
+namespace pilot {
+class PilotUtil;
+}
 
 /**
  * A workload forecast prediction is described as:

--- a/src/include/self_driving/planning/mcts/monte_carlo_tree_search.h
+++ b/src/include/self_driving/planning/mcts/monte_carlo_tree_search.h
@@ -12,11 +12,10 @@
 #include "self_driving/planning/mcts/tree_node.h"
 
 namespace noisepage::selfdriving {
-class Pilot;
 class WorkloadForecast;
 
 namespace pilot {
-
+class Pilot;
 class PlanningContext;
 
 /**

--- a/src/include/self_driving/planning/mcts/tree_node.h
+++ b/src/include/self_driving/planning/mcts/tree_node.h
@@ -15,11 +15,10 @@
 #define NULL_ACTION INT32_MAX
 
 namespace noisepage::selfdriving {
-class Pilot;
 class WorkloadForecast;
 
 namespace pilot {
-
+class Pilot;
 class PlanningContext;
 
 STRONG_TYPEDEF_HEADER(tree_node_id_t, uint64_t);

--- a/src/include/self_driving/planning/pilot.h
+++ b/src/include/self_driving/planning/pilot.h
@@ -62,14 +62,10 @@ class TaskManager;
 
 }  // namespace noisepage
 
-namespace noisepage::selfdriving {
-namespace pilot {
+namespace noisepage::selfdriving::pilot {
 class AbstractAction;
-class MonteCarloTreeSearch;
 class TreeNode;
 class ActionTreeNode;
-}  // namespace pilot
-
 class PilotUtil;
 
 /**
@@ -127,7 +123,7 @@ class Pilot {
    * Search for and apply the best action for the current timestamp
    * @param best_action_seq pointer to the vector to be filled with the sequence of best actions to take at current time
    */
-  void ActionSearch(std::vector<pilot::ActionTreeNode> *best_action_seq);
+  void ActionSearch(std::vector<ActionTreeNode> *best_action_seq);
 
   /**
    * Search for and apply the best set of actions for the current timestamp using the Sequence Tuning baseline
@@ -155,7 +151,7 @@ class Pilot {
    */
   static void EmptySetterCallback(common::ManagedPointer<common::ActionContext> action_context UNUSED_ATTRIBUTE) {}
 
-  pilot::PlanningContext planning_context_;
+  PlanningContext planning_context_;
 
   Forecaster forecaster_;
   uint64_t action_planning_horizon_{15};
@@ -164,4 +160,4 @@ class Pilot {
   std::mutex forecaster_train_mutex_;
 };
 
-}  // namespace noisepage::selfdriving
+}  // namespace noisepage::selfdriving::pilot

--- a/src/include/self_driving/planning/pilot_thread.h
+++ b/src/include/self_driving/planning/pilot_thread.h
@@ -5,7 +5,7 @@
 
 #include "self_driving/planning/pilot.h"
 
-namespace noisepage::selfdriving {
+namespace noisepage::selfdriving::pilot {
 
 /**
  * Class for spinning off a thread that runs the pilot to process query predictions.
@@ -19,7 +19,7 @@ class PilotThread {
    * @param forecaster_train_interval Sleep time between training forecast model
    * @param pilot_planning if the pilot is enabled
    */
-  PilotThread(common::ManagedPointer<selfdriving::Pilot> pilot, std::chrono::microseconds pilot_interval,
+  PilotThread(common::ManagedPointer<Pilot> pilot, std::chrono::microseconds pilot_interval,
               std::chrono::microseconds forecaster_train_interval, bool pilot_planning);
 
   ~PilotThread() { StopPilot(); }
@@ -66,7 +66,7 @@ class PilotThread {
   common::ManagedPointer<Pilot> GetPilot() { return pilot_; }
 
  private:
-  const common::ManagedPointer<selfdriving::Pilot> pilot_;
+  const common::ManagedPointer<Pilot> pilot_;
   volatile bool run_pilot_;
   volatile bool pilot_paused_;
   std::chrono::microseconds pilot_interval_;
@@ -92,4 +92,4 @@ class PilotThread {
   }
 };
 
-}  // namespace noisepage::selfdriving
+}  // namespace noisepage::selfdriving::pilot

--- a/src/include/self_driving/planning/pilot_util.h
+++ b/src/include/self_driving/planning/pilot_util.h
@@ -35,16 +35,15 @@ class AbstractPlanNode;
 
 namespace noisepage::selfdriving {
 class WorkloadForecast;
-class Pilot;
 
 namespace pilot {
+class Pilot;
 class CreateIndexAction;
 class DropIndexAction;
 struct MemoryInfo;
 class ActionState;
 class AbstractAction;
 class PlanningContext;
-}  // namespace pilot
 
 /**
  * Utility class for helper functions
@@ -256,4 +255,5 @@ class PilotUtil {
   static const uint64_t INTERFERENCE_DIMENSION{27};
 };
 
+}  // namespace pilot
 }  // namespace noisepage::selfdriving

--- a/src/self_driving/planning/pilot_thread.cpp
+++ b/src/self_driving/planning/pilot_thread.cpp
@@ -1,6 +1,6 @@
 #include "self_driving/planning/pilot_thread.h"
 
-namespace noisepage::selfdriving {
+namespace noisepage::selfdriving::pilot {
 PilotThread::PilotThread(common::ManagedPointer<Pilot> pilot, std::chrono::microseconds pilot_interval,
                          std::chrono::microseconds forecaster_train_interval, bool pilot_planning)
     : pilot_(pilot),
@@ -11,4 +11,4 @@ PilotThread::PilotThread(common::ManagedPointer<Pilot> pilot, std::chrono::micro
       forecaster_remain_period_(forecaster_train_interval),
       pilot_thread_(std::thread([this] { PilotThreadLoop(); })) {}
 
-}  // namespace noisepage::selfdriving
+}  // namespace noisepage::selfdriving::pilot


### PR DESCRIPTION
We have mixed namespace usage for code under the `self_driving/planning` folder. This PR makes them all under the `noisepage::selfdriving::pilot` namespace. I don't really think this needs review.