### PR TITLE
Clone oltpbench with depth 1.

### DIFF
--- a/script/testing/oltpbench/constants.py
+++ b/script/testing/oltpbench/constants.py
@@ -6,8 +6,8 @@ from ..util.constants import DIR_TMP
 OLTPBENCH_GIT_URL = "https://github.com/oltpbenchmark/oltpbench.git"
 OLTPBENCH_GIT_LOCAL_PATH = os.path.join(DIR_TMP, "oltpbench")
 OLTPBENCH_GIT_CLEAN_COMMAND = "rm -rf {}".format(OLTPBENCH_GIT_LOCAL_PATH)
-OLTPBENCH_GIT_CLONE_COMMAND = "git clone {} {}".format(OLTPBENCH_GIT_URL,
-                                                 OLTPBENCH_GIT_LOCAL_PATH)
+OLTPBENCH_GIT_CLONE_COMMAND = "git clone --depth 1 {} {}".format(OLTPBENCH_GIT_URL,
+                                                                 OLTPBENCH_GIT_LOCAL_PATH)
 
 # OLTPBench default settings.
 OLTPBENCH_DEFAULT_TIME = 30


### PR DESCRIPTION
# Heading

Clone oltpbench with depth 1.

## Description

The OLTPBench repo is pretty big and we clone it at least 4 times in running any forecasting/pilot-related scripts (because the abstractions end up doing something like: repeat 4 times { download oltpbench, run oltpbench, delete oltpbench })

This just makes the clone a little less expensive.

## Remaining tasks

Seeing if this broke CI in any way. I don't think we'd be checking out old branches of oltpbench though.

I'm inclined to argue that this is a point in favor of repetitive but readable bash scripts over python abstractions that are rarely really reusable, but that's a future thing.