### PR TITLE
remove junit from microbenchmark stage

### DIFF
--- a/Jenkinsfile-utils.groovy
+++ b/Jenkinsfile-utils.groovy
@@ -347,7 +347,6 @@ void stageNightlyMicrobenchmark() {
     ''', label:'Microbenchmark'
 
     archiveArtifacts 'script/testing/*.json'
-    junit 'script/testing/*.xml'
     stagePost()
 }
 


### PR DESCRIPTION
This stage does not produce any junit results anyway.  The junit
Jenkins plugin prior to version 1.53 would silently ignore missing &
empty test result files.  As of version 1.53, it produces an error that
fails the stage.

Signed-off-by: Chad Dougherty <crd@acm.org>
