### PR TITLE
Flush pending writes on connection close

### DIFF
--- a/src/network/connection_handle.cpp
+++ b/src/network/connection_handle.cpp
@@ -193,6 +193,10 @@ Transition ConnectionHandle::GetResult() {
 }
 
 Transition ConnectionHandle::TryCloseConnection() {
+  // Flush out any pending writes before closing the connection. In theory this should just be error messages and not
+  // partial query data, but I don't completely understand the network state machine. This is mostly to make sure we
+  // flush error messages on connection startup. @see PostgresProtocolInterpreter::ProcessStartup's error states
+  if (io_wrapper_->ShouldFlush()) TryWrite();
   // Stop the protocol interpreter.
   protocol_interpreter_->Teardown(io_wrapper_->GetReadBuffer(), io_wrapper_->GetWriteQueue(), traffic_cop_,
                                   common::ManagedPointer(&context_));


### PR DESCRIPTION
In theory this should just be error messages and not partial query data, but I don't completely understand the network state machine. This is mostly to make sure we flush error messages on connection startup. See `PostgresProtocolInterpreter::ProcessStartup`'s error states.

This came from @lmwnshn seeing behavior where clients couldn't connect while a simultaneous transaction was running that made DDL changes. We now get the verbose error (that was always written to the packet, just never flushed) returned to the client.

Client 1:
```
$ psql -h localhost -p 15721 -d noisepage
psql (12.7 (Ubuntu 12.7-0ubuntu0.20.04.1), server 9.5devel)
Type "help" for help.

noisepage=# begin;
BEGIN
Time: 1.427 ms
noisepage=# create table foo (id int);
CREATE TABLE
Time: 7.825 ms
noisepage=# 
```
Client 2:
```
$ psql -h localhost -p 15721 -d noisepage
psql: error: FATAL:  Failed to create a temporary namespace for this connection. There may be a concurrent DDL change. Please retry.
```