### PR TITLE
Add Validation to Column Constructor

### DIFF
--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -94,7 +94,7 @@ class Schema {
           default_value_(default_value.Copy()) {
       // TODO(Rohan,Gautam,Preetansh): We need to manually set the max varlen size here
       //  as we cannot get this from Output schema for now
-      type_modifier_ = -1;
+      Validate();
     }
 
     /**


### PR DESCRIPTION
The CTE PR added a new constructor for the `Column` type but neglected to include a call to `Column::Validate()` to validate instances upon construction. This PR adds this missing validation step.