### PR TITLE
Add PYTHONPATH to tests in CMake. Ignore cmake-build-relwithdebinfo. Verbose self-driving tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,6 +247,7 @@ cmake_build
 .cmake_build
 cmake-build-debug
 cmake-build-release
+cmake-build-relwithdebinfo
 
 # Generated documentation
 apidoc/doc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -846,6 +846,7 @@ add_custom_target(jumbotests
         USES_TERMINAL)
 add_custom_target(self_driving_e2e_test         # For now, this target is specifically used for self-driving pipeline
         ctest
+        --extra-verbose                     # Print out the details of test failure.
         --resource-spec-file ${BUILD_SUPPORT_DATA_DIR}/ctest_resource_specs.json    # For controlling conflicting tests.
         ${UNITTEST_OUTPUT_ON_FAILURE}       # Whether to print output when a test fails.
         -j ${NOISEPAGE_TEST_PARALLELISM}    # Maximum number of parallel jobs.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -939,7 +939,10 @@ function(add_noisepage_test
     # TODO(WAN): The "modern" gtest_discover_test has a ton of files. Favoring legacy add_test for now...
     add_test(${TEST_NAME} ${BUILD_SUPPORT_DIR}/run-test.sh ${CMAKE_BINARY_DIR} test ${TEST_OUTPUT_DIR}/${TEST_NAME})
     # Label each test with TEST_LABEL so that ctest can run all the tests under the TEST_LABEL label later.
-    set_tests_properties(${TEST_NAME} PROPERTIES LABELS "${TEST_LABEL};${TEST_NAME}")
+    set_tests_properties(${TEST_NAME} PROPERTIES
+            LABELS "${TEST_LABEL};${TEST_NAME}"                 # Label the test.
+            ENVIRONMENT "PYTHONPATH=${PROJECT_SOURCE_DIR}"      # Set the PYTHONPATH to project root for self-driving.
+            )
     # Add TEST_NAME as a dependency to TEST_LABEL. Note that TEST_LABEL must be a valid target!
     add_dependencies(${TEST_LABEL} ${TEST_NAME})
 endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -846,7 +846,7 @@ add_custom_target(jumbotests
         USES_TERMINAL)
 add_custom_target(self_driving_e2e_test         # For now, this target is specifically used for self-driving pipeline
         ctest
-        --extra-verbose                     # Print out the details of test failure.
+        --extra-verbose                     # Print out the test output as it runs.
         --resource-spec-file ${BUILD_SUPPORT_DATA_DIR}/ctest_resource_specs.json    # For controlling conflicting tests.
         ${UNITTEST_OUTPUT_ON_FAILURE}       # Whether to print output when a test fails.
         -j ${NOISEPAGE_TEST_PARALLELISM}    # Maximum number of parallel jobs.


### PR DESCRIPTION
# Heading

Add PYTHONPATH to tests in CMake. Ignore cmake-build-relwithdebinfo.

## Description

- Add cmake-build-relwithdebinfo to gitignore.
- Make self-driving tests extra verbose.
- Set PYTHONPATH for tests. See #1612.

## Remaining tasks

Going to see whether it produces a reasonable amount of output in CI for the self-driving tests.