### PR TITLE
Switch to the new version of OLTPBench.

### DIFF
--- a/script/testing/oltpbench/constants.py
+++ b/script/testing/oltpbench/constants.py
@@ -3,11 +3,15 @@ import os
 from ..util.constants import DIR_TMP
 
 # git settings for OLTPBench.
+OLTPBENCH_VERSION = "oltpbench2-20.1.3-SNAPSHOT"
 OLTPBENCH_GIT_URL = "https://github.com/oltpbenchmark/oltpbench.git"
 OLTPBENCH_GIT_LOCAL_PATH = os.path.join(DIR_TMP, "oltpbench")
+OLTPBENCH_GIT_TARGET_PATH = os.path.join(OLTPBENCH_GIT_LOCAL_PATH, "target")
+OLTPBENCH_GIT_FINAL_PATH = os.path.join(OLTPBENCH_GIT_TARGET_PATH, OLTPBENCH_VERSION)
 OLTPBENCH_GIT_CLEAN_COMMAND = "rm -rf {}".format(OLTPBENCH_GIT_LOCAL_PATH)
-OLTPBENCH_GIT_CLONE_COMMAND = "git clone --depth 1 {} {}".format(OLTPBENCH_GIT_URL,
-                                                                 OLTPBENCH_GIT_LOCAL_PATH)
+OLTPBENCH_GIT_CLONE_COMMAND = "git clone --single-branch --branch oltpbench_tim --depth 1 {} {}".format(
+    OLTPBENCH_GIT_URL,
+    OLTPBENCH_GIT_LOCAL_PATH)
 
 # OLTPBench default settings.
 OLTPBENCH_DEFAULT_TIME = 30
@@ -21,7 +25,7 @@ OLTPBENCH_DEFAULT_PASSWORD = "postgres"
 OLTPBENCH_DEFAULT_DBTYPE = "noisepage"
 OLTPBENCH_DEFAULT_DRIVER = "org.postgresql.Driver"
 OLTPBENCH_DEFAULT_RATE = "unlimited"
-OLTPBENCH_DEFAULT_BIN = os.path.join(OLTPBENCH_GIT_LOCAL_PATH, "oltpbenchmark")
+OLTPBENCH_DEFAULT_BIN = "java -jar oltpbench2.jar "
 OLTPBENCH_DEFAULT_DATABASE_RESTART = True
 OLTPBENCH_DEFAULT_DATABASE_CREATE = True
 OLTPBENCH_DEFAULT_DATABASE_LOAD = True
@@ -30,17 +34,8 @@ OLTPBENCH_DEFAULT_REPORT_SERVER = None
 OLTPBENCH_DEFAULT_WAL_ENABLE = True
 OLTPBENCH_DEFAULT_CONTINUE_ON_ERROR = False
 
-OLTPBENCH_DIR_CONFIG = os.path.join(OLTPBENCH_GIT_LOCAL_PATH, "config")
-OLTPBENCH_DIR_TEST_RESULT = os.path.join(OLTPBENCH_GIT_LOCAL_PATH, "results")
-
-# ant commands for invoking OLTPBench.
-OLTPBENCH_ANT_BUILD_FILE = os.path.join(OLTPBENCH_GIT_LOCAL_PATH, "build.xml")
-OLTPBENCH_ANT_COMMANDS = [
-    "ant bootstrap -buildfile {}".format(OLTPBENCH_ANT_BUILD_FILE),
-    "ant resolve -buildfile {}".format(OLTPBENCH_ANT_BUILD_FILE),
-    "ant clean -buildfile {}".format(OLTPBENCH_ANT_BUILD_FILE),
-    "ant build -buildfile {}".format(OLTPBENCH_ANT_BUILD_FILE),
-]
+OLTPBENCH_DIR_CONFIG = os.path.join(OLTPBENCH_GIT_FINAL_PATH, "config", "noisepage")
+OLTPBENCH_DIR_TEST_RESULT = os.path.join(OLTPBENCH_GIT_FINAL_PATH, "results")
 
 # API endpoints for Performance Storage Service
 # Each pair represents different environment. One could choose where the benchmark testing result will be uploaded to

--- a/script/testing/oltpbench/test_case_oltp.py
+++ b/script/testing/oltpbench/test_case_oltp.py
@@ -79,15 +79,15 @@ class TestCaseOLTPBench(TestCase):
             self.test_output_file = os.path.join(self.test_result_dir,
                                                  "oltpbench.log")
 
-        # oltpbench historgrams results - json format
+        # oltpbench histograms results - json format
         self.test_histograms_json_file = self.args.get("test_json_histograms")
         if not self.test_histograms_json_file:
             self.test_histograms_json_file = "oltp_histograms_" + self.filename_suffix + ".json"
         self.test_histogram_path = os.path.join(
-            constants.OLTPBENCH_GIT_LOCAL_PATH, self.test_histograms_json_file)
+            constants.OLTPBENCH_GIT_FINAL_PATH, self.test_histograms_json_file)
 
         # oltpbench initiate database and load data
-        self.oltp_flag = "--histograms --execute={EXECUTE} -s {BUCKETS}".format(
+        self.oltp_flag = "--execute={EXECUTE} -s {BUCKETS}".format(
             EXECUTE=self.db_execute, BUCKETS=self.buckets)
 
         # oltpbench test command
@@ -98,7 +98,7 @@ class TestCaseOLTPBench(TestCase):
             XML=self.xml_config,
             FLAGS=self.oltp_flag,
             HISTOGRAMS=self.test_histogram_path)
-        self.test_command_cwd = constants.OLTPBENCH_GIT_LOCAL_PATH
+        self.test_command_cwd = constants.OLTPBENCH_GIT_FINAL_PATH
 
     def run_pre_test(self):
         self._config_xml_file()
@@ -149,9 +149,9 @@ class TestCaseOLTPBench(TestCase):
     def _config_xml_file(self):
         xml = ElementTree.parse(self.xml_template)
         root = xml.getroot()
-        root.find("dbtype").text = constants.OLTPBENCH_DEFAULT_DBTYPE
+        root.find("type").text = constants.OLTPBENCH_DEFAULT_DBTYPE
         root.find("driver").text = constants.OLTPBENCH_DEFAULT_DRIVER
-        root.find("DBUrl").text = self._get_db_url()
+        root.find("url").text = self._get_db_url()
         root.find("username").text = constants.OLTPBENCH_DEFAULT_USERNAME
         root.find("password").text = constants.OLTPBENCH_DEFAULT_PASSWORD
         root.find("isolation").text = str(self.transaction_isolation)
@@ -199,9 +199,7 @@ class TestCaseOLTPBench(TestCase):
         with open(self.test_histogram_path) as oltp_result_file:
             test_result = json.load(oltp_result_file)
         unexpected_result = test_result.get("unexpected", {}).get("HISTOGRAM")
-        if unexpected_result and unexpected_result.keys():
+        if unexpected_result:
             for test in unexpected_result.keys():
                 if unexpected_result[test] != 0:
                     raise RuntimeError(str(unexpected_result))
-        else:
-            raise RuntimeError(str(unexpected_result))

--- a/script/testing/oltpbench/test_oltpbench.py
+++ b/script/testing/oltpbench/test_oltpbench.py
@@ -2,6 +2,8 @@ from ..util.common import expect_command
 from ..util.test_server import TestServer
 from . import constants
 
+import os
+
 
 class TestOLTPBench(TestServer):
     """
@@ -39,5 +41,9 @@ class TestOLTPBench(TestServer):
         Raises an exception if anything goes wrong.
         Assumes that _download_oltpbench() has already been run.
         """
-        for command in constants.OLTPBENCH_ANT_COMMANDS:
-            expect_command(command)
+        old_dir = os.getcwd()
+        os.chdir(constants.OLTPBENCH_GIT_LOCAL_PATH)
+        expect_command("./mvnw package")
+        os.chdir(constants.OLTPBENCH_GIT_TARGET_PATH)
+        expect_command(f"tar xvzf {constants.OLTPBENCH_VERSION}.tgz")
+        os.chdir(old_dir)

--- a/src/include/traffic_cop/traffic_cop.h
+++ b/src/include/traffic_cop/traffic_cop.h
@@ -190,15 +190,15 @@ class TrafficCop {
                                        common::ManagedPointer<network::Statement> statement) const;
 
   /**
-   * Contains the logic to handle SHOW statements. Currently a hack to only support SHOW TRANSACTION ISOLATION LEVEL
-   * @param connection_ctx The context to be used to access the internal txn.
-   * @param statement The show statement to be executed.
-   * @param out Packet writer for writing results.
-   * @return The result of the operation.
+   * Contains the logic to handle SHOW statements.
+   * @param connection_ctx  The context to be used to access the internal txn.
+   * @param out             The packet writer to return results.
+   * @param statement       The statement to be executed.
+   * @return                The result of the operation.
    */
   TrafficCopResult ExecuteShowStatement(common::ManagedPointer<network::ConnectionContext> connection_ctx,
-                                        common::ManagedPointer<network::Statement> statement,
-                                        common::ManagedPointer<network::PostgresPacketWriter> out) const;
+                                        common::ManagedPointer<network::PostgresPacketWriter> out,
+                                        common::ManagedPointer<network::Statement> statement) const;
 
   /**
    * Contains the logic to reason about CREATE execution.

--- a/src/network/postgres/postgres_packet_util.cpp
+++ b/src/network/postgres/postgres_packet_util.cpp
@@ -99,7 +99,7 @@ parser::ConstantValueExpression PostgresPacketUtil::TextValueToInternalValue(
     }
     default:
       // TODO(Matt): Note that not all types are handled yet. Add them as we support them.
-      UNREACHABLE("Unsupported type for parameter.");
+      UNREACHABLE(fmt::format("Unsupported type for parameter {}.", type).c_str());
   }
 }
 

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -224,8 +224,8 @@ TrafficCopResult TrafficCop::ExecuteSetStatement(common::ManagedPointer<network:
 
 TrafficCopResult TrafficCop::ExecuteShowStatement(
     common::ManagedPointer<network::ConnectionContext> connection_ctx,
-    common::ManagedPointer<network::Statement> statement,
-    const common::ManagedPointer<network::PostgresPacketWriter> out) const {
+    common::ManagedPointer<network::PostgresPacketWriter> out,
+    common::ManagedPointer<network::Statement> statement) const {
   NOISEPAGE_ASSERT(connection_ctx->TransactionState() == network::NetworkTransactionStateType::IDLE,
                    "This is a non-transactional operation and we should not be in a transaction.");
   NOISEPAGE_ASSERT(statement->GetQueryType() == network::QueryType::QUERY_SHOW,
@@ -245,7 +245,6 @@ TrafficCopResult TrafficCop::ExecuteShowStatement(
   cols.emplace_back(param_name, execution::sql::SqlTypeId::Varchar, std::move(expr));
   execution::sql::StringVal result{param_val.c_str()};
 
-  out->WriteRowDescription(cols, {network::FieldFormat::text});
   out->WriteDataRow(reinterpret_cast<const byte *>(&result), cols, {network::FieldFormat::text});
   return {ResultType::COMPLETE, 0u};
 }


### PR DESCRIPTION
# Heading

Switch to the new version of OLTPBench.

## Description

Blocked on merging:

- [ ] https://github.com/cmu-db/noisepage/pull/1631
- [ ] https://github.com/oltpbenchmark/oltpbench/pull/384

Does NOT need OLTPBench itself to merge oltpbench_tim into master.