### PR TITLE
Refactor support for SHOW commands in DESCRIBE.

### DIFF
--- a/src/include/traffic_cop/traffic_cop.h
+++ b/src/include/traffic_cop/traffic_cop.h
@@ -190,15 +190,15 @@ class TrafficCop {
                                        common::ManagedPointer<network::Statement> statement) const;
 
   /**
-   * Contains the logic to handle SHOW statements. Currently a hack to only support SHOW TRANSACTION ISOLATION LEVEL
-   * @param connection_ctx The context to be used to access the internal txn.
-   * @param statement The show statement to be executed.
-   * @param out Packet writer for writing results.
-   * @return The result of the operation.
+   * Contains the logic to handle SHOW statements.
+   * @param connection_ctx  The context to be used to access the internal txn.
+   * @param out             The packet writer to return results.
+   * @param statement       The statement to be executed.
+   * @return                The result of the operation.
    */
   TrafficCopResult ExecuteShowStatement(common::ManagedPointer<network::ConnectionContext> connection_ctx,
-                                        common::ManagedPointer<network::Statement> statement,
-                                        common::ManagedPointer<network::PostgresPacketWriter> out) const;
+                                        common::ManagedPointer<network::PostgresPacketWriter> out,
+                                        common::ManagedPointer<network::Statement> statement) const;
 
   /**
    * Contains the logic to reason about CREATE execution.

--- a/src/network/postgres/postgres_packet_util.cpp
+++ b/src/network/postgres/postgres_packet_util.cpp
@@ -10,6 +10,7 @@
 #include "network/postgres/postgres_defs.h"
 #include "network/postgres/postgres_protocol_util.h"
 #include "parser/expression/constant_value_expression.h"
+#include "spdlog/fmt/fmt.h"
 
 namespace noisepage::network {
 

--- a/src/network/postgres/postgres_packet_util.cpp
+++ b/src/network/postgres/postgres_packet_util.cpp
@@ -99,7 +99,7 @@ parser::ConstantValueExpression PostgresPacketUtil::TextValueToInternalValue(
     }
     default:
       // TODO(Matt): Note that not all types are handled yet. Add them as we support them.
-      UNREACHABLE("Unsupported type for parameter.");
+      UNREACHABLE(fmt::format("Unsupported type for parameter {}.", type).c_str());
   }
 }
 

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -224,8 +224,8 @@ TrafficCopResult TrafficCop::ExecuteSetStatement(common::ManagedPointer<network:
 
 TrafficCopResult TrafficCop::ExecuteShowStatement(
     common::ManagedPointer<network::ConnectionContext> connection_ctx,
-    common::ManagedPointer<network::Statement> statement,
-    const common::ManagedPointer<network::PostgresPacketWriter> out) const {
+    common::ManagedPointer<network::PostgresPacketWriter> out,
+    common::ManagedPointer<network::Statement> statement) const {
   NOISEPAGE_ASSERT(connection_ctx->TransactionState() == network::NetworkTransactionStateType::IDLE,
                    "This is a non-transactional operation and we should not be in a transaction.");
   NOISEPAGE_ASSERT(statement->GetQueryType() == network::QueryType::QUERY_SHOW,
@@ -245,7 +245,6 @@ TrafficCopResult TrafficCop::ExecuteShowStatement(
   cols.emplace_back(param_name, execution::sql::SqlTypeId::Varchar, std::move(expr));
   execution::sql::StringVal result{param_val.c_str()};
 
-  out->WriteRowDescription(cols, {network::FieldFormat::text});
   out->WriteDataRow(reinterpret_cast<const byte *>(&result), cols, {network::FieldFormat::text});
   return {ResultType::COMPLETE, 0u};
 }

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -222,10 +222,9 @@ TrafficCopResult TrafficCop::ExecuteSetStatement(common::ManagedPointer<network:
   return {ResultType::COMPLETE, 0u};
 }
 
-TrafficCopResult TrafficCop::ExecuteShowStatement(
-    common::ManagedPointer<network::ConnectionContext> connection_ctx,
-    common::ManagedPointer<network::PostgresPacketWriter> out,
-    common::ManagedPointer<network::Statement> statement) const {
+TrafficCopResult TrafficCop::ExecuteShowStatement(common::ManagedPointer<network::ConnectionContext> connection_ctx,
+                                                  common::ManagedPointer<network::PostgresPacketWriter> out,
+                                                  common::ManagedPointer<network::Statement> statement) const {
   NOISEPAGE_ASSERT(connection_ctx->TransactionState() == network::NetworkTransactionStateType::IDLE,
                    "This is a non-transactional operation and we should not be in a transaction.");
   NOISEPAGE_ASSERT(statement->GetQueryType() == network::QueryType::QUERY_SHOW,


### PR DESCRIPTION
# Heading

Refactor support for SHOW commands in DESCRIBE.

## Description

Previously, DESCRIBE was writing NO DATA for SHOW.
This fix makes the HikariCP connection pool in the new version of OLTPBench happy.

## Remaining tasks

- Get through CI.