### PR TITLE
disable unity build for modeling coverage.

### DIFF
--- a/Jenkinsfile-utils.groovy
+++ b/Jenkinsfile-utils.groovy
@@ -258,7 +258,7 @@ void stageModeling() {
 
     // Recompile the noisepage DBMS in Debug mode with code coverage.
     buildNoisePage([buildCommand:'ninja noisepage', cmake:
-        '-DCMAKE_BUILD_TYPE=Debug -DNOISEPAGE_GENERATE_COVERAGE=ON'
+        '-DCMAKE_BUILD_TYPE=Debug -DNOISEPAGE_UNITY_BUILD=OFF -DNOISEPAGE_GENERATE_COVERAGE=ON'
     ])
 
     // Run the self_driving_e2e_test.


### PR DESCRIPTION
Excerpt from the Modeling stage in Jenkins:
```
-- Coverage: ON
-- Unity builds (NOISEPAGE_UNITY_BUILD): ON
```
Unity builds break coverage calculations, so we should make sure to turn it off if coverage is on. Maybe we should make the CMake configuration fail if those are both set to ON?