### PR TITLE
Fix the conversion between SqlTypeId and string

### DIFF
--- a/src/execution/sql/sql.cpp
+++ b/src/execution/sql/sql.cpp
@@ -279,9 +279,9 @@ std::string SqlTypeIdToString(SqlTypeId type) {
     case SqlTypeId::Timestamp:
       return "Timestamp";
     case SqlTypeId::Varchar:
-      return "VarChar";
+      return "Varchar";
     case SqlTypeId::Varbinary:
-      return "VarBinary";
+      return "Varbinary";
     default:
       // All cases handled
       UNREACHABLE("Impossible type");
@@ -289,10 +289,10 @@ std::string SqlTypeIdToString(SqlTypeId type) {
 }
 
 SqlTypeId SqlTypeIdFromString(const std::string &type_string) {
-  if (type_string == "INVALID") {
+  if (type_string == "Invalid") {
     return SqlTypeId::Invalid;
   }
-  if (type_string == "BOOLEAN") {
+  if (type_string == "Boolean") {
     return SqlTypeId::Boolean;
   }
   if (type_string == "TinyInt") {


### PR DESCRIPTION
There are a few inconsistencies in the conversion between `SqlTypeId` and string. I encountered this issue when I was using the query traces for the pilot.

We seem to have the convention that directly uses type names as their string representations (case sensitive). This PR makes those conversions consistent.